### PR TITLE
docs(phase3): add API documentation configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,4 +79,4 @@ Thumbs.db
 *.orig
 
 # Documentation
-documents/
+documents/docs/api/

--- a/.gitignore
+++ b/.gitignore
@@ -79,4 +79,4 @@ Thumbs.db
 *.orig
 
 # Documentation
-documents/docs/api/
+documents/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![CodeFactor](https://www.codefactor.io/repository/github/kcenon/network_system/badge)](https://www.codefactor.io/repository/github/kcenon/network_system)
-
 [![Ubuntu-GCC](https://github.com/kcenon/network_system/actions/workflows/build-ubuntu-gcc.yaml/badge.svg)](https://github.com/kcenon/network_system/actions/workflows/build-ubuntu-gcc.yaml)
 [![Ubuntu-Clang](https://github.com/kcenon/network_system/actions/workflows/build-ubuntu-clang.yaml/badge.svg)](https://github.com/kcenon/network_system/actions/workflows/build-ubuntu-clang.yaml)
 [![Windows-MSYS2](https://github.com/kcenon/network_system/actions/workflows/build-windows-msys2.yaml/badge.svg)](https://github.com/kcenon/network_system/actions/workflows/build-windows-msys2.yaml)


### PR DESCRIPTION
## Summary
- Configure Doxygen for API documentation generation
- Add .gitignore entry for generated documentation
- Complete Phase 3 documentation improvements

## Changes
- Updated .gitignore to exclude docs/api/ directory
- API documentation can be generated using generate_docs.sh script

## Test Plan
- Verify Doxygen configuration is valid
- Generate documentation and verify HTML output
- Confirm generated files are ignored by git

## Related Issues
Completes Phase 3 Task 3.3 from system improvement plan