### PR TITLE
Make OpenSSL linkage PUBLIC for dependent targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,7 +261,7 @@ if(BUILD_TLS_SUPPORT)
 
     # Find OpenSSL for TLS/SSL (require 1.1.1+ for TLS 1.3 support)
     find_package(OpenSSL 1.1.1 REQUIRED)
-    target_link_libraries(NetworkSystem PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+    target_link_libraries(NetworkSystem PUBLIC OpenSSL::SSL OpenSSL::Crypto)
 
     message(STATUS "TLS/SSL support enabled (TLS 1.2/1.3)")
     message(STATUS "  OpenSSL version: ${OPENSSL_VERSION}")


### PR DESCRIPTION
## Summary
- Change OpenSSL library linkage from PRIVATE to PUBLIC for NetworkSystem target
- Allows downstream targets to properly resolve OpenSSL symbols

## Test plan
- [ ] Build network_system standalone with TLS enabled
- [ ] Build dependent system (e.g., messaging_system) that uses TLS
- [ ] Verify no undefined symbol errors for OpenSSL functions