### PR TITLE
feat(integration): enable common_system integration by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ option(BUILD_SAMPLES "Build samples" ON)
 option(BUILD_WITH_CONTAINER_SYSTEM "Build with container_system integration" ON)
 option(BUILD_WITH_THREAD_SYSTEM "Build with thread_system integration" ON)
 option(BUILD_WITH_LOGGER_SYSTEM "Build with logger_system integration" ON)
-option(BUILD_WITH_COMMON_SYSTEM "Build with common_system integration" OFF)
+option(BUILD_WITH_COMMON_SYSTEM "Build with common_system integration" ON)
 option(BUILD_MESSAGING_BRIDGE "Build messaging_system bridge" ON)
 option(ENABLE_COVERAGE "Enable code coverage" OFF)
 


### PR DESCRIPTION
## Summary

Change `BUILD_WITH_COMMON_SYSTEM` option default from `OFF` to `ON` to standardize integration policy across all infrastructure systems.

## Motivation

Prior to this change, network_system was the only infrastructure system with `BUILD_WITH_COMMON_SYSTEM=OFF` by default:

| System | Default |
|--------|---------|
| thread_system | ON ✅ |
| container_system | ON ✅ |
| database_system | ON ✅ |
| network_system | **OFF** ❌ |

This inconsistency caused confusion and required users to manually enable common_system integration.

## Changes

```cmake
# Before
option(BUILD_WITH_COMMON_SYSTEM "Build with common_system integration" OFF)

# After
option(BUILD_WITH_COMMON_SYSTEM "Build with common_system integration" ON)
```

## Benefits

1. **Consistency**: Aligns with other infrastructure systems
2. **Better defaults**: Most users want integration enabled
3. **Enhanced features**: Result<T> error handling enabled by default
4. **Future-ready**: Prepared for advanced integration features

## Testing

- ✅ CMake configuration succeeds with `ON`
- ✅ Build completes successfully
- ✅ All integrations (logger, thread, container) work correctly
- ✅ Backward compatible: Users can still set `-DBUILD_WITH_COMMON_SYSTEM=OFF`

## Part of Phase 3

This change implements Phase 3 Task 3.1: Standardize common_system Integration.

See also:
- [INTEGRATION_POLICY.md](https://github.com/kcenon/common_system/blob/feature/phase3-documentation/INTEGRATION_POLICY.md) - 3-tier integration model
- logger_system PR #26 - Related monitoring interface fix