### PR TITLE
refactor(core): implement unified SessionManager<T> template

### DIFF
--- a/include/kcenon/network/core/session_info.h
+++ b/include/kcenon/network/core/session_info.h
@@ -1,0 +1,85 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+*****************************************************************************/
+
+#pragma once
+
+#include "kcenon/network/core/session_traits.h"
+
+#include <chrono>
+#include <memory>
+
+namespace kcenon::network::core {
+
+/**
+ * @struct session_info_base
+ * @brief Wrapper for session with optional activity tracking
+ *
+ * Uses template specialization based on traits to avoid storage overhead
+ * when activity tracking is disabled.
+ *
+ * @tparam SessionType The session type being wrapped
+ * @tparam HasActivityTracking Whether to include activity tracking fields
+ */
+template <typename SessionType, bool HasActivityTracking>
+struct session_info_base;
+
+/**
+ * @brief Specialization with activity tracking enabled
+ *
+ * Includes timestamps for creation and last activity for idle detection.
+ */
+template <typename SessionType>
+struct session_info_base<SessionType, true> {
+    std::shared_ptr<SessionType> session;
+    std::chrono::steady_clock::time_point created_at;
+    std::chrono::steady_clock::time_point last_activity;
+
+    explicit session_info_base(std::shared_ptr<SessionType> sess)
+        : session(std::move(sess))
+        , created_at(std::chrono::steady_clock::now())
+        , last_activity(created_at) {}
+
+    /**
+     * @brief Updates the last activity timestamp to current time
+     */
+    void update_activity() { last_activity = std::chrono::steady_clock::now(); }
+
+    /**
+     * @brief Calculates the idle duration since last activity
+     * @return Duration since last activity in milliseconds
+     */
+    [[nodiscard]] auto idle_duration() const -> std::chrono::milliseconds {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - last_activity);
+    }
+};
+
+/**
+ * @brief Specialization without activity tracking (minimal overhead)
+ *
+ * Only stores the session pointer, no timestamp fields.
+ */
+template <typename SessionType>
+struct session_info_base<SessionType, false> {
+    std::shared_ptr<SessionType> session;
+
+    explicit session_info_base(std::shared_ptr<SessionType> sess)
+        : session(std::move(sess)) {}
+};
+
+/**
+ * @brief Convenience alias that selects the appropriate session_info_base
+ *        based on session_traits
+ *
+ * @tparam SessionType The session type to wrap
+ */
+template <typename SessionType>
+using session_info_t =
+    session_info_base<SessionType,
+                      session_traits<SessionType>::has_activity_tracking>;
+
+} // namespace kcenon::network::core

--- a/include/kcenon/network/core/session_manager.h
+++ b/include/kcenon/network/core/session_manager.h
@@ -1,57 +1,43 @@
 /*****************************************************************************
 BSD 3-Clause License
 
-Copyright (c) 2025, 🍀☀🌕🌥 🌊
+Copyright (c) 2025, kcenon
 All rights reserved.
 *****************************************************************************/
 
 #pragma once
 
