### PR TITLE
feat(grpc): Add gRPC dependency configuration (#362)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,95 +416,64 @@ endif()
 
 # Official gRPC library support (conditional)
 # See ADR-001 for architecture decision details
-if(NETWORK_ENABLE_GRPC_OFFICIAL)
+# gRPC detection is done in NetworkSystemDependencies.cmake via find_grpc_library()
+if(NETWORK_ENABLE_GRPC_OFFICIAL AND GRPC_FOUND)
     message(STATUS "")
     message(STATUS "========================================")
     message(STATUS "Official gRPC Integration (Issue #360)")
     message(STATUS "========================================")
 
-    # Find gRPC package
-    find_package(gRPC CONFIG QUIET)
+    # Add gRPC wrapper sources
+    target_sources(NetworkSystem PRIVATE
+        src/protocols/grpc/grpc_official_wrapper.cpp
+    )
 
-    if(gRPC_FOUND)
-        message(STATUS "Found gRPC via CMake config")
-
-        # Find Protobuf (required by gRPC)
-        find_package(Protobuf CONFIG QUIET)
-        if(NOT Protobuf_FOUND)
-            find_package(Protobuf REQUIRED)
-        endif()
-
-        # Add gRPC wrapper sources
-        target_sources(NetworkSystem PRIVATE
-            src/protocols/grpc/grpc_official_wrapper.cpp
-        )
-
-        # Link gRPC libraries
+    if(GRPC_CMAKE_CONFIG)
+        # Use CMake config targets (preferred)
         target_link_libraries(NetworkSystem PRIVATE
             gRPC::grpc++
             gRPC::grpc++_reflection
             protobuf::libprotobuf
         )
 
-        # Define compile-time flag
-        target_compile_definitions(NetworkSystem PUBLIC NETWORK_GRPC_OFFICIAL=1)
-
-        message(STATUS "  gRPC++: Enabled")
-        message(STATUS "  Reflection: Enabled")
-        message(STATUS "  Protobuf: ${Protobuf_VERSION}")
-        message(STATUS "")
-        message(STATUS "Note: Existing gRPC API (grpc_server, grpc_client) remains unchanged.")
-        message(STATUS "      Internal implementation now uses official gRPC library.")
-        message(STATUS "========================================")
-    else()
-        # Try pkg-config as fallback
-        find_package(PkgConfig QUIET)
-        if(PkgConfig_FOUND)
-            pkg_check_modules(GRPCPP QUIET grpc++)
-            pkg_check_modules(PROTOBUF QUIET protobuf)
-
-            if(GRPCPP_FOUND AND PROTOBUF_FOUND)
-                target_sources(NetworkSystem PRIVATE
-                    src/protocols/grpc/grpc_official_wrapper.cpp
-                )
-
-                target_include_directories(NetworkSystem PRIVATE
-                    ${GRPCPP_INCLUDE_DIRS}
-                    ${PROTOBUF_INCLUDE_DIRS}
-                )
-
-                target_link_libraries(NetworkSystem PRIVATE
-                    ${GRPCPP_LIBRARIES}
-                    ${PROTOBUF_LIBRARIES}
-                )
-
-                target_compile_definitions(NetworkSystem PUBLIC NETWORK_GRPC_OFFICIAL=1)
-
-                message(STATUS "  gRPC++ (via pkg-config): ${GRPCPP_VERSION}")
-                message(STATUS "  Protobuf (via pkg-config): ${PROTOBUF_VERSION}")
-                message(STATUS "========================================")
-            else()
-                message(WARNING "")
-                message(WARNING "NETWORK_ENABLE_GRPC_OFFICIAL is ON but gRPC not found.")
-                message(WARNING "Falling back to prototype implementation.")
-                message(WARNING "")
-                message(WARNING "Install gRPC:")
-                message(WARNING "  macOS:  brew install grpc")
-                message(WARNING "  Ubuntu: apt-get install libgrpc++-dev protobuf-compiler-grpc")
-                message(WARNING "  vcpkg:  vcpkg install grpc")
-                message(WARNING "========================================")
-                set(NETWORK_ENABLE_GRPC_OFFICIAL OFF)
-            endif()
-        else()
-            message(WARNING "")
-            message(WARNING "NETWORK_ENABLE_GRPC_OFFICIAL is ON but gRPC not found.")
-            message(WARNING "Falling back to prototype implementation.")
-            message(WARNING "")
-            message(WARNING "Install gRPC and ensure it's discoverable via CMake or pkg-config.")
-            message(WARNING "========================================")
-            set(NETWORK_ENABLE_GRPC_OFFICIAL OFF)
+        # Link abseil if found separately (gRPC 1.50+ requirement)
+        if(ABSEIL_FOUND)
+            # abseil is typically linked transitively through gRPC::grpc++
+            # but explicit linking may be needed for some configurations
+            message(STATUS "  Abseil: Linked via gRPC")
         endif()
+
+        message(STATUS "  gRPC++: Enabled (CMake config)")
+        message(STATUS "  Reflection: Enabled")
+        if(DEFINED Protobuf_VERSION)
+            message(STATUS "  Protobuf: ${Protobuf_VERSION}")
+        endif()
+    elseif(GRPC_PKGCONFIG)
+        # Use pkg-config libraries
+        target_include_directories(NetworkSystem PRIVATE
+            ${GRPCPP_INCLUDE_DIRS}
+            ${PROTOBUF_INCLUDE_DIRS}
+        )
+
+        target_link_libraries(NetworkSystem PRIVATE
+            ${GRPCPP_LIBRARIES}
+            ${PROTOBUF_LIBRARIES}
+        )
+
+        message(STATUS "  gRPC++: Enabled (pkg-config)")
+        message(STATUS "  Reflection: Manual linking required")
     endif()
+
+    # Define compile-time flag
+    target_compile_definitions(NetworkSystem PUBLIC NETWORK_GRPC_OFFICIAL=1)
+
+    message(STATUS "")
+    message(STATUS "Note: Existing gRPC API (grpc_server, grpc_client) remains unchanged.")
+    message(STATUS "      Internal implementation now uses official gRPC library.")
+    message(STATUS "========================================")
+elseif(NETWORK_ENABLE_GRPC_OFFICIAL AND NOT GRPC_FOUND)
+    # gRPC was requested but not found - warning already printed by find_grpc_library()
+    message(STATUS "Official gRPC: Disabled (gRPC not found, using prototype)")
 else()
     message(STATUS "Official gRPC: Disabled (using prototype implementation)")
 endif()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- **gRPC Dependency Configuration** (2025-12-28) (#362)
+  - Added `find_grpc_library()` function to `NetworkSystemDependencies.cmake`
+  - Comprehensive gRPC/Protobuf/Abseil detection via CMake config and pkg-config
+  - Version requirement enforcement (grpc++ >= 1.50.0, protobuf >= 3.21.0)
+  - Automatic fallback to prototype implementation when gRPC not found
+  - Clear installation instructions in warning messages for all platforms
+  - Updated BUILD.md with gRPC installation and configuration guide
+  - Part of official gRPC integration epic (#360, Phase 2)
+
 - **Official gRPC Library Integration** (2025-12-28)
   - Added `NETWORK_ENABLE_GRPC_OFFICIAL` CMake option for production gRPC support
   - Created ADR-001 documenting the wrapper architecture decision

--- a/docs/guides/BUILD.md
+++ b/docs/guides/BUILD.md
@@ -175,7 +175,42 @@ ninja
 | `BUILD_WITH_CONTAINER_SYSTEM` | ON | Enable container_system integration |
 | `BUILD_WITH_THREAD_SYSTEM` | ON | Enable thread_system integration |
 | `BUILD_MESSAGING_BRIDGE` | ON | Build messaging_system compatibility bridge |
+| `BUILD_TLS_SUPPORT` | ON | Enable TLS/SSL support |
+| `BUILD_WEBSOCKET_SUPPORT` | ON | Enable WebSocket protocol support |
+| `NETWORK_ENABLE_GRPC_OFFICIAL` | OFF | Use official gRPC library (grpc++) |
 | `CMAKE_BUILD_TYPE` | Debug | Build configuration (Debug/Release/RelWithDebInfo/MinSizeRel) |
+
+### gRPC Official Library Integration
+
+The `NETWORK_ENABLE_GRPC_OFFICIAL` option enables integration with the official gRPC library (grpc++) for production-ready gRPC support. When disabled, a prototype implementation is used.
+
+**Required Versions:**
+- grpc++ >= 1.50.0
+- protobuf >= 3.21.0
+- abseil (bundled with gRPC)
+
+**Installation:**
+
+```bash
+# Ubuntu/Debian
+sudo apt install libgrpc++-dev protobuf-compiler-grpc
+
+# macOS
+brew install grpc
+
+# Windows (vcpkg)
+vcpkg install grpc:x64-windows
+
+# vcpkg (cross-platform)
+vcpkg install grpc
+```
+
+**Build with gRPC:**
+```bash
+cmake .. -DNETWORK_ENABLE_GRPC_OFFICIAL=ON
+```
+
+If gRPC is not found, the build will automatically fall back to the prototype implementation with a warning message. See [ADR-001](../adr/ADR-001-grpc-official-library-wrapper.md) for the architectural decision details.
 
 ### Example Configurations
 


### PR DESCRIPTION
## Summary

- Add `find_grpc_library()` function to `NetworkSystemDependencies.cmake` for comprehensive gRPC/Protobuf/Abseil detection
- Support both CMake config and pkg-config fallback for cross-platform compatibility
- Refactor `CMakeLists.txt` to use centralized dependency detection
- Update documentation with gRPC installation and configuration guide

## Changes

### CMake Configuration
- Added `find_grpc_library()` function with:
  - CMake config detection (preferred for vcpkg, brew)
  - pkg-config fallback for system packages
  - Version requirement enforcement (grpc++ >= 1.50.0, protobuf >= 3.21.0)
  - Abseil detection for gRPC 1.50+ compatibility
  - Clear warning messages with installation instructions

### Documentation
- Updated `docs/guides/BUILD.md` with:
  - `NETWORK_ENABLE_GRPC_OFFICIAL` option in CMake options table
  - New "gRPC Official Library Integration" section
  - Installation instructions for Ubuntu, macOS, Windows
- Updated `docs/CHANGELOG.md` with Phase 2 changes

## Test Plan

- [x] Build with `NETWORK_ENABLE_GRPC_OFFICIAL=OFF` - passes
- [x] Build with `NETWORK_ENABLE_GRPC_OFFICIAL=ON` (gRPC not installed) - graceful fallback with warning
- [ ] CI verification on Linux, macOS, Windows
- [ ] Build with gRPC installed (requires gRPC in CI environment)

## Related Issues

Closes #362
Part of #360 (gRPC Official Integration Epic)