### PR TITLE
feat: adopt common_system Result<T> for unified error handling

### DIFF
--- a/docs/integration/with-common-system.md
+++ b/docs/integration/with-common-system.md
@@ -86,27 +86,44 @@ server->on_connection([executor](auto conn) {
 
 ## Error Handling with Result<T>
 
-Network system uses `Result<T>` for all fallible operations:
+Network system uses `Result<T>` for all fallible operations. As of the ecosystem-wide
+Result<T> unification initiative, **`kcenon::common::Result<T>` is the primary API**.
+
+### Migration Notice
+
+The `network_system::Result<T>` alias is retained for backward compatibility but
+new code should use `kcenon::common::Result<T>` directly for ecosystem consistency.
+
+To enable deprecation warnings during migration preparation, define:
+```cpp
+#define NETWORK_SYSTEM_ENABLE_DEPRECATION_WARNINGS
+```
+
+See [common_system Result<T> Unification](https://github.com/kcenon/common_system/issues/205)
+for more details on the ecosystem-wide migration.
 
 ### Basic Usage
 
 ```cpp
-#include "common_system/result.h"
-#include "network_system/TcpClient.h"
+#include <kcenon/common/patterns/result.h>
+#include <kcenon/network/core/messaging_client.h>
 
-auto client = network_system::TcpClient::create();
+// Use common::Result<T> directly (recommended)
+using kcenon::common::Result;
+using kcenon::common::VoidResult;
 
-// Connect returns Result<Connection>
-auto conn_result = client->connect("example.com", 80);
+auto client = std::make_shared<network_system::core::messaging_client>("client");
 
-if (!conn_result) {
+// Connect returns VoidResult
+auto conn_result = client->start_client("example.com", 80);
+
+if (conn_result.is_err()) {
     // Handle error
-    std::cerr << "Connection failed: " << conn_result.error() << std::endl;
+    std::cerr << "Connection failed: " << conn_result.error().message << std::endl;
     return;
 }
 
-auto conn = conn_result.value();
-// ... use connection ...
+// ... use client ...
 ```
 
 ### Propagating Errors

--- a/include/kcenon/network/utils/result_types.h
+++ b/include/kcenon/network/utils/result_types.h
@@ -43,13 +43,50 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace network_system {
 
 #ifdef BUILD_WITH_COMMON_SYSTEM
-	// Use common_system Result<T> when available
+	// ============================================================
+	// Primary API: Use common::Result<T> directly
+	// ============================================================
+	//
+	// network_system now uses common_system's Result<T> as the primary
+	// error handling mechanism. While network_system::Result<T> aliases
+	// remain available for backward compatibility, new code should use
+	// kcenon::common::Result<T> directly for ecosystem-wide consistency.
+	//
+	// Migration path:
+	//   Before: network_system::Result<T>
+	//   After:  kcenon::common::Result<T>
+	//
+	// To enable deprecation warnings for migration preparation, define:
+	//   NETWORK_SYSTEM_ENABLE_DEPRECATION_WARNINGS
+	//
+	// See: https://github.com/kcenon/common_system/issues/205
+	// ============================================================
+
+#ifdef NETWORK_SYSTEM_ENABLE_DEPRECATION_WARNINGS
+	// Deprecated aliases - enable warnings to find usage during migration
+	template<typename T>
+	using Result [[deprecated("Use kcenon::common::Result<T> directly for ecosystem consistency. "
+	                          "See https://github.com/kcenon/common_system/issues/205")]]
+		= ::kcenon::common::Result<T>;
+
+	using VoidResult [[deprecated("Use kcenon::common::VoidResult directly for ecosystem consistency. "
+	                              "See https://github.com/kcenon/common_system/issues/205")]]
+		= ::kcenon::common::VoidResult;
+
+	using error_info [[deprecated("Use kcenon::common::error_info directly for ecosystem consistency. "
+	                              "See https://github.com/kcenon/common_system/issues/205")]]
+		= ::kcenon::common::error_info;
+#else
+	// Backward-compatible aliases (prefer kcenon::common::Result<T> for new code)
+	// These aliases are retained for migration support but may be removed
+	// in a future major version.
 	template<typename T>
 	using Result = ::kcenon::common::Result<T>;
 
 	using VoidResult = ::kcenon::common::VoidResult;
 
 	using error_info = ::kcenon::common::error_info;
+#endif
 
 	// Error code namespace (includes common_errors and network_system)
 	namespace error_codes = ::kcenon::common::error::codes;


### PR DESCRIPTION
## Summary

- Add deprecation support for `network_system::Result<T>` aliases with opt-in warnings via `NETWORK_SYSTEM_ENABLE_DEPRECATION_WARNINGS`
- Update documentation to recommend `kcenon::common::Result<T>` directly
- Maintain backward compatibility with existing code

## Background

This PR implements the network_system portion of the ecosystem-wide `Result<T>` unification initiative ([common_system#205](https://github.com/kcenon/common_system/issues/205)).

## Changes

### `result_types.h`
- Added clear documentation explaining the migration path
- Added opt-in deprecation warnings (disabled by default to avoid breaking builds)
- When `NETWORK_SYSTEM_ENABLE_DEPRECATION_WARNINGS` is defined, using `network_system::Result<T>` will emit deprecation warnings

### Documentation
- Updated `docs/integration/with-common-system.md` with migration notice
- Added example code showing recommended usage with `kcenon::common::Result<T>`

## Migration Path

1. **Immediate (no action required)**: Existing code continues to work without changes
2. **Preparation**: Define `NETWORK_SYSTEM_ENABLE_DEPRECATION_WARNINGS` to find all usages
3. **Migration**: Replace `network_system::Result<T>` with `kcenon::common::Result<T>`

## Test plan

- [x] Build passes with `BUILD_WITH_COMMON_SYSTEM=ON`
- [x] All NetworkTest tests pass (13/13)
- [x] No new deprecation warnings in normal builds