### PR TITLE
refactor(quic): migrate QUIC classes from CRTP to composition pattern (Phase 1.4.4)

### DIFF
--- a/include/kcenon/network/core/messaging_quic_client.h
+++ b/include/kcenon/network/core/messaging_quic_client.h
@@ -32,12 +32,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "kcenon/network/core/messaging_quic_client_base.h"
-#include "kcenon/network/core/network_context.h"
-#include "kcenon/network/interfaces/i_quic_client.h"
-#include "kcenon/network/integration/thread_integration.h"
-#include "kcenon/network/utils/result_types.h"
-
 #include <atomic>
 #include <chrono>
 #include <functional>
@@ -48,9 +42,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <span>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <vector>
 
 #include <asio.hpp>
+
+#include "kcenon/network/core/network_context.h"
+#include "kcenon/network/interfaces/i_quic_client.h"
+#include "kcenon/network/integration/thread_integration.h"
+#include "kcenon/network/utils/callback_manager.h"
+#include "kcenon/network/utils/lifecycle_manager.h"
+#include "kcenon/network/utils/result_types.h"
 
 // Forward declaration
 namespace kcenon::network::internal
@@ -128,8 +130,9 @@ namespace kcenon::network::core
 	 * \class messaging_quic_client
 	 * \brief A QUIC client that provides reliable, multiplexed communication
 	 *
-	 * This class inherits from messaging_quic_client_base using the CRTP pattern,
-	 * which provides common lifecycle management and callback handling.
+	 * This class uses composition pattern with lifecycle_manager and
+	 * callback_manager for common lifecycle management and callback handling.
+	 * It also implements the i_quic_client interface for composition-based usage.
 	 *
 	 * ### Overview
 	 * Implements a QUIC (RFC 9000) client with an API consistent with the
@@ -146,8 +149,11 @@ namespace kcenon::network::core
 	 * - Uses \c asio::io_context in a dedicated thread for I/O events.
 	 * - Supports multiple concurrent streams (QUIC-specific).
 	 * - Provides \c start_client(), \c stop_client(), and \c wait_for_stop()
-	 *   for lifecycle control (inherited from base).
+	 *   for lifecycle control.
 	 * - Full Result<T> error handling for all fallible operations.
+	 *
+	 * ### Interface Compliance
+	 * This class implements interfaces::i_quic_client for composition-based usage.
 	 *
 	 * ### Comparison with messaging_client (TCP)
 	 * | Feature              | messaging_client (TCP) | messaging_quic_client |
@@ -161,12 +167,20 @@ namespace kcenon::network::core
 	 * | 0-RTT               | ✗                      | ✓ (QUIC specific)    |
 	 */
 	class messaging_quic_client
