### PR TITLE
chore: add version 1.0.0 for unified_system integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 ##################################################
 
 project(NetworkSystem
+    VERSION 1.0.0
     DESCRIPTION "Independent High-Performance Network System"
     LANGUAGES CXX
 )


### PR DESCRIPTION
## Summary
- Add VERSION 1.0.0 to project definition
- Part of unified_system version standardization effort

## Details
All subprojects in unified_system are being standardized to v1.0.0 for:
- Consistent version management across the ecosystem
- Simplified dependency version tracking
- Unified release management

## Changes
- `CMakeLists.txt`: Added `VERSION 1.0.0` to project definition

## Notes
This project previously had no explicit version number.
With unified_system integration, all projects now have unified version management starting from v1.0.0.

## Test plan
- [x] Build verification
- [ ] CI pipeline passes