### PR TITLE
fix(logger): use thread-safe localtime_r/localtime_s in get_timestamp

### DIFF
--- a/src/integration/logger_integration.cpp
+++ b/src/integration/logger_integration.cpp
@@ -69,15 +69,22 @@ static const char* level_to_string(log_level level) {
     }
 }
 
-// Helper function to get current timestamp
+// Helper function to get current timestamp (thread-safe)
 static std::string get_timestamp() {
     auto now = std::chrono::system_clock::now();
-    auto time_t = std::chrono::system_clock::to_time_t(now);
+    auto time_t_val = std::chrono::system_clock::to_time_t(now);
     auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
         now.time_since_epoch()) % 1000;
 
+    std::tm tm_buf{};
+#ifdef _WIN32
+    localtime_s(&tm_buf, &time_t_val);  // Windows thread-safe version
+#else
+    localtime_r(&time_t_val, &tm_buf);  // POSIX thread-safe version
+#endif
+
     std::stringstream ss;
-    ss << std::put_time(std::localtime(&time_t), "%Y-%m-%d %H:%M:%S");
+    ss << std::put_time(&tm_buf, "%Y-%m-%d %H:%M:%S");
     ss << '.' << std::setfill('0') << std::setw(3) << ms.count();
     return ss.str();
 }


### PR DESCRIPTION
## Summary
- Replace non-thread-safe `std::localtime()` with platform-specific thread-safe versions
- Use `localtime_r` on POSIX and `localtime_s` on Windows
- Eliminates data races during concurrent logging operations

## Changes
- Add local `std::tm` buffer to avoid static internal buffer
- Add platform-specific preprocessor directives (`#ifdef _WIN32`)
- Rename variable `time_t` to `time_t_val` to avoid shadowing

## Test Plan
- [x] Verify build succeeds on POSIX platforms
- [x] Verify build succeeds on Windows platforms
- [x] Run ThreadSanitizer stress tests with concurrent logging
- [x] Verify timestamp format remains unchanged

Closes #339