-		: public messaging_quic_client_base<messaging_quic_client>
+		: public std::enable_shared_from_this<messaging_quic_client>
 		, public interfaces::i_quic_client
 	{
 	public:
-		//! \brief Allow base class to access protected methods
-		friend class messaging_quic_client_base<messaging_quic_client>;
+		//! \brief Callback type for received data
+		using receive_callback_t = std::function<void(const std::vector<uint8_t>&)>;
+		//! \brief Callback type for stream data (stream_id, data, fin)
+		using stream_receive_callback_t = std::function<void(uint64_t, const std::vector<uint8_t>&, bool)>;
+		//! \brief Callback type for connection established
+		using connected_callback_t = std::function<void()>;
+		//! \brief Callback type for disconnection
+		using disconnected_callback_t = std::function<void()>;
+		//! \brief Callback type for errors
+		using error_callback_t = std::function<void(std::error_code)>;
 
 		/*!
 		 * \brief Constructs a QUIC client with a given identifier.
@@ -176,23 +190,18 @@ namespace kcenon::network::core
 
 		/*!
 		 * \brief Destructor; automatically calls \c stop_client() if running.
-		 * (Handled by base class)
 		 */
-		~messaging_quic_client() noexcept override = default;
+		~messaging_quic_client() noexcept override;
 
-		// Disable copy (inherited from base)
+		// Non-copyable, non-movable
 		messaging_quic_client(const messaging_quic_client&) = delete;
 		messaging_quic_client& operator=(const messaging_quic_client&) = delete;
+		messaging_quic_client(messaging_quic_client&&) = delete;
+		messaging_quic_client& operator=(messaging_quic_client&&) = delete;
 
 		// =====================================================================
-		// Connection Management (Extended)
+		// Lifecycle Management
 		// =====================================================================
-
-		// stop_client(), wait_for_stop(), is_running(),
-		// is_connected(), client_id() are provided by base class
-
-		//! \brief Bring base class start_client into scope
-		using messaging_quic_client_base<messaging_quic_client>::start_client;
 
 		/*!
 		 * \brief Starts the client with default configuration.
@@ -213,6 +222,18 @@ namespace kcenon::network::core
 		[[nodiscard]] auto start_client(std::string_view host,
 		                                unsigned short port,
 		                                const quic_client_config& config) -> VoidResult;
+
+		/*!
+		 * \brief Stops the client and releases all resources.
+		 * \return Result<void> - Success if client stopped, or error with code.
+		 */
+		[[nodiscard]] auto stop_client() -> VoidResult;
+
+		/*!
+		 * \brief Returns the client identifier.
+		 * \return The client_id string.
+		 */
+		[[nodiscard]] auto client_id() const -> const std::string&;
 
 		// =====================================================================
 		// Data Transfer (Default Stream)
@@ -253,7 +274,7 @@ namespace kcenon::network::core
 		[[nodiscard]] auto stats() const -> quic_connection_stats;
 
 		// =====================================================================
-		// i_quic_client interface implementation
+		// i_network_component interface implementation
 		// =====================================================================
 
 		/*!
@@ -262,18 +283,18 @@ namespace kcenon::network::core
 		 *
 		 * Implements i_network_component::is_running().
 		 */
-		[[nodiscard]] auto is_running() const -> bool override {
-			return messaging_quic_client_base::is_running();
-		}
+		[[nodiscard]] auto is_running() const -> bool override;
 
 		/*!
 		 * \brief Blocks until stop() is called.
 		 *
 		 * Implements i_network_component::wait_for_stop().
 		 */
-		auto wait_for_stop() -> void override {
-			messaging_quic_client_base::wait_for_stop();
-		}
+		auto wait_for_stop() -> void override;
+
+		// =====================================================================
+		// i_quic_client interface implementation
+		// =====================================================================
 
 		/*!
 		 * \brief Starts the QUIC client connecting to the specified server.
@@ -283,9 +304,7 @@ namespace kcenon::network::core
 		 *
 		 * Implements i_quic_client::start(). Delegates to start_client().
 		 */
-		[[nodiscard]] auto start(std::string_view host, uint16_t port) -> VoidResult override {
-			return start_client(host, port);
-		}
+		[[nodiscard]] auto start(std::string_view host, uint16_t port) -> VoidResult override;
 
 		/*!
 		 * \brief Stops the QUIC client.
@@ -293,9 +312,7 @@ namespace kcenon::network::core
 		 *
 		 * Implements i_quic_client::stop(). Delegates to stop_client().
 		 */
-		[[nodiscard]] auto stop() -> VoidResult override {
-			return stop_client();
-		}
+		[[nodiscard]] auto stop() -> VoidResult override;
 
 		/*!
 		 * \brief Checks if the client is connected (interface version).
@@ -303,9 +320,7 @@ namespace kcenon::network::core
 		 *
 		 * Implements i_quic_client::is_connected().
 		 */
-		[[nodiscard]] auto is_connected() const -> bool override {
-			return messaging_quic_client_base::is_connected();
-		}
+		[[nodiscard]] auto is_connected() const -> bool override;
 
 		/*!
 		 * \brief Checks if TLS handshake is complete (interface version).
@@ -313,9 +328,7 @@ namespace kcenon::network::core
 		 *
 		 * Implements i_quic_client::is_handshake_complete().
 		 */
-		[[nodiscard]] auto is_handshake_complete() const -> bool override {
-			return is_handshake_complete_impl();
-		}
+		[[nodiscard]] auto is_handshake_complete() const -> bool override;
 
 		/*!
 		 * \brief Sends data on the default stream (interface version).
@@ -324,9 +337,7 @@ namespace kcenon::network::core
 		 *
 		 * Implements i_quic_client::send().
 		 */
-		[[nodiscard]] auto send(std::vector<uint8_t>&& data) -> VoidResult override {
-			return send_packet(std::move(data));
-		}
+		[[nodiscard]] auto send(std::vector<uint8_t>&& data) -> VoidResult override;
 
 		/*!
 		 * \brief Creates a new bidirectional stream (interface version).
@@ -389,9 +400,7 @@ namespace kcenon::network::core
 		 *
 		 * Implements i_quic_client::is_early_data_accepted().
 		 */
-		[[nodiscard]] auto is_early_data_accepted() const -> bool override {
-			return is_early_data_accepted_impl();
-		}
+		[[nodiscard]] auto is_early_data_accepted() const -> bool override;
 
 		/*!
 		 * \brief Sets the callback for received data on default stream (interface version).
@@ -461,16 +470,18 @@ namespace kcenon::network::core
 		// Legacy API (maintained for backward compatibility)
 		// =====================================================================
 
-		//! \brief Legacy callback setters from base class
-		using messaging_quic_client_base::set_receive_callback;
-		using messaging_quic_client_base::set_stream_receive_callback;
-		using messaging_quic_client_base::set_connected_callback;
-		using messaging_quic_client_base::set_disconnected_callback;
-		using messaging_quic_client_base::set_error_callback;
+		/*!
+		 * \brief Sets the callback for stream data reception (all streams, legacy version).
+		 * \param callback Function called with stream ID, data, and FIN flag.
+		 *
+		 * \note This is kept for backward compatibility. New code should use
+		 *       set_stream_callback() from the i_quic_client interface.
+		 */
+		auto set_stream_receive_callback(stream_receive_callback_t callback) -> void;
 
-	protected:
+	private:
 		// =====================================================================
-		// CRTP Implementation Methods
+		// Internal Implementation Methods
 		// =====================================================================
 
 		/*!
@@ -478,33 +489,14 @@ namespace kcenon::network::core
 		 * \param host The server hostname or IP address.
 		 * \param port The server port number.
 		 * \return VoidResult - Success if client started, or error with code.
-		 *
-		 * Called by base class start_client() after common validation.
 		 */
-		auto do_start(std::string_view host, unsigned short port) -> VoidResult;
+		auto do_start_impl(std::string_view host, unsigned short port) -> VoidResult;
 
 		/*!
 		 * \brief QUIC-specific implementation of client stop.
 		 * \return VoidResult - Success if client stopped, or error with code.
-		 *
-		 * Called by base class stop_client() after common cleanup.
 		 */
-		auto do_stop() -> VoidResult;
-
-	private:
-		// =====================================================================
-		// Internal Methods
-		// =====================================================================
-
-		/*!
-		 * \brief Internal implementation for is_handshake_complete.
-		 */
-		[[nodiscard]] auto is_handshake_complete_impl() const noexcept -> bool;
-
-		/*!
-		 * \brief Internal implementation for is_early_data_accepted.
-		 */
-		[[nodiscard]] auto is_early_data_accepted_impl() const noexcept -> bool;
+		auto do_stop_impl() -> VoidResult;
 
 		/*!
 		 * \brief Internal connection implementation.
@@ -539,8 +531,67 @@ namespace kcenon::network::core
 		auto get_socket() const -> std::shared_ptr<internal::quic_socket>;
 
 		// =====================================================================
+		// Internal Callback Helpers
+		// =====================================================================
+
+		/*!
+		 * \brief Invokes the receive callback.
+		 * \param data The received data.
+		 */
+		auto invoke_receive_callback(const std::vector<uint8_t>& data) -> void;
+
+		/*!
+		 * \brief Invokes the stream receive callback.
+		 * \param stream_id The stream ID.
+		 * \param data The received data.
+		 * \param fin Whether this is the final data on the stream.
+		 */
+		auto invoke_stream_receive_callback(uint64_t stream_id,
+		                                    const std::vector<uint8_t>& data,
+		                                    bool fin) -> void;
+
+		/*!
+		 * \brief Invokes the connected callback.
+		 */
+		auto invoke_connected_callback() -> void;
+
+		/*!
+		 * \brief Invokes the disconnected callback.
+		 */
+		auto invoke_disconnected_callback() -> void;
+
+		/*!
+		 * \brief Invokes the error callback.
+		 * \param ec The error code.
+		 */
+		auto invoke_error_callback(std::error_code ec) -> void;
+
+		// =====================================================================
+		// Callback indices for callback_manager
+		// =====================================================================
+		static constexpr std::size_t kReceiveCallbackIndex = 0;
+		static constexpr std::size_t kStreamReceiveCallbackIndex = 1;
+		static constexpr std::size_t kConnectedCallbackIndex = 2;
+		static constexpr std::size_t kDisconnectedCallbackIndex = 3;
+		static constexpr std::size_t kErrorCallbackIndex = 4;
+
+		//! \brief Callback manager type for this client
+		using callbacks_t = utils::callback_manager<
+			receive_callback_t,
+			stream_receive_callback_t,
+			connected_callback_t,
+			disconnected_callback_t,
+			error_callback_t
+		>;
+
+		// =====================================================================
 		// Member Variables
 		// =====================================================================
+
+		std::string client_id_;                          /*!< Client identifier. */
+		utils::lifecycle_manager lifecycle_;             /*!< Lifecycle state manager. */
+		callbacks_t callbacks_;                          /*!< Callback manager. */
+		std::atomic<bool> is_connected_{false};          /*!< True if connected to remote. */
 
 		std::unique_ptr<asio::io_context> io_context_;  //!< I/O context
 		std::unique_ptr<asio::executor_work_guard<asio::io_context::executor_type>>

--- a/src/core/messaging_quic_server.cpp
+++ b/src/core/messaging_quic_server.cpp
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "kcenon/network/core/messaging_quic_server.h"
 
-#include "kcenon/network/core/network_context.h"
 #include "kcenon/network/integration/logger_integration.h"
 #include "kcenon/network/metrics/network_metrics.h"
 #include "kcenon/network/protocols/quic/packet.h"
@@ -47,498 +46,620 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace kcenon::network::core
 {
 
-	messaging_quic_server::messaging_quic_server(std::string_view server_id)
-	    : messaging_quic_server_base<messaging_quic_server>(server_id)
+messaging_quic_server::messaging_quic_server(std::string_view server_id)
+	: server_id_(server_id)
+{
+}
+
+messaging_quic_server::~messaging_quic_server() noexcept
+{
+	if (lifecycle_.is_running())
 	{
+		auto result = stop_server();
+		(void)result; // Ignore result in destructor
+	}
+}
+
+auto messaging_quic_server::server_id() const -> const std::string&
+{
+	return server_id_;
+}
+
+auto messaging_quic_server::is_running() const -> bool
+{
+	return lifecycle_.is_running();
+}
+
+auto messaging_quic_server::wait_for_stop() -> void
+{
+	lifecycle_.wait_for_stop();
+}
+
+auto messaging_quic_server::start_server(unsigned short port) -> VoidResult
+{
+	// Use default config with no TLS (for development/testing only)
+	return start_server(port, quic_server_config{});
+}
+
+auto messaging_quic_server::start_server(unsigned short port,
+                                         const quic_server_config& config)
+	-> VoidResult
+{
+	if (lifecycle_.is_running())
+	{
+		return error_void(
+			error_codes::network_system::server_already_running,
+			"QUIC server is already running",
+			"messaging_quic_server::start_server");
 	}
 
-	auto messaging_quic_server::start_server(unsigned short port) -> VoidResult
+	config_ = config;
+	lifecycle_.set_running();
+
+	auto result = do_start_impl(port);
+	if (result.is_err())
 	{
-		// Use default config with no TLS (for development/testing only)
-		return start_server(port, quic_server_config{});
+		lifecycle_.mark_stopped();
 	}
 
-	auto messaging_quic_server::start_server(unsigned short port,
-	                                         const quic_server_config& config)
-	    -> VoidResult
+	return result;
+}
+
+auto messaging_quic_server::stop_server() -> VoidResult
+{
+	if (!lifecycle_.is_running())
 	{
-		config_ = config;
-		// Use base class start_server which calls do_start
-		return messaging_quic_server_base<messaging_quic_server>::start_server(port);
+		return error_void(
+			error_codes::network_system::server_not_started,
+			"QUIC server is not running",
+			"messaging_quic_server::stop_server");
 	}
 
-	auto messaging_quic_server::do_start(unsigned short port) -> VoidResult
+	if (!lifecycle_.prepare_stop())
 	{
-		try
+		return error_void(
+			error_codes::network_system::server_not_started,
+			"QUIC server is already stopping",
+			"messaging_quic_server::stop_server");
+	}
+
+	auto result = do_stop_impl();
+	lifecycle_.mark_stopped();
+
+	return result;
+}
+
+auto messaging_quic_server::start(uint16_t port) -> VoidResult
+{
+	return start_server(port);
+}
+
+auto messaging_quic_server::stop() -> VoidResult
+{
+	return stop_server();
+}
+
+auto messaging_quic_server::connection_count() const -> size_t
+{
+	return session_count();
+}
+
+auto messaging_quic_server::do_start_impl(unsigned short port) -> VoidResult
+{
+	try
+	{
+		// Create io_context
+		io_context_ = std::make_unique<asio::io_context>();
+		work_guard_ = std::make_unique<
+			asio::executor_work_guard<asio::io_context::executor_type>>(
+			asio::make_work_guard(*io_context_));
+
+		// Create UDP socket
+		udp_socket_ = std::make_unique<asio::ip::udp::socket>(
+			*io_context_,
+			asio::ip::udp::endpoint(asio::ip::udp::v4(), port));
+
+		// Create cleanup timer
+		cleanup_timer_ = std::make_unique<asio::steady_timer>(*io_context_);
+
+		// Start receiving packets
+		start_receive();
+
+		// Start periodic cleanup timer
+		start_cleanup_timer();
+
+		// Get thread pool from network context
+		thread_pool_ = network_context::instance().get_thread_pool();
+		if (!thread_pool_)
 		{
-			// Create io_context
-			io_context_ = std::make_unique<asio::io_context>();
-			work_guard_ = std::make_unique<
-			    asio::executor_work_guard<asio::io_context::executor_type>>(
-			    asio::make_work_guard(*io_context_));
-
-			// Create UDP socket
-			udp_socket_ = std::make_unique<asio::ip::udp::socket>(
-			    *io_context_,
-			    asio::ip::udp::endpoint(asio::ip::udp::v4(), port));
-
-			// Create cleanup timer
-			cleanup_timer_ = std::make_unique<asio::steady_timer>(*io_context_);
-
-			// Start receiving packets
-			start_receive();
-
-			// Start periodic cleanup timer
-			start_cleanup_timer();
-
-			// Get thread pool from network context
-			thread_pool_ = network_context::instance().get_thread_pool();
-			if (!thread_pool_)
-			{
-				thread_pool_ = std::make_shared<integration::basic_thread_pool>(2);
-			}
-
-			// Submit io_context run task to thread pool
-			io_context_future_ = thread_pool_->submit(
-			    [this]()
-			    {
-				    try
-				    {
-					    NETWORK_LOG_INFO(
-					        "[messaging_quic_server] Starting io_context on thread pool");
-					    io_context_->run();
-					    NETWORK_LOG_INFO(
-					        "[messaging_quic_server] io_context stopped");
-				    }
-				    catch (const std::exception& e)
-				    {
-					    NETWORK_LOG_ERROR(
-					        "[messaging_quic_server] Exception in io_context: "
-					        + std::string(e.what()));
-				    }
-			    });
-
-			NETWORK_LOG_INFO("[messaging_quic_server] Started listening on port "
-			                 + std::to_string(port));
-			return ok();
+			thread_pool_ = std::make_shared<integration::basic_thread_pool>(2);
 		}
-		catch (const std::system_error& e)
-		{
-			if (e.code() == asio::error::address_in_use ||
-			    e.code() == std::errc::address_in_use)
-			{
-				return error_void(error_codes::network_system::bind_failed,
-				                  "Failed to bind to port: address already in use",
-				                  "messaging_quic_server::do_start",
-				                  "Port: " + std::to_string(port));
-			}
-			else if (e.code() == asio::error::access_denied ||
-			         e.code() == std::errc::permission_denied)
-			{
-				return error_void(error_codes::network_system::bind_failed,
-				                  "Failed to bind to port: permission denied",
-				                  "messaging_quic_server::do_start",
-				                  "Port: " + std::to_string(port));
-			}
 
-			return error_void(error_codes::common_errors::internal_error,
-			                  "Failed to start server: " + std::string(e.what()),
-			                  "messaging_quic_server::do_start",
-			                  "Port: " + std::to_string(port));
-		}
-		catch (const std::exception& e)
-		{
-			return error_void(error_codes::common_errors::internal_error,
-			                  "Failed to start server: " + std::string(e.what()),
-			                  "messaging_quic_server::do_start",
-			                  "Port: " + std::to_string(port));
-		}
-	}
-
-	auto messaging_quic_server::do_stop() -> VoidResult
-	{
-		try
-		{
-			// Cancel cleanup timer
-			if (cleanup_timer_)
+		// Submit io_context run task to thread pool
+		io_context_future_ = thread_pool_->submit(
+			[this]()
 			{
-				cleanup_timer_->cancel();
-			}
-
-			// Close UDP socket
-			if (udp_socket_)
-			{
-				asio::error_code ec;
-				udp_socket_->cancel(ec);
-				if (udp_socket_->is_open())
+				try
 				{
-					udp_socket_->close(ec);
+					NETWORK_LOG_INFO(
+						"[messaging_quic_server] Starting io_context on thread pool");
+					io_context_->run();
+					NETWORK_LOG_INFO(
+						"[messaging_quic_server] io_context stopped");
 				}
-			}
+				catch (const std::exception& e)
+				{
+					NETWORK_LOG_ERROR(
+						"[messaging_quic_server] Exception in io_context: "
+						+ std::string(e.what()));
+				}
+			});
 
-			// Stop all sessions
-			disconnect_all(0);
-
-			// Release work guard
-			if (work_guard_)
-			{
-				work_guard_.reset();
-			}
-
-			// Stop io_context
-			if (io_context_)
-			{
-				io_context_->stop();
-			}
-
-			// Wait for io_context task
-			if (io_context_future_.valid())
-			{
-				io_context_future_.wait();
-			}
-
-			// Release resources
-			udp_socket_.reset();
-			cleanup_timer_.reset();
-			thread_pool_.reset();
-			io_context_.reset();
-
-			NETWORK_LOG_INFO("[messaging_quic_server] Stopped.");
-			return ok();
-		}
-		catch (const std::exception& e)
+		NETWORK_LOG_INFO("[messaging_quic_server] Started listening on port "
+		                 + std::to_string(port));
+		return ok();
+	}
+	catch (const std::system_error& e)
+	{
+		if (e.code() == asio::error::address_in_use ||
+			e.code() == std::errc::address_in_use)
 		{
-			return error_void(error_codes::common_errors::internal_error,
-			                  "Failed to stop server: " + std::string(e.what()),
-			                  "messaging_quic_server::do_stop",
-			                  "Server ID: " + server_id_);
+			return error_void(error_codes::network_system::bind_failed,
+			                  "Failed to bind to port: address already in use",
+			                  "messaging_quic_server::do_start_impl",
+			                  "Port: " + std::to_string(port));
 		}
+		else if (e.code() == asio::error::access_denied ||
+		         e.code() == std::errc::permission_denied)
+		{
+			return error_void(error_codes::network_system::bind_failed,
+			                  "Failed to bind to port: permission denied",
+			                  "messaging_quic_server::do_start_impl",
+			                  "Port: " + std::to_string(port));
+		}
+
+		return error_void(error_codes::common_errors::internal_error,
+		                  "Failed to start server: " + std::string(e.what()),
+		                  "messaging_quic_server::do_start_impl",
+		                  "Port: " + std::to_string(port));
+	}
+	catch (const std::exception& e)
+	{
+		return error_void(error_codes::common_errors::internal_error,
+		                  "Failed to start server: " + std::string(e.what()),
+		                  "messaging_quic_server::do_start_impl",
+		                  "Port: " + std::to_string(port));
+	}
+}
+
+auto messaging_quic_server::do_stop_impl() -> VoidResult
+{
+	try
+	{
+		// Cancel cleanup timer
+		if (cleanup_timer_)
+		{
+			cleanup_timer_->cancel();
+		}
+
+		// Close UDP socket
+		if (udp_socket_)
+		{
+			asio::error_code ec;
+			udp_socket_->cancel(ec);
+			if (udp_socket_->is_open())
+			{
+				udp_socket_->close(ec);
+			}
+		}
+
+		// Stop all sessions
+		disconnect_all(0);
+
+		// Release work guard
+		if (work_guard_)
+		{
+			work_guard_.reset();
+		}
+
+		// Stop io_context
+		if (io_context_)
+		{
+			io_context_->stop();
+		}
+
+		// Wait for io_context task
+		if (io_context_future_.valid())
+		{
+			io_context_future_.wait();
+		}
+
+		// Release resources
+		udp_socket_.reset();
+		cleanup_timer_.reset();
+		thread_pool_.reset();
+		io_context_.reset();
+
+		NETWORK_LOG_INFO("[messaging_quic_server] Stopped.");
+		return ok();
+	}
+	catch (const std::exception& e)
+	{
+		return error_void(error_codes::common_errors::internal_error,
+		                  "Failed to stop server: " + std::string(e.what()),
+		                  "messaging_quic_server::do_stop_impl",
+		                  "Server ID: " + server_id_);
+	}
+}
+
+auto messaging_quic_server::sessions() const
+	-> std::vector<std::shared_ptr<session::quic_session>>
+{
+	std::shared_lock<std::shared_mutex> lock(sessions_mutex_);
+	std::vector<std::shared_ptr<session::quic_session>> result;
+	result.reserve(sessions_.size());
+	for (const auto& [id, session] : sessions_)
+	{
+		result.push_back(session);
+	}
+	return result;
+}
+
+auto messaging_quic_server::get_session(const std::string& session_id)
+	-> std::shared_ptr<session::quic_session>
+{
+	std::shared_lock<std::shared_mutex> lock(sessions_mutex_);
+	auto it = sessions_.find(session_id);
+	if (it != sessions_.end())
+	{
+		return it->second;
+	}
+	return nullptr;
+}
+
+auto messaging_quic_server::session_count() const -> size_t
+{
+	std::shared_lock<std::shared_mutex> lock(sessions_mutex_);
+	return sessions_.size();
+}
+
+auto messaging_quic_server::disconnect_session(const std::string& session_id,
+                                               uint64_t error_code)
+	-> VoidResult
+{
+	std::shared_ptr<session::quic_session> session;
+	{
+		std::unique_lock<std::shared_mutex> lock(sessions_mutex_);
+		auto it = sessions_.find(session_id);
+		if (it == sessions_.end())
+		{
+			return error_void(error_codes::common_errors::not_found,
+			                  "Session not found",
+			                  "messaging_quic_server::disconnect_session",
+			                  "Session ID: " + session_id);
+		}
+		session = it->second;
+		sessions_.erase(it);
 	}
 
-	auto messaging_quic_server::sessions() const
-	    -> std::vector<std::shared_ptr<session::quic_session>>
+	if (session)
+	{
+		return session->close(error_code);
+	}
+	return ok();
+}
+
+auto messaging_quic_server::disconnect_all(uint64_t error_code) -> void
+{
+	std::vector<std::shared_ptr<session::quic_session>> sessions_to_close;
+	{
+		std::unique_lock<std::shared_mutex> lock(sessions_mutex_);
+		sessions_to_close.reserve(sessions_.size());
+		for (auto& [id, session] : sessions_)
+		{
+			sessions_to_close.push_back(session);
+		}
+		sessions_.clear();
+	}
+
+	for (auto& session : sessions_to_close)
+	{
+		if (session)
+		{
+			auto result = session->close(error_code);
+			(void)result;
+		}
+	}
+}
+
+auto messaging_quic_server::broadcast(std::vector<uint8_t>&& data)
+	-> VoidResult
+{
+	auto sessions_list = sessions();
+	for (auto& session : sessions_list)
+	{
+		if (session && session->is_active())
+		{
+			std::vector<uint8_t> data_copy(data);
+			auto result = session->send(std::move(data_copy));
+			if (result.is_err())
+			{
+				NETWORK_LOG_WARN("[messaging_quic_server] Failed to send to session "
+				                 + session->session_id() + ": "
+				                 + result.error().message);
+			}
+		}
+	}
+	return ok();
+}
+
+auto messaging_quic_server::multicast(
+	const std::vector<std::string>& session_ids,
+	std::vector<uint8_t>&& data) -> VoidResult
+{
+	for (const auto& session_id : session_ids)
+	{
+		auto session = get_session(session_id);
+		if (session && session->is_active())
+		{
+			std::vector<uint8_t> data_copy(data);
+			auto result = session->send(std::move(data_copy));
+			if (result.is_err())
+			{
+				NETWORK_LOG_WARN("[messaging_quic_server] Failed to send to session "
+				                 + session_id + ": " + result.error().message);
+			}
+		}
+	}
+	return ok();
+}
+
+#if KCENON_WITH_COMMON_SYSTEM
+auto messaging_quic_server::set_monitor(
+	kcenon::common::interfaces::IMonitor* monitor) -> void
+{
+	monitor_ = monitor;
+}
+
+auto messaging_quic_server::get_monitor() const
+	-> kcenon::common::interfaces::IMonitor*
+{
+	return monitor_;
+}
+#endif
+
+auto messaging_quic_server::start_receive() -> void
+{
+	if (!is_running() || !udp_socket_)
+	{
+		return;
+	}
+
+	auto self = shared_from_this();
+	udp_socket_->async_receive_from(
+		asio::buffer(recv_buffer_),
+		recv_endpoint_,
+		[this, self](std::error_code ec, std::size_t bytes_received)
+		{
+			if (!is_running())
+			{
+				return;
+			}
+
+			if (ec)
+			{
+				if (ec != asio::error::operation_aborted)
+				{
+					NETWORK_LOG_ERROR(
+						"[messaging_quic_server] Receive error: " + ec.message());
+
+					invoke_error_callback(ec);
+				}
+				return;
+			}
+
+			// Handle the received packet
+			std::span<const uint8_t> packet_data(recv_buffer_.data(),
+			                                     bytes_received);
+			handle_packet(packet_data, recv_endpoint_);
+
+			// Continue receiving
+			start_receive();
+		});
+}
+
+auto messaging_quic_server::handle_packet(std::span<const uint8_t> data,
+                                          const asio::ip::udp::endpoint& from)
+	-> void
+{
+	if (data.empty())
+	{
+		return;
+	}
+
+	// Parse packet header to get destination connection ID
+	auto header_result = protocols::quic::packet_parser::parse_header(data);
+	if (header_result.is_err())
+	{
+		NETWORK_LOG_DEBUG("[messaging_quic_server] Invalid packet from "
+		                  + from.address().to_string());
+		return;
+	}
+
+	// Extract destination connection ID from header
+	protocols::quic::connection_id dcid;
+	std::visit(
+		[&dcid](auto&& hdr)
+		{
+			dcid = hdr.dest_conn_id;
+		},
+		header_result.value().first);
+
+	// Find or create session for this connection
+	auto session = find_or_create_session(dcid, from);
+	if (!session)
+	{
+		NETWORK_LOG_DEBUG(
+			"[messaging_quic_server] Could not find or create session for packet");
+		return;
+	}
+
+	// Delegate packet handling to session
+	session->handle_packet(data);
+}
+
+auto messaging_quic_server::find_or_create_session(
+	const protocols::quic::connection_id& dcid,
+	const asio::ip::udp::endpoint& endpoint)
+	-> std::shared_ptr<session::quic_session>
+{
+	// First, check existing sessions
 	{
 		std::shared_lock<std::shared_mutex> lock(sessions_mutex_);
-		std::vector<std::shared_ptr<session::quic_session>> result;
-		result.reserve(sessions_.size());
 		for (const auto& [id, session] : sessions_)
 		{
-			result.push_back(session);
+			if (session->matches_connection_id(dcid))
+			{
+				return session;
+			}
 		}
-		return result;
 	}
 
-	auto messaging_quic_server::get_session(const std::string& session_id)
-	    -> std::shared_ptr<session::quic_session>
+	// Check connection limit
+	if (session_count() >= config_.max_connections)
 	{
-		std::shared_lock<std::shared_mutex> lock(sessions_mutex_);
-		auto it = sessions_.find(session_id);
-		if (it != sessions_.end())
-		{
-			return it->second;
-		}
+		NETWORK_LOG_WARN(
+			"[messaging_quic_server] Connection limit reached, rejecting new connection");
 		return nullptr;
 	}
 
-	auto messaging_quic_server::session_count() const -> size_t
+	// Create new session for this connection
+	auto session_id = generate_session_id();
+
+	// Create QUIC socket for the new session
+	asio::ip::udp::socket session_socket(
+		*io_context_, asio::ip::udp::endpoint(asio::ip::udp::v4(), 0));
+	session_socket.connect(endpoint);
+
+	auto quic_socket = std::make_shared<internal::quic_socket>(
+		std::move(session_socket), internal::quic_role::server);
+
+	// Accept the connection with TLS config
+	if (!config_.cert_file.empty() && !config_.key_file.empty())
 	{
-		std::shared_lock<std::shared_mutex> lock(sessions_mutex_);
-		return sessions_.size();
-	}
-
-	auto messaging_quic_server::disconnect_session(const std::string& session_id,
-	                                               uint64_t error_code)
-	    -> VoidResult
-	{
-		std::shared_ptr<session::quic_session> session;
+		auto accept_result =
+			quic_socket->accept(config_.cert_file, config_.key_file);
+		if (accept_result.is_err())
 		{
-			std::unique_lock<std::shared_mutex> lock(sessions_mutex_);
-			auto it = sessions_.find(session_id);
-			if (it == sessions_.end())
-			{
-				return error_void(error_codes::common_errors::not_found,
-				                  "Session not found",
-				                  "messaging_quic_server::disconnect_session",
-				                  "Session ID: " + session_id);
-			}
-			session = it->second;
-			sessions_.erase(it);
-		}
-
-		if (session)
-		{
-			return session->close(error_code);
-		}
-		return ok();
-	}
-
-	auto messaging_quic_server::disconnect_all(uint64_t error_code) -> void
-	{
-		std::vector<std::shared_ptr<session::quic_session>> sessions_to_close;
-		{
-			std::unique_lock<std::shared_mutex> lock(sessions_mutex_);
-			sessions_to_close.reserve(sessions_.size());
-			for (auto& [id, session] : sessions_)
-			{
-				sessions_to_close.push_back(session);
-			}
-			sessions_.clear();
-		}
-
-		for (auto& session : sessions_to_close)
-		{
-			if (session)
-			{
-				auto result = session->close(error_code);
-				(void)result;
-			}
+			NETWORK_LOG_ERROR(
+				"[messaging_quic_server] Failed to accept connection: "
+				+ accept_result.error().message);
+			return nullptr;
 		}
 	}
 
-	auto messaging_quic_server::broadcast(std::vector<uint8_t>&& data)
-	    -> VoidResult
-	{
-		auto sessions_list = sessions();
-		for (auto& session : sessions_list)
+	auto session =
+		std::make_shared<session::quic_session>(quic_socket, session_id);
+
+	// Set up session callbacks
+	auto self = weak_from_this();
+
+	session->set_receive_callback(
+		[self, session_id](const std::vector<uint8_t>& data)
 		{
-			if (session && session->is_active())
+			if (auto server = self.lock())
 			{
-				std::vector<uint8_t> data_copy(data);
-				auto result = session->send(std::move(data_copy));
-				if (result.is_err())
+				auto sess = server->get_session(session_id);
+				if (sess)
 				{
-					NETWORK_LOG_WARN("[messaging_quic_server] Failed to send to session "
-					                 + session->session_id() + ": "
-					                 + result.error().message);
+					server->invoke_receive_callback(sess, data);
 				}
 			}
-		}
-		return ok();
-	}
+		});
 
-	auto messaging_quic_server::multicast(
-	    const std::vector<std::string>& session_ids,
-	    std::vector<uint8_t>&& data) -> VoidResult
-	{
-		for (const auto& session_id : session_ids)
+	session->set_stream_receive_callback(
+		[self, session_id](uint64_t stream_id,
+		                   const std::vector<uint8_t>& data,
+		                   bool fin)
 		{
-			auto session = get_session(session_id);
-			if (session && session->is_active())
+			if (auto server = self.lock())
 			{
-				std::vector<uint8_t> data_copy(data);
-				auto result = session->send(std::move(data_copy));
-				if (result.is_err())
+				auto sess = server->get_session(session_id);
+				if (sess)
 				{
-					NETWORK_LOG_WARN("[messaging_quic_server] Failed to send to session "
-					                 + session_id + ": " + result.error().message);
+					server->invoke_stream_receive_callback(sess, stream_id, data, fin);
 				}
 			}
-		}
-		return ok();
+		});
+
+	session->set_close_callback(
+		[self, session_id]()
+		{
+			if (auto server = self.lock())
+			{
+				server->on_session_close(session_id);
+			}
+		});
+
+	// Add session to map
+	{
+		std::unique_lock<std::shared_mutex> lock(sessions_mutex_);
+		sessions_[session_id] = session;
 	}
+
+	// Start the session
+	session->start_session();
+
+	// Report metrics
+	metrics::metric_reporter::report_connection_accepted();
+	metrics::metric_reporter::report_active_connections(session_count());
+
+	// Invoke connection callback
+	invoke_connection_callback(session);
 
 #if KCENON_WITH_COMMON_SYSTEM
-	auto messaging_quic_server::set_monitor(
-	    kcenon::common::interfaces::IMonitor* monitor) -> void
+	if (monitor_)
 	{
-		monitor_ = monitor;
-	}
-
-	auto messaging_quic_server::get_monitor() const
-	    -> kcenon::common::interfaces::IMonitor*
-	{
-		return monitor_;
+		monitor_->record_metric("active_connections",
+		                        static_cast<double>(session_count()));
 	}
 #endif
 
-	auto messaging_quic_server::start_receive() -> void
+	NETWORK_LOG_INFO("[messaging_quic_server] New session created: "
+	                 + session_id + " from " + endpoint.address().to_string());
+
+	return session;
+}
+
+auto messaging_quic_server::generate_session_id() -> std::string
+{
+	auto counter = session_counter_.fetch_add(1);
+	std::ostringstream oss;
+	oss << server_id_ << "-" << counter;
+	return oss.str();
+}
+
+auto messaging_quic_server::on_session_close(const std::string& session_id)
+	-> void
+{
+	std::shared_ptr<session::quic_session> session;
 	{
-		if (!is_running() || !udp_socket_)
+		std::unique_lock<std::shared_mutex> lock(sessions_mutex_);
+		auto it = sessions_.find(session_id);
+		if (it != sessions_.end())
 		{
-			return;
+			session = it->second;
+			sessions_.erase(it);
 		}
-
-		auto self = shared_from_this();
-		udp_socket_->async_receive_from(
-		    asio::buffer(recv_buffer_),
-		    recv_endpoint_,
-		    [this, self](std::error_code ec, std::size_t bytes_received)
-		    {
-			    if (!is_running())
-			    {
-				    return;
-			    }
-
-			    if (ec)
-			    {
-				    if (ec != asio::error::operation_aborted)
-				    {
-					    NETWORK_LOG_ERROR(
-					        "[messaging_quic_server] Receive error: " + ec.message());
-
-					    invoke_error_callback(ec);
-				    }
-				    return;
-			    }
-
-			    // Handle the received packet
-			    std::span<const uint8_t> packet_data(recv_buffer_.data(),
-			                                         bytes_received);
-			    handle_packet(packet_data, recv_endpoint_);
-
-			    // Continue receiving
-			    start_receive();
-		    });
 	}
 
-	auto messaging_quic_server::handle_packet(std::span<const uint8_t> data,
-	                                          const asio::ip::udp::endpoint& from)
-	    -> void
+	if (session)
 	{
-		if (data.empty())
-		{
-			return;
-		}
-
-		// Parse packet header to get destination connection ID
-		auto header_result = protocols::quic::packet_parser::parse_header(data);
-		if (header_result.is_err())
-		{
-			NETWORK_LOG_DEBUG("[messaging_quic_server] Invalid packet from "
-			                  + from.address().to_string());
-			return;
-		}
-
-		// Extract destination connection ID from header
-		protocols::quic::connection_id dcid;
-		std::visit(
-		    [&dcid](auto&& hdr)
-		    {
-			    dcid = hdr.dest_conn_id;
-		    },
-		    header_result.value().first);
-
-		// Find or create session for this connection
-		auto session = find_or_create_session(dcid, from);
-		if (!session)
-		{
-			NETWORK_LOG_DEBUG(
-			    "[messaging_quic_server] Could not find or create session for packet");
-			return;
-		}
-
-		// Delegate packet handling to session
-		session->handle_packet(data);
-	}
-
-	auto messaging_quic_server::find_or_create_session(
-	    const protocols::quic::connection_id& dcid,
-	    const asio::ip::udp::endpoint& endpoint)
-	    -> std::shared_ptr<session::quic_session>
-	{
-		// First, check existing sessions
-		{
-			std::shared_lock<std::shared_mutex> lock(sessions_mutex_);
-			for (const auto& [id, session] : sessions_)
-			{
-				if (session->matches_connection_id(dcid))
-				{
-					return session;
-				}
-			}
-		}
-
-		// Check connection limit
-		if (session_count() >= config_.max_connections)
-		{
-			NETWORK_LOG_WARN(
-			    "[messaging_quic_server] Connection limit reached, rejecting new connection");
-			return nullptr;
-		}
-
-		// Create new session for this connection
-		auto session_id = generate_session_id();
-
-		// Create QUIC socket for the new session
-		asio::ip::udp::socket session_socket(
-		    *io_context_, asio::ip::udp::endpoint(asio::ip::udp::v4(), 0));
-		session_socket.connect(endpoint);
-
-		auto quic_socket = std::make_shared<internal::quic_socket>(
-		    std::move(session_socket), internal::quic_role::server);
-
-		// Accept the connection with TLS config
-		if (!config_.cert_file.empty() && !config_.key_file.empty())
-		{
-			auto accept_result =
-			    quic_socket->accept(config_.cert_file, config_.key_file);
-			if (accept_result.is_err())
-			{
-				NETWORK_LOG_ERROR(
-				    "[messaging_quic_server] Failed to accept connection: "
-				    + accept_result.error().message);
-				return nullptr;
-			}
-		}
-
-		auto session =
-		    std::make_shared<session::quic_session>(quic_socket, session_id);
-
-		// Set up session callbacks
-		auto self = weak_from_this();
-
-		session->set_receive_callback(
-		    [self, session_id](const std::vector<uint8_t>& data)
-		    {
-			    if (auto server = self.lock())
-			    {
-				    auto sess = server->get_session(session_id);
-				    if (sess)
-				    {
-					    server->invoke_receive_callback(sess, data);
-				    }
-			    }
-		    });
-
-		session->set_stream_receive_callback(
-		    [self, session_id](uint64_t stream_id,
-		                       const std::vector<uint8_t>& data,
-		                       bool fin)
-		    {
-			    if (auto server = self.lock())
-			    {
-				    auto sess = server->get_session(session_id);
-				    if (sess)
-				    {
-					    server->invoke_stream_receive_callback(sess, stream_id, data, fin);
-				    }
-			    }
-		    });
-
-		session->set_close_callback(
-		    [self, session_id]()
-		    {
-			    if (auto server = self.lock())
-			    {
-				    server->on_session_close(session_id);
-			    }
-		    });
-
-		// Add session to map
-		{
-			std::unique_lock<std::shared_mutex> lock(sessions_mutex_);
-			sessions_[session_id] = session;
-		}
-
-		// Start the session
-		session->start_session();
-
 		// Report metrics
-		metrics::metric_reporter::report_connection_accepted();
 		metrics::metric_reporter::report_active_connections(session_count());
 
-		// Invoke connection callback via base class
-		invoke_connection_callback(session);
+		// Invoke disconnection callback
+		invoke_disconnection_callback(session);
 
 #if KCENON_WITH_COMMON_SYSTEM
 		if (monitor_)
@@ -548,175 +669,194 @@ namespace kcenon::network::core
 		}
 #endif
 
-		NETWORK_LOG_INFO("[messaging_quic_server] New session created: "
-		                 + session_id + " from " + endpoint.address().to_string());
+		NETWORK_LOG_INFO("[messaging_quic_server] Session closed: "
+		                 + session_id);
+	}
+}
 
