### PR TITLE
docs: update CHANGELOG and ARCHITECTURE for secure_messaging CRTP migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Concepts improve error messages and serve as self-documenting type constraints
 
 ### Changed
+- **secure_messaging CRTP Migration**: Migrated all secure messaging classes to use CRTP base classes (#383)
+  - `secure_messaging_client` now inherits from `messaging_client_base<secure_messaging_client>`
+  - `secure_messaging_server` now inherits from `messaging_server_base<secure_messaging_server, secure_session>`
+  - `secure_messaging_udp_client` now inherits from `messaging_client_base<secure_messaging_udp_client>`
+  - `secure_messaging_udp_server` maintains manual lifecycle management due to UDP-specific callbacks
+  - Added `set_udp_receive_callback()` for UDP clients with endpoint-aware callback signature
+  - All TLS/DTLS-specific behavior preserved in `do_start()`, `do_stop()`, `do_send()` methods
+  - Common callback setters and lifecycle methods now provided by base classes
+  - Maintains full backward compatibility with existing API
 - **messaging_server CRTP Migration**: Migrated `messaging_server` to use `messaging_server_base` CRTP pattern (#382)
   - Inherits from `messaging_server_base<messaging_server>` for common lifecycle management
   - Implements `do_start()`, `do_stop()` for TCP-specific server behavior

--- a/CHANGELOG_KO.md
+++ b/CHANGELOG_KO.md
@@ -73,6 +73,15 @@ Network System 프로젝트의 모든 주요 변경 사항이 이 파일에 문�
   - Concepts는 에러 메시지를 개선하고 자기 문서화 타입 제약 역할
 
 ### 변경됨
+- **secure_messaging CRTP 마이그레이션**: 모든 secure messaging 클래스를 CRTP 기본 클래스를 사용하도록 마이그레이션 (#383)
+  - `secure_messaging_client`가 이제 `messaging_client_base<secure_messaging_client>`를 상속
+  - `secure_messaging_server`가 이제 `messaging_server_base<secure_messaging_server, secure_session>`을 상속
+  - `secure_messaging_udp_client`가 이제 `messaging_client_base<secure_messaging_udp_client>`를 상속
+  - `secure_messaging_udp_server`는 UDP 특화 콜백으로 인해 수동 생명주기 관리 유지
+  - 엔드포인트 인식 콜백 시그니처를 가진 UDP 클라이언트용 `set_udp_receive_callback()` 추가
+  - 모든 TLS/DTLS 특화 동작은 `do_start()`, `do_stop()`, `do_send()` 메서드에 보존
+  - 공통 콜백 설정자 및 생명주기 메서드가 이제 기본 클래스에서 제공됨
+  - 기존 API와의 완전한 하위 호환성 유지
 - **messaging_server CRTP 마이그레이션**: `messaging_server`를 `messaging_server_base` CRTP 패턴을 사용하도록 마이그레이션 (#382)
   - 공통 생명주기 관리를 위해 `messaging_server_base<messaging_server>`를 상속
   - TCP 특화 서버 동작을 위한 `do_start()`, `do_stop()` 구현

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,7 +46,7 @@ Network_system provides a high-performance networking foundation that:
 | **Async-First** | Coroutine-based async operations (C++20) | ✅ Achieved |
 | **Integration-Friendly** | Pluggable thread, logger, container systems | ✅ Achieved |
 | **Connection Pooling** | Efficient connection reuse | 🔄 In Progress |
-| **TLS/SSL Support** | Secure communication | 📋 Planned |
+| **TLS/SSL Support** | Secure communication (TLS 1.3, DTLS) | ✅ Achieved |
 
 ---
 
@@ -750,7 +750,7 @@ Session Pool → Acquire → Use → Release → Pool
 
 | Feature | Status | Priority | ETA |
 |---------|--------|----------|-----|
-| TLS/SSL Support | 📋 Planned | P1 | Q1 2026 |
+| TLS/SSL Support | ✅ Achieved | P1 | - |
 | Connection Pooling | 🔄 In Progress | P1 | Q4 2025 |
 | HTTP/2 Support | 📋 Planned | P2 | Q2 2026 |
 | WebSocket Support | 📋 Planned | P2 | Q2 2026 |


### PR DESCRIPTION
## Summary

- Add secure_messaging CRTP migration entry to CHANGELOG.md and CHANGELOG_KO.md
- Update TLS/SSL Support status from Planned to Achieved in ARCHITECTURE.md
- Document migration of secure_messaging_client, secure_messaging_server, secure_messaging_udp_client, and secure_messaging_udp_server to CRTP base classes

## Changes

- **CHANGELOG.md / CHANGELOG_KO.md**: Added entry for #383 secure_messaging CRTP migration
- **docs/ARCHITECTURE.md**: Updated TLS/SSL Support status to "Achieved" (previously "Planned")

## Related Issues

Follows up on #383 and #391

## Test Plan

- [x] Documentation changes only, no code changes