### PR TITLE
Make UDP sample always build like TCP samples

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -37,12 +37,8 @@ set(SAMPLE_PROGRAMS
     http_client_demo
     run_all_samples
     memory_profile_demo
+    udp_echo_demo
 )
-
-# Add UDP sample if UDP support is enabled
-if(NETWORK_ENABLE_UDP)
-    list(APPEND SAMPLE_PROGRAMS udp_echo_demo)
-endif()
 
 # Output directory
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -72,7 +68,7 @@ foreach(SAMPLE ${SAMPLE_PROGRAMS})
     )
 
     # Configure ASIO for samples that use it directly
-    if(SAMPLE STREQUAL "udp_echo_demo")
+    if(SAMPLE STREQUAL "udp_echo_demo" AND NETWORK_ENABLE_UDP)
         setup_asio_integration(${SAMPLE})
     endif()
     
@@ -147,13 +143,10 @@ set(SAMPLE_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/http_client_demo.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/run_all_samples.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/memory_profile_demo.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/udp_echo_demo.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt
     ${CMAKE_CURRENT_SOURCE_DIR}/README.md
 )
-
-if(NETWORK_ENABLE_UDP)
-    list(APPEND SAMPLE_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/udp_echo_demo.cpp)
-endif()
 
 install(FILES ${SAMPLE_SOURCE_FILES}
     DESTINATION share/network_system/samples

--- a/samples/udp_echo_demo.cpp
+++ b/samples/udp_echo_demo.cpp
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
 /**
- * @file udp_example.cpp
+ * @file udp_echo_demo.cpp
  * @brief Simple example demonstrating UDP client and server usage
  *
  * This example shows:
@@ -41,10 +41,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * 4. Graceful shutdown
  */
 
+#include <iostream>
+
+#ifdef NETWORK_ENABLE_UDP
+
 #include "network_system/core/messaging_udp_server.h"
 #include "network_system/core/messaging_udp_client.h"
 
-#include <iostream>
 #include <thread>
 #include <chrono>
 #include <string>
@@ -211,7 +214,7 @@ void run_client()
 
 int main()
 {
-    std::cout << "=== UDP Example ===\n";
+    std::cout << "=== UDP Echo Demo ===\n";
     std::cout << "This example demonstrates basic UDP client/server communication.\n\n";
 
     try
@@ -237,3 +240,13 @@ int main()
         return 1;
     }
 }
+
+#else // NETWORK_ENABLE_UDP
+
+int main()
+{
+    std::cout << "UDP support is not enabled. Rebuild with -DNETWORK_ENABLE_UDP=ON\n";
+    return 1;
+}
+
+#endif // NETWORK_ENABLE_UDP


### PR DESCRIPTION
## Summary

This PR updates the UDP sample to always build regardless of the `NETWORK_ENABLE_UDP` flag, matching the behavior of TCP samples. The sample now uses conditional compilation to provide appropriate feedback when UDP is disabled.

## Changes

### Build Configuration

- **Removed conditional from CMakeLists.txt**: UDP sample (`udp_echo_demo`) is now always in the `SAMPLE_PROGRAMS` list
- **Removed conditional from installation**: UDP sample source is always included in installation files
- **Conditional ASIO integration**: ASIO is only configured when UDP is enabled

### Sample Code

- **Added preprocessor guards**: `#ifdef NETWORK_ENABLE_UDP` wraps UDP-specific code
- **Fallback implementation**: When UDP is disabled, sample shows informative message
- **Consistent behavior**: Matches how TCP samples handle missing features

## Technical Details

### Conditional Compilation Pattern

```cpp
#ifdef NETWORK_ENABLE_UDP
// Full UDP implementation
#else
int main() {
    std::cout << "UDP support is not enabled. Rebuild with -DNETWORK_ENABLE_UDP=ON\n";
    return 1;
}
#endif
```

### Build Behavior

| Configuration | Behavior |
|--------------|----------|
| `NETWORK_ENABLE_UDP=ON` | Full UDP functionality |
| `NETWORK_ENABLE_UDP=OFF` | Builds with informative message |

## Testing

### With UDP Enabled
```bash
cmake -B build -DBUILD_SAMPLES=ON -DNETWORK_ENABLE_UDP=ON
cmake --build build --target udp_echo_demo
./build/bin/udp_echo_demo
# Output: Full UDP echo demo functionality
```

### With UDP Disabled
```bash
cmake -B build -DBUILD_SAMPLES=ON -DNETWORK_ENABLE_UDP=OFF
cmake --build build --target udp_echo_demo
./build/bin/udp_echo_demo
# Output: "UDP support is not enabled. Rebuild with -DNETWORK_ENABLE_UDP=ON"
```

## Benefits

1. **Consistency**: UDP sample behaves like TCP samples (always built)
2. **User-friendly**: Clear message when feature is disabled
3. **Build flexibility**: No build errors regardless of configuration
4. **Discovery**: Users can discover UDP feature even when disabled

## Files Changed

- `samples/CMakeLists.txt` - Removed conditional sample inclusion
- `samples/udp_echo_demo.cpp` - Added conditional compilation guards

## Backward Compatibility

✅ Fully backward compatible - sample builds in all configurations

## Related

Follow-up to PR #49 (Add UDP Protocol Support)