-		return session;
+auto messaging_quic_server::start_cleanup_timer() -> void
+{
+	if (!cleanup_timer_ || !is_running())
+	{
+		return;
 	}
 
-	auto messaging_quic_server::generate_session_id() -> std::string
-	{
-		auto counter = session_counter_.fetch_add(1);
-		std::ostringstream oss;
-		oss << server_id_ << "-" << counter;
-		return oss.str();
-	}
+	// Schedule cleanup every 30 seconds
+	cleanup_timer_->expires_after(std::chrono::seconds(30));
 
-	auto messaging_quic_server::on_session_close(const std::string& session_id)
-	    -> void
-	{
-		std::shared_ptr<session::quic_session> session;
+	auto self = shared_from_this();
+	cleanup_timer_->async_wait(
+		[this, self](const std::error_code& ec)
 		{
-			std::unique_lock<std::shared_mutex> lock(sessions_mutex_);
-			auto it = sessions_.find(session_id);
-			if (it != sessions_.end())
+			if (!ec && is_running())
 			{
-				session = it->second;
-				sessions_.erase(it);
+				cleanup_dead_sessions();
+				start_cleanup_timer(); // Reschedule
+			}
+		});
+}
+
+auto messaging_quic_server::cleanup_dead_sessions() -> void
+{
+	std::vector<std::string> dead_session_ids;
+
+	{
+		std::shared_lock<std::shared_mutex> lock(sessions_mutex_);
+		for (const auto& [id, session] : sessions_)
+		{
+			if (!session || !session->is_active())
+			{
+				dead_session_ids.push_back(id);
 			}
 		}
+	}
 
-		if (session)
-		{
-			// Report metrics
-			metrics::metric_reporter::report_active_connections(session_count());
+	for (const auto& id : dead_session_ids)
+	{
+		on_session_close(id);
+	}
 
-			// Invoke disconnection callback via base class
-			invoke_disconnection_callback(session);
+	if (!dead_session_ids.empty())
+	{
+		NETWORK_LOG_DEBUG(
+			"[messaging_quic_server] Cleaned up "
+			+ std::to_string(dead_session_ids.size())
+			+ " dead sessions. Active: " + std::to_string(session_count()));
+	}
+}
 
-#if KCENON_WITH_COMMON_SYSTEM
-			if (monitor_)
+// =============================================================================
+// Callback invocation helpers
+// =============================================================================
+
+auto messaging_quic_server::invoke_connection_callback(
+	std::shared_ptr<session::quic_session> session) -> void
+{
+	callbacks_.invoke<kConnectionCallbackIndex>(session);
+}
+
+auto messaging_quic_server::invoke_disconnection_callback(
+	std::shared_ptr<session::quic_session> session) -> void
+{
+	callbacks_.invoke<kDisconnectionCallbackIndex>(session);
+}
+
+auto messaging_quic_server::invoke_receive_callback(
+	std::shared_ptr<session::quic_session> session,
+	const std::vector<uint8_t>& data) -> void
+{
+	callbacks_.invoke<kReceiveCallbackIndex>(session, data);
+}
+
+auto messaging_quic_server::invoke_stream_receive_callback(
+	std::shared_ptr<session::quic_session> session,
+	uint64_t stream_id,
+	const std::vector<uint8_t>& data,
+	bool fin) -> void
+{
+	callbacks_.invoke<kStreamReceiveCallbackIndex>(session, stream_id, data, fin);
+}
+
+auto messaging_quic_server::invoke_error_callback(std::error_code ec) -> void
+{
+	callbacks_.invoke<kErrorCallbackIndex>(ec);
+}
+
+// =============================================================================
+// Legacy callback setters
+// =============================================================================
+
+auto messaging_quic_server::set_connection_callback(connection_callback_t callback) -> void
+{
+	callbacks_.set<kConnectionCallbackIndex>(std::move(callback));
+}
+
+auto messaging_quic_server::set_disconnection_callback(disconnection_callback_t callback) -> void
+{
+	callbacks_.set<kDisconnectionCallbackIndex>(std::move(callback));
+}
+
+auto messaging_quic_server::set_receive_callback(receive_callback_t callback) -> void
+{
+	callbacks_.set<kReceiveCallbackIndex>(std::move(callback));
+}
+
+auto messaging_quic_server::set_stream_receive_callback(stream_receive_callback_t callback) -> void
+{
+	callbacks_.set<kStreamReceiveCallbackIndex>(std::move(callback));
+}
+
+auto messaging_quic_server::set_error_callback(error_callback_t callback) -> void
+{
+	callbacks_.set<kErrorCallbackIndex>(std::move(callback));
+}
+
+// =============================================================================
+// i_quic_server interface callback implementations
+// =============================================================================
+
+auto messaging_quic_server::set_connection_callback(
+	interfaces::i_quic_server::connection_callback_t callback) -> void
+{
+	// Convert callback to internal type (quic_session to i_quic_session)
+	set_connection_callback(
+		[cb = std::move(callback)](std::shared_ptr<session::quic_session> session) {
+			if (cb && session)
 			{
-				monitor_->record_metric("active_connections",
-				                        static_cast<double>(session_count()));
+				// quic_session implements i_quic_session, so we can pass it directly
+				cb(session);
 			}
-#endif
+		});
+}
 
-			NETWORK_LOG_INFO("[messaging_quic_server] Session closed: "
-			                 + session_id);
-		}
-	}
-
-	auto messaging_quic_server::start_cleanup_timer() -> void
-	{
-		if (!cleanup_timer_ || !is_running())
-		{
-			return;
-		}
-
-		// Schedule cleanup every 30 seconds
-		cleanup_timer_->expires_after(std::chrono::seconds(30));
-
-		auto self = shared_from_this();
-		cleanup_timer_->async_wait(
-		    [this, self](const std::error_code& ec)
-		    {
-			    if (!ec && is_running())
-			    {
-				    cleanup_dead_sessions();
-				    start_cleanup_timer(); // Reschedule
-			    }
-		    });
-	}
-
-	auto messaging_quic_server::cleanup_dead_sessions() -> void
-	{
-		std::vector<std::string> dead_session_ids;
-
-		{
-			std::shared_lock<std::shared_mutex> lock(sessions_mutex_);
-			for (const auto& [id, session] : sessions_)
+auto messaging_quic_server::set_disconnection_callback(
+	interfaces::i_quic_server::disconnection_callback_t callback) -> void
+{
+	set_disconnection_callback(
+		[cb = std::move(callback)](std::shared_ptr<session::quic_session> session) {
+			if (cb && session)
 			{
-				if (!session || !session->is_active())
-				{
-					dead_session_ids.push_back(id);
-				}
+				cb(session->session_id());
 			}
-		}
+		});
+}
 
-		for (const auto& id : dead_session_ids)
-		{
-			on_session_close(id);
-		}
+auto messaging_quic_server::set_receive_callback(
+	interfaces::i_quic_server::receive_callback_t callback) -> void
+{
+	set_receive_callback(
+		[cb = std::move(callback)](std::shared_ptr<session::quic_session> session,
+		                            const std::vector<uint8_t>& data) {
+			if (cb && session)
+			{
+				cb(session->session_id(), data);
+			}
+		});
+}
 
-		if (!dead_session_ids.empty())
-		{
-			NETWORK_LOG_DEBUG(
-			    "[messaging_quic_server] Cleaned up "
-			    + std::to_string(dead_session_ids.size())
-			    + " dead sessions. Active: " + std::to_string(session_count()));
-		}
-	}
+auto messaging_quic_server::set_stream_callback(
+	interfaces::i_quic_server::stream_callback_t callback) -> void
+{
+	set_stream_receive_callback(
+		[cb = std::move(callback)](std::shared_ptr<session::quic_session> session,
+		                            uint64_t stream_id,
+		                            const std::vector<uint8_t>& data,
+		                            bool fin) {
+			if (cb && session)
+			{
+				cb(session->session_id(), stream_id, data, fin);
+			}
+		});
+}
 