-#include <atomic>
-#include <chrono>
-#include <memory>
-#include <mutex>
-#include <optional>
-#include <shared_mutex>
-#include <unordered_map>
-#include <vector>
-
+#include "kcenon/network/core/session_manager_base.h"
 #include "kcenon/network/session/messaging_session.h"
 
 namespace kcenon::network::core {
 
 /**
- * @struct session_config
- * @brief Configuration for session management
- */
-struct session_config {
-    size_t max_sessions{1000};
-    std::chrono::milliseconds idle_timeout{std::chrono::minutes(5)};
-    std::chrono::milliseconds cleanup_interval{std::chrono::seconds(30)};
-    bool enable_backpressure{true};
-    double backpressure_threshold{0.8};
-};
-
-/**
- * @struct session_info
- * @brief Information about a managed session including activity tracking
+ * @brief Session info struct for backward compatibility
+ *
+ * This struct is provided for backward compatibility with code that
+ * accesses session_info directly. New code should use the template-based
+ * session_info_t<SessionType> instead.
  */
 struct session_info {
     std::shared_ptr<kcenon::network::session::messaging_session> session;
     std::chrono::steady_clock::time_point created_at;
     std::chrono::steady_clock::time_point last_activity;
 
-    explicit session_info(std::shared_ptr<kcenon::network::session::messaging_session> sess)
+    explicit session_info(
+        std::shared_ptr<kcenon::network::session::messaging_session> sess)
         : session(std::move(sess))
         , created_at(std::chrono::steady_clock::now())
-        , last_activity(created_at)
-    {
-    }
+        , last_activity(created_at) {}
 };
 
 /**
  * @class session_manager
- * @brief Thread-safe session lifecycle management with backpressure
+ * @brief Thread-safe TCP session lifecycle management with backpressure
+ *
+ * This is a type alias for session_manager_base<messaging_session> that
+ * provides backward compatibility with existing code while leveraging
+ * the unified template implementation.
  *
  * This manager provides:
  * - Thread-safe session tracking
@@ -85,322 +71,43 @@ struct session_info {
  * manager->cleanup_idle_sessions();
  * @endcode
  */
-class session_manager {
+class session_manager : public session_manager_base<session::messaging_session> {
 public:
-    using session_ptr = std::shared_ptr<kcenon::network::session::messaging_session>;
+    using session_ptr = std::shared_ptr<session::messaging_session>;
+    using base_type = session_manager_base<session::messaging_session>;
 
     explicit session_manager(const session_config& config = session_config())
-        : config_(config)
-        , session_count_(0)
-        , total_accepted_(0)
-        , total_rejected_(0)
-        , total_cleaned_up_(0)
-    {
-    }
+        : base_type(config) {}
 
     /**
-     * @brief Check if new connection can be accepted
-     * @return true if under max_sessions limit
-     */
-    [[nodiscard]] bool can_accept_connection() const {
-        return session_count_.load(std::memory_order_acquire) < config_.max_sessions;
-    }
-
-    /**
-     * @brief Check if backpressure should be applied
-     * @return true if session count exceeds backpressure threshold
-     */
-    [[nodiscard]] bool is_backpressure_active() const {
-        if (!config_.enable_backpressure) {
-            return false;
-        }
-
-        auto count = session_count_.load(std::memory_order_acquire);
-        auto threshold = static_cast<size_t>(config_.max_sessions * config_.backpressure_threshold);
-
-        return count >= threshold;
-    }
-
-    /**
-     * @brief Get current session utilization
-     * @return Utilization ratio (0.0 to 1.0)
-     */
-    [[nodiscard]] double get_utilization() const {
-        if (config_.max_sessions == 0) {
-            return 0.0;
-        }
-
-        auto count = session_count_.load(std::memory_order_acquire);
-        return static_cast<double>(count) / config_.max_sessions;
-    }
-
-    /**
-     * @brief Add session to manager (thread-safe)
-     * @param session Session to add
-     * @param session_id Optional session ID
-     * @return true if added successfully, false if limit reached
-     */
-    bool add_session(session_ptr session, const std::string& session_id = "") {
-        if (!can_accept_connection()) {
-            total_rejected_.fetch_add(1, std::memory_order_relaxed);
-            return false;
-        }
-
-        std::unique_lock<std::shared_mutex> lock(sessions_mutex_);
-
-        // Generate ID if not provided
-        std::string id = session_id.empty() ?
-            generate_session_id() : session_id;
-
-        // Add to active sessions
-        active_sessions_.emplace(id, session_info(session));
-        session_count_.fetch_add(1, std::memory_order_release);
-        total_accepted_.fetch_add(1, std::memory_order_relaxed);
-
-        return true;
-    }
-
-    /**
-     * @brief Remove session (thread-safe)
-     * @param session_id Session ID to remove
-     * @return true if removed
-     */
-    bool remove_session(const std::string& session_id) {
-        std::unique_lock<std::shared_mutex> lock(sessions_mutex_);
-
-        auto it = active_sessions_.find(session_id);
-        if (it != active_sessions_.end()) {
-            active_sessions_.erase(it);
-            session_count_.fetch_sub(1, std::memory_order_release);
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * @brief Get session by ID (thread-safe)
-     */
-    [[nodiscard]] session_ptr get_session(const std::string& session_id) const {
-        std::shared_lock<std::shared_mutex> lock(sessions_mutex_);
-
-        auto it = active_sessions_.find(session_id);
-        if (it != active_sessions_.end()) {
-            return it->second.session;
-        }
-
-        return nullptr;
-    }
-
-    /**
-     * @brief Update session activity timestamp (thread-safe)
-     * @param session_id Session ID to update
-     *
-     * Call this method when a session sends or receives data
-     * to keep the session alive and prevent idle timeout.
-     */
-    void update_activity(const std::string& session_id) {
-        std::unique_lock<std::shared_mutex> lock(sessions_mutex_);
-
-        auto it = active_sessions_.find(session_id);
-        if (it != active_sessions_.end()) {
-            it->second.last_activity = std::chrono::steady_clock::now();
-        }
-    }
-
-    /**
-     * @brief Get all active sessions (thread-safe)
-     */
-    [[nodiscard]] std::vector<session_ptr> get_all_sessions() const {
-        std::shared_lock<std::shared_mutex> lock(sessions_mutex_);
-
-        std::vector<session_ptr> sessions;
-        sessions.reserve(active_sessions_.size());
-
-        for (const auto& [id, info] : active_sessions_) {
-            sessions.push_back(info.session);
-        }
-
-        return sessions;
-    }
-
-    /**
-     * @brief Stop all sessions gracefully (thread-safe)
-     */
-    void stop_all_sessions() {
-        // Get sessions under read lock
-        std::vector<session_ptr> sessions;
-        {
-            std::shared_lock<std::shared_mutex> lock(sessions_mutex_);
-            sessions.reserve(active_sessions_.size());
-
-            for (const auto& [id, info] : active_sessions_) {
-                sessions.push_back(info.session);
-            }
-        }
-
-        // Stop sessions without holding lock
-        for (auto& session : sessions) {
-            try {
-                if (session) {
-                    session->stop_session();
-                }
-            } catch (...) {
-                // Ignore errors during shutdown
-            }
-        }
-
-        // Clear all sessions
-        std::unique_lock<std::shared_mutex> lock(sessions_mutex_);
-        active_sessions_.clear();
-        session_count_.store(0, std::memory_order_release);
-    }
-
-    /**
-     * @brief Cleanup idle sessions
-     * @return Number of sessions cleaned up
-     *
-     * Identifies sessions that have been idle longer than the configured
-     * idle_timeout, gracefully stops them, and removes them from the manager.
-     *
-     * This method should be called periodically, either manually or via
-     * a timer mechanism.
-     */
-    size_t cleanup_idle_sessions() {
-        auto now = std::chrono::steady_clock::now();
-        std::vector<std::pair<std::string, session_ptr>> to_remove;
-
-        // Identify idle sessions under read lock
-        {
-            std::shared_lock<std::shared_mutex> lock(sessions_mutex_);
-
-            for (const auto& [id, info] : active_sessions_) {
-                auto idle_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
-                    now - info.last_activity);
-
-                if (idle_duration > config_.idle_timeout) {
-                    to_remove.emplace_back(id, info.session);
-                }
-            }
-        }
-
-        // Gracefully stop and remove idle sessions
-        size_t removed = 0;
-        for (const auto& [id, session] : to_remove) {
-            // Stop session gracefully before removal
-            if (session) {
-                try {
-                    session->stop_session();
-                } catch (...) {
-                    // Ignore errors during cleanup
-                }
-            }
-
-            if (remove_session(id)) {
-                removed++;
-            }
-        }
-
-        if (removed > 0) {
-            total_cleaned_up_.fetch_add(removed, std::memory_order_relaxed);
-        }
-
-        return removed;
-    }
-
-    /**
-     * @brief Get session info including activity timestamps (thread-safe)
+     * @brief Get session info including activity timestamps
      * @param session_id Session ID to query
      * @return Optional session_info if found
+     *
+     * This method is provided for backward compatibility. It converts
+     * the internal session_info_t to the legacy session_info struct.
      */
-    [[nodiscard]] std::optional<session_info> get_session_info(const std::string& session_id) const {
-        std::shared_lock<std::shared_mutex> lock(sessions_mutex_);
-
+    [[nodiscard]] auto get_session_info(const std::string& session_id) const
+        -> std::optional<session_info> {
+        std::shared_lock lock(sessions_mutex_);
         auto it = active_sessions_.find(session_id);
         if (it != active_sessions_.end()) {
-            return it->second;
+            session_info info(it->second.session);
+            info.created_at = it->second.created_at;
+            info.last_activity = it->second.last_activity;
+            return info;
         }
-
         return std::nullopt;
     }
 
-    /**
-     * @brief Get idle duration for a session (thread-safe)
-     * @param session_id Session ID to query
-     * @return Idle duration, or nullopt if session not found
-     */
-    [[nodiscard]] std::optional<std::chrono::milliseconds> get_idle_duration(
-        const std::string& session_id) const {
-        std::shared_lock<std::shared_mutex> lock(sessions_mutex_);
-
-        auto it = active_sessions_.find(session_id);
-        if (it != active_sessions_.end()) {
-            auto now = std::chrono::steady_clock::now();
-            return std::chrono::duration_cast<std::chrono::milliseconds>(
-                now - it->second.last_activity);
-        }
-
-        return std::nullopt;
-    }
-
-    /**
-     * @brief Get statistics
-     */
-    struct stats {
-        size_t active_sessions;
-        size_t max_sessions;
-        size_t total_accepted;
-        size_t total_rejected;
-        size_t total_cleaned_up;
-        double utilization;
-        bool backpressure_active;
-        std::chrono::milliseconds idle_timeout;
-    };
-
-    [[nodiscard]] stats get_stats() const {
-        stats s;
-        s.active_sessions = session_count_.load(std::memory_order_acquire);
-        s.max_sessions = config_.max_sessions;
-        s.total_accepted = total_accepted_.load(std::memory_order_acquire);
-        s.total_rejected = total_rejected_.load(std::memory_order_acquire);
-        s.total_cleaned_up = total_cleaned_up_.load(std::memory_order_acquire);
-        s.utilization = get_utilization();
-        s.backpressure_active = is_backpressure_active();
-        s.idle_timeout = config_.idle_timeout;
-
-        return s;
-    }
-
-    /**
-     * @brief Set maximum sessions
-     */
-    void set_max_sessions(size_t max_sessions) {
-        config_.max_sessions = max_sessions;
-    }
-
-    /**
-     * @brief Get current session count
-     */
-    [[nodiscard]] size_t get_session_count() const {
-        return session_count_.load(std::memory_order_acquire);
-    }
-
 private:
-    std::string generate_session_id() {
-        static std::atomic<uint64_t> counter{0};
-        return "session_" + std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
-    }
-
-private:
-    session_config config_;
-
-    mutable std::shared_mutex sessions_mutex_;
-    std::unordered_map<std::string, session_info> active_sessions_;
-
-    std::atomic<size_t> session_count_;
-    std::atomic<uint64_t> total_accepted_;
-    std::atomic<uint64_t> total_rejected_;
-    std::atomic<uint64_t> total_cleaned_up_;
+    /**
+     * @brief Generate session ID (private, for backward compatibility)
+     * @return Generated session ID
+     *
+     * @deprecated Use the static generate_id() method from base class.
+     */
+    auto generate_session_id() -> std::string { return generate_id(); }
 };
 
 } // namespace kcenon::network::core

--- a/include/kcenon/network/core/session_manager_base.h
+++ b/include/kcenon/network/core/session_manager_base.h
@@ -1,0 +1,479 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+*****************************************************************************/
+
+#pragma once
+
+#include "kcenon/network/core/session_info.h"
+#include "kcenon/network/core/session_traits.h"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <shared_mutex>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+namespace kcenon::network::core {
+
+/**
+ * @struct session_config
+ * @brief Configuration for session management
+ */
+struct session_config {
+    size_t max_sessions{1000};
+    std::chrono::milliseconds idle_timeout{std::chrono::minutes(5)};
+    std::chrono::milliseconds cleanup_interval{std::chrono::seconds(30)};
+    bool enable_backpressure{true};
+    double backpressure_threshold{0.8};
+};
+
+/**
+ * @class session_manager_base
+ * @brief Thread-safe session lifecycle management template
+ *
+ * Generic session manager that works with any session type.
+ * Behavior is customized via session_traits<SessionType>.
+ *
+ * Features:
+ * - Thread-safe session tracking using shared_mutex
+ * - Connection limit enforcement with backpressure
+ * - Optional idle session cleanup (when traits enable activity tracking)
+ * - Metrics collection (accepted, rejected, cleaned up)
+ *
+ * @tparam SessionType The session/connection type to manage
+ *
+ * Thread Safety:
+ * - All methods are thread-safe using shared_mutex for concurrent reads
+ *   and exclusive writes.
+ *
+ * Usage Example:
+ * @code
+ * session_config config;
+ * config.max_sessions = 1000;
+ *
+ * auto manager = std::make_shared<session_manager_base<MySession>>(config);
+ *
+ * if (manager->can_accept_connection()) {
+ *     auto session = create_session();
+ *     manager->add_session(session, "session_123");
+ * }
+ * @endcode
+ */
+template <typename SessionType>
+class session_manager_base {
+public:
+    using session_ptr = std::shared_ptr<SessionType>;
+    using traits = session_traits<SessionType>;
+    using info_type = session_info_t<SessionType>;
+
+    /**
+     * @brief Constructs a session manager with the given configuration
+     * @param config Session management configuration
+     */
+    explicit session_manager_base(const session_config& config = session_config())
+        : config_(config)
+        , session_count_(0)
+        , total_accepted_(0)
+        , total_rejected_(0)
+        , total_cleaned_up_(0) {}
+
+    // Non-copyable, non-movable
+    session_manager_base(const session_manager_base&) = delete;
+    session_manager_base& operator=(const session_manager_base&) = delete;
+    session_manager_base(session_manager_base&&) = delete;
+    session_manager_base& operator=(session_manager_base&&) = delete;
+
+    virtual ~session_manager_base() = default;
+
+    // =========================================================================
+    // Connection Acceptance
+    // =========================================================================
+
+    /**
+     * @brief Check if new connection can be accepted
+     * @return true if under max_sessions limit
+     */
+    [[nodiscard]] auto can_accept_connection() const -> bool {
+        return session_count_.load(std::memory_order_acquire) < config_.max_sessions;
+    }
+
+    /**
+     * @brief Check if backpressure should be applied
+     * @return true if session count exceeds backpressure threshold
+     */
+    [[nodiscard]] auto is_backpressure_active() const -> bool {
+        if (!config_.enable_backpressure) {
+            return false;
+        }
+        auto count = session_count_.load(std::memory_order_acquire);
+        auto threshold =
+            static_cast<size_t>(config_.max_sessions * config_.backpressure_threshold);
+        return count >= threshold;
+    }
+
+    // =========================================================================
+    // Session CRUD
+    // =========================================================================
+
+    /**
+     * @brief Add a session to the manager
+     * @param session Session to add
+     * @param session_id Optional session ID (auto-generated if empty)
+     * @return true if added, false if rejected (limit reached)
+     */
+    auto add_session(session_ptr session, const std::string& session_id = "") -> bool {
+        if (!can_accept_connection()) {
+            total_rejected_.fetch_add(1, std::memory_order_relaxed);
+            return false;
+        }
+
+        std::unique_lock lock(sessions_mutex_);
+        std::string id = session_id.empty() ? generate_id() : session_id;
+        active_sessions_.emplace(id, info_type(std::move(session)));
+        session_count_.fetch_add(1, std::memory_order_release);
+        total_accepted_.fetch_add(1, std::memory_order_relaxed);
+
+        return true;
+    }
+
+    /**
+     * @brief Add a session and return the assigned ID
+     * @param session Session to add
+     * @param session_id Optional session ID (auto-generated if empty)
+     * @return Session ID if added, empty string if rejected
+     *
+     * This method is useful when auto-generating IDs and needing
+     * to know the assigned ID for subsequent operations.
+     */
+    auto add_session_with_id(session_ptr session, const std::string& session_id = "")
+        -> std::string {
+        if (!can_accept_connection()) {
+            total_rejected_.fetch_add(1, std::memory_order_relaxed);
+            return "";
+        }
+
+        std::unique_lock lock(sessions_mutex_);
+        std::string id = session_id.empty() ? generate_id() : session_id;
+        active_sessions_.emplace(id, info_type(std::move(session)));
+        session_count_.fetch_add(1, std::memory_order_release);
+        total_accepted_.fetch_add(1, std::memory_order_relaxed);
+
+        return id;
+    }
+
+    /**
+     * @brief Remove session by ID
+     * @param session_id Session ID to remove
+     * @return true if removed
+     */
+    auto remove_session(const std::string& session_id) -> bool {
+        std::unique_lock lock(sessions_mutex_);
+        auto it = active_sessions_.find(session_id);
+        if (it != active_sessions_.end()) {
+            active_sessions_.erase(it);
+            session_count_.fetch_sub(1, std::memory_order_release);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @brief Get session by ID
+     * @param session_id Session ID to lookup
+     * @return Session pointer, or nullptr if not found
+     */
+    [[nodiscard]] auto get_session(const std::string& session_id) const -> session_ptr {
+        std::shared_lock lock(sessions_mutex_);
+        auto it = active_sessions_.find(session_id);
+        return (it != active_sessions_.end()) ? it->second.session : nullptr;
+    }
+
+    /**
+     * @brief Get all active sessions
+     * @return Vector of session pointers
+     */
+    [[nodiscard]] auto get_all_sessions() const -> std::vector<session_ptr> {
+        std::shared_lock lock(sessions_mutex_);
+        std::vector<session_ptr> sessions;
+        sessions.reserve(active_sessions_.size());
+        for (const auto& [id, info] : active_sessions_) {
+            sessions.push_back(info.session);
+        }
+        return sessions;
+    }
+
+    /**
+     * @brief Get all session IDs
+     * @return Vector of session IDs
+     */
+    [[nodiscard]] auto get_all_session_ids() const -> std::vector<std::string> {
+        std::shared_lock lock(sessions_mutex_);
+        std::vector<std::string> ids;
+        ids.reserve(active_sessions_.size());
+        for (const auto& [id, info] : active_sessions_) {
+            ids.push_back(id);
+        }
+        return ids;
+    }
+
+    // =========================================================================
+    // Activity Tracking (only available when traits::has_activity_tracking)
+    // =========================================================================
+
+    /**
+     * @brief Update session activity timestamp
+     * @param session_id Session ID to update
+     *
+     * Only available when session_traits<SessionType>::has_activity_tracking is true.
+     */
+    template <typename T = SessionType>
+    auto update_activity(const std::string& session_id)
+        -> std::enable_if_t<session_traits<T>::has_activity_tracking, void> {
+        std::unique_lock lock(sessions_mutex_);
+        auto it = active_sessions_.find(session_id);
+        if (it != active_sessions_.end()) {
+            it->second.update_activity();
+        }
+    }
+
+    /**
+     * @brief Get idle duration for a session
+     * @param session_id Session ID to query
+     * @return Idle duration, or nullopt if session not found
+     *
+     * Only available when session_traits<SessionType>::has_activity_tracking is true.
+     */
+    template <typename T = SessionType>
+    [[nodiscard]] auto get_idle_duration(const std::string& session_id) const
+        -> std::enable_if_t<session_traits<T>::has_activity_tracking,
+                            std::optional<std::chrono::milliseconds>> {
+        std::shared_lock lock(sessions_mutex_);
+        auto it = active_sessions_.find(session_id);
+        if (it != active_sessions_.end()) {
+            return it->second.idle_duration();
+        }
+        return std::nullopt;
+    }
+
+    /**
+     * @brief Cleanup idle sessions that exceeded idle_timeout
+     * @return Number of sessions cleaned up
+     *
+     * Only available when session_traits<SessionType>::has_activity_tracking is true.
+     */
+    template <typename T = SessionType>
+    auto cleanup_idle_sessions()
+        -> std::enable_if_t<session_traits<T>::has_activity_tracking, size_t> {
+        std::vector<std::pair<std::string, session_ptr>> to_remove;
+
+        // Identify idle sessions under read lock
+        {
+            std::shared_lock lock(sessions_mutex_);
+            for (const auto& [id, info] : active_sessions_) {
+                if (info.idle_duration() > config_.idle_timeout) {
+                    to_remove.emplace_back(id, info.session);
+                }
+            }
+        }
+
+        // Stop and remove idle sessions
+        size_t removed = 0;
+        for (const auto& [id, session] : to_remove) {
+            if constexpr (traits::stop_on_clear) {
+                if (session) {
+                    try {
+                        session->stop_session();
+                    } catch (...) {
+                    }
+                }
+            }
+            if (remove_session(id)) {
+                removed++;
+            }
+        }
+
+        if (removed > 0) {
+            total_cleaned_up_.fetch_add(removed, std::memory_order_relaxed);
+        }
+        return removed;
+    }
+
+    // =========================================================================
+    // Lifecycle Management
+    // =========================================================================
+
+    /**
+     * @brief Clear all sessions
+     *
+     * If traits::stop_on_clear is true, calls stop_session() on each
+     * session before removal.
+     */
+    auto clear_all_sessions() -> void {
+        if constexpr (traits::stop_on_clear) {
+            // Get sessions under read lock
+            std::vector<session_ptr> sessions;
+            {
+                std::shared_lock lock(sessions_mutex_);
+                sessions.reserve(active_sessions_.size());
+                for (const auto& [id, info] : active_sessions_) {
+                    sessions.push_back(info.session);
+                }
+            }
+
+            // Stop sessions without holding lock
+            for (auto& session : sessions) {
+                if (session) {
+                    try {
+                        session->stop_session();
+                    } catch (...) {
+                    }
+                }
+            }
+        }
+
+        std::unique_lock lock(sessions_mutex_);
+        active_sessions_.clear();
+        session_count_.store(0, std::memory_order_release);
+    }
+
+    /**
+     * @brief Stop all sessions gracefully
+     *
+     * Alias for clear_all_sessions() for backward compatibility with session_manager.
+     */
+    auto stop_all_sessions() -> void { clear_all_sessions(); }
+
+    // =========================================================================
+    // Metrics
+    // =========================================================================
+
+    /**
+     * @brief Get current session count
+     * @return Number of active sessions
+     */
+    [[nodiscard]] auto get_session_count() const -> size_t {
+        return session_count_.load(std::memory_order_acquire);
+    }
+
+    /**
+     * @brief Get total accepted connections
+     * @return Total number of accepted connections since creation
+     */
+    [[nodiscard]] auto get_total_accepted() const -> uint64_t {
+        return total_accepted_.load(std::memory_order_relaxed);
+    }
+
+    /**
+     * @brief Get total rejected connections
+     * @return Total number of rejected connections since creation
+     */
+    [[nodiscard]] auto get_total_rejected() const -> uint64_t {
+        return total_rejected_.load(std::memory_order_relaxed);
+    }
+
+    /**
+     * @brief Get total cleaned up sessions
+     * @return Total number of sessions cleaned up due to idle timeout
+     */
+    [[nodiscard]] auto get_total_cleaned_up() const -> uint64_t {
+        return total_cleaned_up_.load(std::memory_order_relaxed);
+    }
+
+    /**
+     * @brief Get current session utilization
+     * @return Utilization ratio (0.0 to 1.0)
+     */
+    [[nodiscard]] auto get_utilization() const -> double {
+        if (config_.max_sessions == 0) {
+            return 0.0;
+        }
+        return static_cast<double>(session_count_.load(std::memory_order_acquire)) /
+               config_.max_sessions;
+    }
+
+    // =========================================================================
+    // Configuration
+    // =========================================================================
+
+    /**
+     * @brief Set maximum sessions
+     * @param max_sessions New maximum session limit
+     */
+    auto set_max_sessions(size_t max_sessions) -> void {
+        config_.max_sessions = max_sessions;
+    }
+
+    /**
+     * @brief Get current configuration
+     * @return Reference to session configuration
+     */
+    [[nodiscard]] auto get_config() const -> const session_config& { return config_; }
+
+    // =========================================================================
+    // Statistics (comprehensive view)
+    // =========================================================================
+
+    /**
+     * @struct stats
+     * @brief Comprehensive session manager statistics
+     */
+    struct stats {
+        size_t active_sessions;
+        size_t max_sessions;
+        uint64_t total_accepted;
+        uint64_t total_rejected;
+        uint64_t total_cleaned_up;
+        double utilization;
+        bool backpressure_active;
+        std::chrono::milliseconds idle_timeout;
+    };
+
+    /**
+     * @brief Get comprehensive statistics
+     * @return Stats struct with all metrics
+     */
+    [[nodiscard]] auto get_stats() const -> stats {
+        return stats{.active_sessions = session_count_.load(std::memory_order_acquire),
+                     .max_sessions = config_.max_sessions,
+                     .total_accepted = total_accepted_.load(std::memory_order_relaxed),
+                     .total_rejected = total_rejected_.load(std::memory_order_relaxed),
+                     .total_cleaned_up = total_cleaned_up_.load(std::memory_order_relaxed),
+                     .utilization = get_utilization(),
+                     .backpressure_active = is_backpressure_active(),
+                     .idle_timeout = config_.idle_timeout};
+    }
+
+    // =========================================================================
+    // ID Generation (public for external use)
+    // =========================================================================
+
+    /**
+     * @brief Generate a unique session ID
+     * @return Generated ID with traits-defined prefix
+     */
+    static auto generate_id() -> std::string {
+        static std::atomic<uint64_t> counter{0};
+        return std::string(traits::id_prefix) +
+               std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
+    }
+
+protected:
+    session_config config_;
+    mutable std::shared_mutex sessions_mutex_;
+    std::unordered_map<std::string, info_type> active_sessions_;
+
+    std::atomic<size_t> session_count_;
+    std::atomic<uint64_t> total_accepted_;
+    std::atomic<uint64_t> total_rejected_;
+    std::atomic<uint64_t> total_cleaned_up_;
+};
+
+} // namespace kcenon::network::core

--- a/include/kcenon/network/core/session_traits.h
+++ b/include/kcenon/network/core/session_traits.h
@@ -1,0 +1,67 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+*****************************************************************************/
+
+#pragma once
+
+namespace kcenon::network::session {
+class messaging_session;
+} // namespace kcenon::network::session
+
+namespace kcenon::network::core {
+
+class ws_connection;
+
+/**
+ * @struct session_traits
+ * @brief Customization point for session manager behavior
+ *
+ * Specialize this struct for different session types to control:
+ * - Activity tracking (idle timeout support)
+ * - Cleanup behavior (graceful stop on clear)
+ * - ID generation strategy
+ *
+ * @tparam SessionType The session type to customize behavior for
+ */
+template <typename SessionType>
+struct session_traits {
+    /// Enable activity timestamp tracking (required for idle cleanup)
+    static constexpr bool has_activity_tracking = false;
+
+    /// Call session's stop method when clearing all sessions
+    static constexpr bool stop_on_clear = false;
+
+    /// ID prefix for auto-generated session IDs
+    static constexpr const char* id_prefix = "session_";
+};
+
+/**
+ * @brief Session traits specialization for TCP messaging sessions
+ *
+ * TCP sessions have activity tracking enabled for idle timeout detection
+ * and stop_on_clear enabled for graceful shutdown.
+ */
+template <>
+struct session_traits<session::messaging_session> {
+    static constexpr bool has_activity_tracking = true;
+    static constexpr bool stop_on_clear = true;
+    static constexpr const char* id_prefix = "session_";
+};
+
+/**
+ * @brief Session traits specialization for WebSocket connections
+ *
+ * WebSocket connections have activity tracking disabled (no idle cleanup)
+ * and stop_on_clear disabled (connections are simply removed).
+ */
+template <>
+struct session_traits<ws_connection> {
+    static constexpr bool has_activity_tracking = false;
+    static constexpr bool stop_on_clear = false;
+    static constexpr const char* id_prefix = "ws_conn_";
+};
+
+} // namespace kcenon::network::core

--- a/include/kcenon/network/core/ws_session_manager.h
+++ b/include/kcenon/network/core/ws_session_manager.h
@@ -1,7 +1,7 @@
 /*****************************************************************************
 BSD 3-Clause License
 
-Copyright (c) 2024, 🍀☀🌕🌥 🌊
+Copyright (c) 2024, kcenon
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -32,278 +32,153 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "kcenon/network/core/session_manager.h"
+#include "kcenon/network/core/session_manager_base.h"
 
-#include <atomic>
-#include <memory>
-#include <mutex>
-#include <shared_mutex>
-#include <string>
-#include <unordered_map>
-#include <vector>
+namespace kcenon::network::core {
 
-namespace kcenon::network::core
-{
-	// Forward declaration
-	class ws_connection;
+// Forward declaration
+class ws_connection;
 
-	/*!
-	 * \class ws_session_manager
-	 * \brief Thread-safe WebSocket session lifecycle management.
-	 *
-	 * This manager provides the same connection management features as
-	 * session_manager but for WebSocket connections instead of TCP sessions.
-	 * It maintains type safety and clear separation while reusing the same
-	 * configuration structure.
-	 *
-	 * Features:
-	 * - Thread-safe connection tracking
-	 * - Connection limit enforcement
-	 * - Backpressure signaling
-	 * - Connection metrics
-	 * - Automatic connection ID generation
-	 *
-	 * Thread Safety:
-	 * - All public methods are thread-safe
-	 * - Uses shared_mutex for concurrent reads and exclusive writes
-	 * - Atomic counters for metrics
-	 *
-	 * Usage Example:
-	 * \code
-	 * session_config config;
-	 * config.max_sessions = 1000;
-	 * auto manager = std::make_shared<ws_session_manager>(config);
-	 *
-	 * // Check before accepting new connection
-	 * if (manager->can_accept_connection()) {
-	 *     auto conn = create_ws_connection();
-	 *     auto conn_id = manager->add_connection(conn);
-	 *     if (!conn_id.empty()) {
-	 *         // Connection accepted
-	 *     }
-	 * }
-	 * \endcode
-	 */
-	class ws_session_manager
-	{
-	public:
-		using ws_connection_ptr = std::shared_ptr<ws_connection>;
+/**
+ * @class ws_session_manager
+ * @brief Thread-safe WebSocket session lifecycle management.
+ *
+ * This class extends session_manager_base<ws_connection> to provide
+ * WebSocket-specific connection management while leveraging the unified
+ * template implementation for common functionality.
+ *
+ * Features:
+ * - Thread-safe connection tracking
+ * - Connection limit enforcement
+ * - Backpressure signaling
+ * - Connection metrics
+ * - Automatic connection ID generation
+ *
+ * Thread Safety:
+ * - All public methods are thread-safe
+ * - Uses shared_mutex for concurrent reads and exclusive writes
+ * - Atomic counters for metrics
+ *
+ * Usage Example:
+ * @code
+ * session_config config;
+ * config.max_sessions = 1000;
+ * auto manager = std::make_shared<ws_session_manager>(config);
+ *
+ * // Check before accepting new connection
+ * if (manager->can_accept_connection()) {
+ *     auto conn = create_ws_connection();
+ *     auto conn_id = manager->add_connection(conn);
+ *     if (!conn_id.empty()) {
+ *         // Connection accepted
+ *     }
+ * }
+ * @endcode
+ */
+class ws_session_manager : public session_manager_base<ws_connection> {
+public:
+    using ws_connection_ptr = std::shared_ptr<ws_connection>;
+    using base_type = session_manager_base<ws_connection>;
 
-		/*!
-		 * \brief Constructs a WebSocket session manager.
-		 *
-		 * \param config Session management configuration
-		 */
-		explicit ws_session_manager(const session_config& config = session_config())
-			: config_(config)
-			, connection_count_(0)
-			, total_accepted_(0)
-			, total_rejected_(0)
-		{
-		}
+    /**
+     * @brief Constructs a WebSocket session manager.
+     *
+     * @param config Session management configuration
+     */
+    explicit ws_session_manager(const session_config& config = session_config())
+        : base_type(config) {}
 
-		/*!
-		 * \brief Checks if a new connection can be accepted.
-		 *
-		 * \return True if under max_sessions limit
-		 */
-		[[nodiscard]] auto can_accept_connection() const -> bool
-		{
-			return connection_count_.load(std::memory_order_acquire) <
-				   config_.max_sessions;
-		}
+    // =========================================================================
+    // Backward-compatible API (aliases to base class methods)
+    // =========================================================================
 
-		/*!
-		 * \brief Checks if backpressure should be applied.
-		 *
-		 * Backpressure is activated when the connection count exceeds
-		 * the configured threshold percentage of max_sessions.
-		 *
-		 * \return True if connection count exceeds backpressure threshold
-		 */
-		[[nodiscard]] auto is_backpressure_active() const -> bool
-		{
-			if (!config_.enable_backpressure)
-			{
-				return false;
-			}
+    /**
+     * @brief Adds a connection to the manager.
+     *
+     * Thread-safe operation that adds a connection with automatic or
+     * provided ID. If max_sessions limit is reached, the connection
+     * is rejected.
+     *
+     * @param conn Connection to add
+     * @param conn_id Optional connection ID (auto-generated if empty)
+     * @return Connection ID that was used (empty string if rejected)
+     */
+    auto add_connection(ws_connection_ptr conn, const std::string& conn_id = "")
+        -> std::string {
+        return add_session_with_id(std::move(conn), conn_id);
+    }
 
-			auto count = connection_count_.load(std::memory_order_acquire);
-			auto threshold = static_cast<size_t>(config_.max_sessions *
-												  config_.backpressure_threshold);
-			return count >= threshold;
-		}
+    /**
+     * @brief Removes a connection from the manager.
+     *
+     * Thread-safe operation that removes a connection by ID.
+     *
+     * @param conn_id Connection ID to remove
+     * @return True if connection was found and removed
+     */
+    auto remove_connection(const std::string& conn_id) -> bool {
+        return remove_session(conn_id);
+    }
 
-		/*!
-		 * \brief Adds a connection to the manager.
-		 *
-		 * Thread-safe operation that adds a connection with automatic or
-		 * provided ID. If max_sessions limit is reached, the connection
-		 * is rejected.
-		 *
-		 * \param conn Connection to add
-		 * \param conn_id Optional connection ID (auto-generated if empty)
-		 * \return Connection ID that was used (empty string if rejected)
-		 */
-		auto add_connection(ws_connection_ptr conn, const std::string& conn_id = "")
-			-> std::string
-		{
-			if (!can_accept_connection())
-			{
-				total_rejected_.fetch_add(1, std::memory_order_relaxed);
-				return ""; // Rejected
-			}
+    /**
+     * @brief Gets a connection by ID.
+     *
+     * Thread-safe read operation.
+     *
+     * @param conn_id Connection ID to lookup
+     * @return Shared pointer to connection, or nullptr if not found
+     */
+    [[nodiscard]] auto get_connection(const std::string& conn_id) const
+        -> ws_connection_ptr {
+        return get_session(conn_id);
+    }
 
-			std::unique_lock<std::shared_mutex> lock(connections_mutex_);
-			std::string id = conn_id.empty() ? generate_connection_id() : conn_id;
+    /**
+     * @brief Gets all active connections.
+     *
+     * Thread-safe operation that returns a snapshot of all connections.
+     *
+     * @return Vector of all active connections
+     */
+    [[nodiscard]] auto get_all_connections() const -> std::vector<ws_connection_ptr> {
+        return get_all_sessions();
+    }
 
-			active_connections_[id] = conn;
-			connection_count_.fetch_add(1, std::memory_order_release);
-			total_accepted_.fetch_add(1, std::memory_order_relaxed);
+    /**
+     * @brief Gets all connection IDs.
+     *
+     * Thread-safe operation that returns a list of all connection IDs.
+     *
+     * @return Vector of connection IDs
+     */
+    [[nodiscard]] auto get_all_connection_ids() const -> std::vector<std::string> {
+        return get_all_session_ids();
+    }
 
-			return id; // Return the ID that was used
-		}
+    /**
+     * @brief Gets the current connection count.
+     *
+     * @return Number of active connections
+     */
+    [[nodiscard]] auto get_connection_count() const -> size_t {
+        return get_session_count();
+    }
 
-		/*!
-		 * \brief Removes a connection from the manager.
-		 *
-		 * Thread-safe operation that removes a connection by ID.
-		 *
-		 * \param conn_id Connection ID to remove
-		 * \return True if connection was found and removed
-		 */
-		auto remove_connection(const std::string& conn_id) -> bool
-		{
-			std::unique_lock<std::shared_mutex> lock(connections_mutex_);
+    /**
+     * @brief Clears all connections.
+     *
+     * Thread-safe operation that removes all connections.
+     */
+    auto clear_all_connections() -> void { clear_all_sessions(); }
 
-			auto it = active_connections_.find(conn_id);
-			if (it != active_connections_.end())
-			{
-				active_connections_.erase(it);
-				connection_count_.fetch_sub(1, std::memory_order_release);
-				return true;
-			}
-			return false;
-		}
-
-		/*!
-		 * \brief Gets a connection by ID.
-		 *
-		 * Thread-safe read operation.
-		 *
-		 * \param conn_id Connection ID to lookup
-		 * \return Shared pointer to connection, or nullptr if not found
-		 */
-		[[nodiscard]] auto get_connection(const std::string& conn_id) const
-			-> ws_connection_ptr
-		{
-			std::shared_lock<std::shared_mutex> lock(connections_mutex_);
-			auto it = active_connections_.find(conn_id);
-			return (it != active_connections_.end()) ? it->second : nullptr;
-		}
-
-		/*!
-		 * \brief Gets all active connections.
-		 *
-		 * Thread-safe operation that returns a snapshot of all connections.
-		 *
-		 * \return Vector of all active connections
-		 */
-		[[nodiscard]] auto get_all_connections() const -> std::vector<ws_connection_ptr>
-		{
-			std::shared_lock<std::shared_mutex> lock(connections_mutex_);
-			std::vector<ws_connection_ptr> conns;
-			conns.reserve(active_connections_.size());
-			for (const auto& [id, conn] : active_connections_)
-			{
-				conns.push_back(conn);
-			}
-			return conns;
-		}
-
-		/*!
-		 * \brief Gets all connection IDs.
-		 *
-		 * Thread-safe operation that returns a list of all connection IDs.
-		 *
-		 * \return Vector of connection IDs
-		 */
-		[[nodiscard]] auto get_all_connection_ids() const -> std::vector<std::string>
-		{
-			std::shared_lock<std::shared_mutex> lock(connections_mutex_);
-			std::vector<std::string> ids;
-			ids.reserve(active_connections_.size());
-			for (const auto& [id, conn] : active_connections_)
-			{
-				ids.push_back(id);
-			}
-			return ids;
-		}
-
-		/*!
-		 * \brief Gets the current connection count.
-		 *
-		 * \return Number of active connections
-		 */
-		[[nodiscard]] auto get_connection_count() const -> size_t
-		{
-			return connection_count_.load(std::memory_order_acquire);
-		}
-
-		/*!
-		 * \brief Gets the total number of accepted connections.
-		 *
-		 * \return Total accepted connection count since creation
-		 */
-		[[nodiscard]] auto get_total_accepted() const -> uint64_t
-		{
-			return total_accepted_.load(std::memory_order_relaxed);
-		}
-
-		/*!
-		 * \brief Gets the total number of rejected connections.
-		 *
-		 * \return Total rejected connection count since creation
-		 */
-		[[nodiscard]] auto get_total_rejected() const -> uint64_t
-		{
-			return total_rejected_.load(std::memory_order_relaxed);
-		}
-
-		/*!
-		 * \brief Clears all connections.
-		 *
-		 * Thread-safe operation that removes all connections.
-		 */
-		auto clear_all_connections() -> void
-		{
-			std::unique_lock<std::shared_mutex> lock(connections_mutex_);
-			active_connections_.clear();
-			connection_count_.store(0, std::memory_order_release);
-		}
-
-		/*!
-		 * \brief Generates a unique connection ID.
-		 *
-		 * This is a static method that can be used to generate IDs externally.
-		 *
-		 * \return Generated connection ID
-		 */
-		static auto generate_connection_id() -> std::string
-		{
-			static std::atomic<uint64_t> counter{0};
-			return "ws_conn_" +
-				   std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
-		}
-
-	private:
-		session_config config_;
-		mutable std::shared_mutex connections_mutex_;
-		std::unordered_map<std::string, ws_connection_ptr> active_connections_;
-
-		std::atomic<size_t> connection_count_;
-		std::atomic<uint64_t> total_accepted_;
-		std::atomic<uint64_t> total_rejected_;
-	};
+    /**
+     * @brief Generates a unique connection ID.
+     *
+     * This is a static method that can be used to generate IDs externally.
+     *
+     * @return Generated connection ID
+     */
+    static auto generate_connection_id() -> std::string { return generate_id(); }
+};
 
 } // namespace kcenon::network::core


### PR DESCRIPTION
Closes #462

## Summary
- Implement unified `session_manager_base<T>` template to consolidate TCP and WebSocket session managers
- Reduce code duplication by ~70% while maintaining full backward compatibility
- Add traits-based customization for protocol-specific behavior

## Changes

### New Files
- `session_traits.h`: Customization point for session behavior (activity tracking, stop-on-clear, ID prefix)
- `session_info.h`: Template wrapper with optional activity tracking based on traits
- `session_manager_base.h`: Unified template implementation with all common functionality

### Modified Files
- `session_manager.h`: Now extends `session_manager_base<messaging_session>` with backward-compatible API
- `ws_session_manager.h`: Now extends `session_manager_base<ws_connection>` with backward-compatible aliases

### Design Highlights
- TCP sessions retain activity tracking and idle cleanup (via traits)
- WebSocket sessions remain lightweight without activity tracking
- Type aliases and method wrappers ensure API compatibility
- No breaking changes to existing code

## Test Plan
- [x] All 18 session_manager unit tests pass
- [x] Build succeeds without errors
- [x] 99% of tests pass (1069/1075 - 6 failures are unrelated UDP/QUIC issues)
- [ ] Manual verification of backward compatibility in dependent code