### PR TITLE
fix(server): fix session cleanup order to prevent heap corruption

### DIFF
--- a/src/core/messaging_server.cpp
+++ b/src/core/messaging_server.cpp
@@ -184,7 +184,9 @@ namespace kcenon::network::core
 				cleanup_timer_->cancel();
 			}
 
-			// Step 2: Stop all active sessions
+			// Step 2: Stop all active sessions (close sockets, stop reading)
+			// NOTE: Do NOT clear sessions here - they may still be referenced by
+			// pending async callbacks. We must wait for io_context to finish first.
 			{
 				std::lock_guard<std::mutex> lock(sessions_mutex_);
 				for (auto& sess : sessions_)
@@ -194,7 +196,6 @@ namespace kcenon::network::core
 						sess->stop_session();
 					}
 				}
-				sessions_.clear();
 			}
 
 			// Step 3: Release work guard to allow io_context to finish
@@ -210,17 +211,24 @@ namespace kcenon::network::core
 			}
 
 			// Step 5: Wait for io_context task to complete
+			// This ensures all pending async callbacks have finished executing
 			if (io_context_future_.valid())
 			{
 				io_context_future_.wait();
 			}
 
-			// Step 6: Release resources explicitly to ensure cleanup
+			// Step 6: NOW it's safe to clear sessions - all async operations are done
+			{
+				std::lock_guard<std::mutex> lock(sessions_mutex_);
+				sessions_.clear();
+			}
+
+			// Step 7: Release resources explicitly to ensure cleanup
 			acceptor_.reset();
 			cleanup_timer_.reset();
 			io_context_.reset();
 
-			// Step 7: Signal the promise for wait_for_stop()
+			// Step 8: Signal the promise for wait_for_stop()
 			if (stop_promise_.has_value())
 			{
 				try


### PR DESCRIPTION
## Summary

Fix heap memory corruption that occurs during server shutdown with active connections.

## Problem

When `stop_server()` is called, `sessions_.clear()` was executed before `io_context` was fully stopped. This caused pending async callbacks to access destroyed session memory, resulting in "corrupted size vs. prev_size" heap corruption errors.

## Solution

Reorder the cleanup sequence:

**Previous (buggy) order:**
1. Stop all sessions (close sockets)
2. Clear sessions vector (destroy session objects) ← Too early!
3. Stop io_context
4. Wait for io_context completion

**New (correct) order:**
1. Stop all sessions (close sockets)
2. Stop io_context
3. Wait for io_context completion (all callbacks finished)
4. Clear sessions vector (now safe to destroy) ← Correct order

## Testing

- Local tests show 6 fewer failures after this fix
- Fixes concurrent stress tests in file_trans_system

## Related

- Unblocks: file_trans_system PR #105