-	// =========================================================================
-	// i_quic_server interface callback implementations
-	// =========================================================================
-
-	auto messaging_quic_server::set_connection_callback(
-	    interfaces::i_quic_server::connection_callback_t callback) -> void
-	{
-		// Convert callback to internal type (quic_session to i_quic_session)
-		messaging_quic_server_base::set_connection_callback(
-		    [cb = std::move(callback)](std::shared_ptr<session::quic_session> session) {
-			    if (cb && session)
-			    {
-				    // quic_session implements i_quic_session, so we can pass it directly
-				    // after implementing the interface on quic_session
-				    // For now, we use the session pointer as-is since the interface
-				    // will be implemented on quic_session in the next step
-				    cb(session);
-			    }
-		    });
-	}
-
-	auto messaging_quic_server::set_disconnection_callback(
-	    interfaces::i_quic_server::disconnection_callback_t callback) -> void
-	{
-		messaging_quic_server_base::set_disconnection_callback(
-		    [cb = std::move(callback)](std::shared_ptr<session::quic_session> session) {
-			    if (cb && session)
-			    {
-				    cb(session->session_id());
-			    }
-		    });
-	}
-
-	auto messaging_quic_server::set_receive_callback(
-	    interfaces::i_quic_server::receive_callback_t callback) -> void
-	{
-		messaging_quic_server_base::set_receive_callback(
-		    [cb = std::move(callback)](std::shared_ptr<session::quic_session> session,
-		                                const std::vector<uint8_t>& data) {
-			    if (cb && session)
-			    {
-				    cb(session->session_id(), data);
-			    }
-		    });
-	}
-
-	auto messaging_quic_server::set_stream_callback(
-	    interfaces::i_quic_server::stream_callback_t callback) -> void
-	{
-		messaging_quic_server_base::set_stream_receive_callback(
-		    [cb = std::move(callback)](std::shared_ptr<session::quic_session> session,
-		                                uint64_t stream_id,
-		                                const std::vector<uint8_t>& data,
-		                                bool fin) {
-			    if (cb && session)
-			    {
-				    cb(session->session_id(), stream_id, data, fin);
-			    }
-		    });
-	}
-
-	auto messaging_quic_server::set_error_callback(
-	    interfaces::i_quic_server::error_callback_t callback) -> void
-	{
-		// Store the interface callback and wrap it for base class
-		// Note: Base class error_callback_t only takes error_code, not session
-		// We need to store the interface callback separately and invoke it from
-		// the receive side where we have session context
-		interface_error_cb_ = std::move(callback);
-	}
+auto messaging_quic_server::set_error_callback(
+	interfaces::i_quic_server::error_callback_t callback) -> void
+{
+	// Store the interface callback and wrap it for base class
+	// Note: Base class error_callback_t only takes error_code, not session
+	// We need to store the interface callback separately and invoke it from
+	// the receive side where we have session context
+	interface_error_cb_ = std::move(callback);
+}
 
 } // namespace kcenon::network::core


