### PR TITLE
refactor(http): migrate parsing functions to Result type

### DIFF
--- a/include/kcenon/network/internal/http_types.h
+++ b/include/kcenon/network/internal/http_types.h
@@ -38,6 +38,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdint>
 #include <optional>
 
+#include "kcenon/network/utils/result_types.h"
+
 namespace network_system::internal
 {
     /*!
@@ -246,9 +248,12 @@ namespace network_system::internal
     /*!
      * \brief Convert string to HTTP method enum
      * \param method_str Method string (e.g., "GET", "POST")
-     * \return HTTP method enum value
+     * \return Result containing HTTP method enum value, or error if invalid
+     *
+     * Possible errors:
+     * - invalid_argument: Unknown HTTP method string
      */
-    auto string_to_http_method(const std::string& method_str) -> std::optional<http_method>;
+    auto string_to_http_method(const std::string& method_str) -> ::network_system::Result<http_method>;
 
     /*!
      * \brief Convert HTTP version enum to string
@@ -260,9 +265,12 @@ namespace network_system::internal
     /*!
      * \brief Convert string to HTTP version enum
      * \param version_str Version string (e.g., "HTTP/1.1")
-     * \return HTTP version enum value
+     * \return Result containing HTTP version enum value, or error if invalid
+     *
+     * Possible errors:
+     * - invalid_argument: Unknown HTTP version string
      */
-    auto string_to_http_version(const std::string& version_str) -> std::optional<http_version>;
+    auto string_to_http_version(const std::string& version_str) -> ::network_system::Result<http_version>;
 
     /*!
      * \brief Get HTTP status message for a status code

--- a/src/internal/http_parser.cpp
+++ b/src/internal/http_parser.cpp
@@ -81,12 +81,12 @@ namespace network_system::internal
         }
 
         auto method_str = std::string(line.substr(0, first_space));
-        auto method_opt = string_to_http_method(method_str);
-        if (!method_opt)
+        auto method_result = string_to_http_method(method_str);
+        if (method_result.is_err())
         {
-            return error<http_request>(-1, "Invalid HTTP method: " + method_str);
+            return error<http_request>(method_result.error().code, method_result.error().message);
         }
-        request.method = *method_opt;
+        request.method = method_result.value();
 
         line = line.substr(first_space + 1);
         auto second_space = line.find(' ');
@@ -111,12 +111,12 @@ namespace network_system::internal
         }
 
         auto version_str = std::string(line.substr(second_space + 1));
-        auto version_opt = string_to_http_version(version_str);
-        if (!version_opt)
+        auto version_result = string_to_http_version(version_str);
+        if (version_result.is_err())
         {
-            return error<http_request>(-1, "Invalid HTTP version: " + version_str);
+            return error<http_request>(version_result.error().code, version_result.error().message);
         }
-        request.version = *version_opt;
+        request.version = version_result.value();
 
         return ok(std::move(request));
     }
@@ -133,12 +133,12 @@ namespace network_system::internal
         }
 
         auto version_str = std::string(line.substr(0, first_space));
-        auto version_opt = string_to_http_version(version_str);
-        if (!version_opt)
+        auto version_result = string_to_http_version(version_str);
+        if (version_result.is_err())
         {
-            return error<http_response>(-1, "Invalid HTTP version: " + version_str);
+            return error<http_response>(version_result.error().code, version_result.error().message);
         }
-        response.version = *version_opt;
+        response.version = version_result.value();
 
         line = line.substr(first_space + 1);
         auto second_space = line.find(' ');

--- a/src/internal/http_types.cpp
+++ b/src/internal/http_types.cpp
@@ -156,23 +156,26 @@ namespace network_system::internal
         }
     }
 
-    auto string_to_http_method(const std::string& method_str) -> std::optional<http_method>
+    auto string_to_http_method(const std::string& method_str) -> ::network_system::Result<http_method>
     {
         auto upper_method = method_str;
         std::transform(upper_method.begin(), upper_method.end(), upper_method.begin(),
             [](unsigned char c) { return std::toupper(c); });
 
-        if (upper_method == "GET")     return http_method::HTTP_GET;
-        if (upper_method == "POST")    return http_method::HTTP_POST;
-        if (upper_method == "PUT")     return http_method::HTTP_PUT;
-        if (upper_method == "DELETE")  return http_method::HTTP_DELETE;
-        if (upper_method == "HEAD")    return http_method::HTTP_HEAD;
-        if (upper_method == "OPTIONS") return http_method::HTTP_OPTIONS;
-        if (upper_method == "PATCH")   return http_method::HTTP_PATCH;
-        if (upper_method == "CONNECT") return http_method::HTTP_CONNECT;
-        if (upper_method == "TRACE")   return http_method::HTTP_TRACE;
+        if (upper_method == "GET")     return ::network_system::ok(http_method::HTTP_GET);
+        if (upper_method == "POST")    return ::network_system::ok(http_method::HTTP_POST);
+        if (upper_method == "PUT")     return ::network_system::ok(http_method::HTTP_PUT);
+        if (upper_method == "DELETE")  return ::network_system::ok(http_method::HTTP_DELETE);
+        if (upper_method == "HEAD")    return ::network_system::ok(http_method::HTTP_HEAD);
+        if (upper_method == "OPTIONS") return ::network_system::ok(http_method::HTTP_OPTIONS);
+        if (upper_method == "PATCH")   return ::network_system::ok(http_method::HTTP_PATCH);
+        if (upper_method == "CONNECT") return ::network_system::ok(http_method::HTTP_CONNECT);
+        if (upper_method == "TRACE")   return ::network_system::ok(http_method::HTTP_TRACE);
 
-        return std::nullopt;
+        return ::network_system::error<http_method>(
+            ::network_system::error_codes::common_errors::invalid_argument,
+            "Unknown HTTP method: " + method_str,
+            "http_types");
     }
 
     auto http_version_to_string(http_version version) -> std::string
@@ -186,14 +189,17 @@ namespace network_system::internal
         }
     }
 
-    auto string_to_http_version(const std::string& version_str) -> std::optional<http_version>
+    auto string_to_http_version(const std::string& version_str) -> ::network_system::Result<http_version>
     {
-        if (version_str == "HTTP/1.0") return http_version::HTTP_1_0;
-        if (version_str == "HTTP/1.1") return http_version::HTTP_1_1;
-        if (version_str == "HTTP/2.0") return http_version::HTTP_2_0;
-        if (version_str == "HTTP/2")   return http_version::HTTP_2_0;
+        if (version_str == "HTTP/1.0") return ::network_system::ok(http_version::HTTP_1_0);
+        if (version_str == "HTTP/1.1") return ::network_system::ok(http_version::HTTP_1_1);
+        if (version_str == "HTTP/2.0") return ::network_system::ok(http_version::HTTP_2_0);
+        if (version_str == "HTTP/2")   return ::network_system::ok(http_version::HTTP_2_0);
 
-        return std::nullopt;
+        return ::network_system::error<http_version>(
+            ::network_system::error_codes::common_errors::invalid_argument,
+            "Unknown HTTP version: " + version_str,
+            "http_types");
     }
 
     auto get_status_message(int status_code) -> std::string


### PR DESCRIPTION
## Summary
- Migrate `string_to_http_method()` and `string_to_http_version()` from `std::optional` to `Result<T>` return type
- Update `http_parser.cpp` to use new Result-based API
- Provide detailed error messages for invalid HTTP method/version strings

## Motivation
This change aligns with TICKET-002 (Network System - Result type migration) and the codebase-wide effort to use `Result<T>` for operations that can fail, providing better error context than `std::optional`.

## Changes
- `http_types.h`: Updated function signatures and added `result_types.h` include
- `http_types.cpp`: Implemented Result-based error handling with descriptive messages
- `http_parser.cpp`: Updated call sites to use new Result API

## Test Plan
- [x] Build passes
- [x] All existing unit tests pass (15 tests)
- [x] No new warnings introduced