### PR DESCRIPTION
## Summary
- Migrate `messaging_quic_client` and `messaging_quic_server` from CRTP-based inheritance to composition pattern
- Replace `messaging_quic_client_base<T>` and `messaging_quic_server_base<T>` with `utils::lifecycle_manager` and `utils::callback_manager`
- Maintain backward compatibility with existing API

## Changes
### messaging_quic_client
- Remove CRTP base class inheritance (`messaging_quic_client_base<messaging_quic_client>`)
- Add `utils::lifecycle_manager` for state management
- Add `utils::callback_manager` for type-safe callback handling
- Implement all lifecycle methods directly
- Add callback invocation helpers

### messaging_quic_server
- Remove CRTP base class inheritance (`messaging_quic_server_base<messaging_quic_server>`)
- Add `utils::lifecycle_manager` for state management
- Add `utils::callback_manager` for type-safe callback handling
- Implement all lifecycle methods directly
- Add callback invocation helpers
- Use correct error codes (`server_already_running`, `server_not_started`)

## Related Issues
Closes #443

## Test plan
- [x] All 22 QUIC client tests pass
- [x] All 21 QUIC server tests pass
- [x] Build succeeds
- [x] Backward compatibility maintained

## Part of
Phase 1.4 of CRTP to Composition Migration (#425)