### PR TITLE
refactor(websocket): remove deprecated API methods

### DIFF
--- a/include/kcenon/network/core/messaging_ws_client.h
+++ b/include/kcenon/network/core/messaging_ws_client.h
@@ -196,17 +196,6 @@ namespace kcenon::network::core
 		 */
 		[[nodiscard]] auto send_ping(std::vector<uint8_t>&& payload = {}) -> VoidResult;
 
-		/*!
-		 * \brief Closes the connection gracefully (legacy API).
-		 * \param code The close status code (default: normal).
-		 * \param reason Optional human-readable reason.
-		 * \return VoidResult indicating success.
-		 *
-		 * \deprecated Use close(uint16_t, std::string_view) for interface compliance.
-		 */
-		[[nodiscard]] auto close(internal::ws_close_code code,
-		                         const std::string& reason) -> VoidResult;
-
 		// ========================================================================
 		// i_network_component interface implementation
 		// ========================================================================
@@ -344,36 +333,6 @@ namespace kcenon::network::core
 		 * Implements i_websocket_client::set_error_callback().
 		 */
 		auto set_error_callback(interfaces::i_websocket_client::error_callback_t callback) -> void override;
-
-		// ========================================================================
-		// Legacy API (maintained for backward compatibility)
-		// ========================================================================
-
-		/*!
-		 * \brief Sets the callback for all message types.
-		 * \param callback Function called when a message is received.
-		 */
-		auto set_message_callback(message_callback_t callback) -> void;
-
-		/*!
-		 * \brief Sets the callback for text messages (legacy version).
-		 * \param callback The callback function.
-		 */
-		auto set_text_message_callback(text_message_callback_t callback) -> void;
-
-		/*!
-		 * \brief Sets the callback for binary messages (legacy version).
-		 * \param callback The callback function.
-		 */
-		auto set_binary_message_callback(binary_message_callback_t callback) -> void;
-
-		/*!
-		 * \brief Sets the callback for disconnection (legacy version with internal close code).
-		 * \param callback The callback function using internal::ws_close_code.
-		 *
-		 * This overload accepts the internal close code type for backward compatibility.
-		 */
-		auto set_disconnected_callback(disconnected_callback_t callback) -> void;
 
 	private:
 		// =====================================================================

--- a/include/kcenon/network/core/messaging_ws_server.h
+++ b/include/kcenon/network/core/messaging_ws_server.h
@@ -176,51 +176,6 @@ namespace kcenon::network::core
 		 */
 		[[nodiscard]] auto path() const -> std::string_view override;
 
-		// ========================================================================
-		// Legacy API (maintained for backward compatibility)
-		// ========================================================================
-
-		/*!
-		 * \brief Sends a text message to the client (legacy version).
-		 * \param message The text message to send.
-		 * \param handler Optional callback invoked with send result.
-		 * \return VoidResult indicating validation success.
-		 *
-		 * \deprecated Use send_text(std::string&&) for interface compliance.
-		 */
-		auto send_text(std::string&& message,
-					   std::function<void(std::error_code, std::size_t)> handler) -> VoidResult;
-
-		/*!
-		 * \brief Sends a binary message to the client (legacy version).
-		 * \param data The binary data to send.
-		 * \param handler Optional callback invoked with send result.
-		 * \return VoidResult indicating success.
-		 *
-		 * \deprecated Use send_binary(std::vector<uint8_t>&&) for interface compliance.
-		 */
-		auto send_binary(std::vector<uint8_t>&& data,
-						 std::function<void(std::error_code, std::size_t)> handler) -> VoidResult;
-
-		/*!
-		 * \brief Closes the connection gracefully (legacy version).
-		 * \param code The close status code (default: normal).
-		 * \param reason Optional human-readable reason.
-		 * \return VoidResult indicating success.
-		 *
-		 * \deprecated Use close(uint16_t, std::string_view) for interface compliance.
-		 */
-		auto close(internal::ws_close_code code,
-				   const std::string& reason) -> VoidResult;
-
-		/*!
-		 * \brief Gets the connection ID.
-		 * \return The unique connection identifier.
-		 *
-		 * \deprecated Use id() for interface compliance.
-		 */
-		auto connection_id() const -> const std::string&;
-
 		/*!
 		 * \brief Gets the remote endpoint address.
 		 * \return String representation of remote address (e.g., "192.168.1.1:54321").
@@ -456,46 +411,6 @@ namespace kcenon::network::core
 		 * Implements i_websocket_server::set_error_callback().
 		 */
 		auto set_error_callback(interfaces::i_websocket_server::error_callback_t callback) -> void override;
-
-		// ========================================================================
-		// Legacy API (maintained for backward compatibility)
-		// ========================================================================
-
-		/*!
-		 * \brief Sets the callback for new connections (legacy version).
-		 * \param callback The callback function.
-		 */
-		auto set_connection_callback(connection_callback_t callback) -> void;
-
-		/*!
-		 * \brief Sets the callback for disconnections (legacy version with internal close code).
-		 * \param callback The callback function using internal::ws_close_code.
-		 */
-		auto set_disconnection_callback(disconnection_callback_t callback) -> void;
-
-		/*!
-		 * \brief Sets the callback for all message types.
-		 * \param callback Function called when a message is received.
-		 */
-		auto set_message_callback(message_callback_t callback) -> void;
-
-		/*!
-		 * \brief Sets the callback for text messages (legacy version).
-		 * \param callback The callback function.
-		 */
-		auto set_text_message_callback(text_message_callback_t callback) -> void;
-
-		/*!
-		 * \brief Sets the callback for binary messages (legacy version).
-		 * \param callback The callback function.
-		 */
-		auto set_binary_message_callback(binary_message_callback_t callback) -> void;
-
-		/*!
-		 * \brief Sets the callback for errors (legacy version).
-		 * \param callback The callback function.
-		 */
-		auto set_error_callback(error_callback_t callback) -> void;
 
 	private:
 		// =====================================================================

--- a/src/core/messaging_ws_server.cpp
+++ b/src/core/messaging_ws_server.cpp
@@ -182,35 +182,6 @@ namespace kcenon::network::core
 		return pimpl_->path();
 	}
 
-	// ========================================================================
-	// Legacy API
-	// ========================================================================
-
-	auto ws_connection::send_text(
-		std::string&& message,
-		std::function<void(std::error_code, std::size_t)> handler) -> VoidResult
-	{
-		return pimpl_->send_text(std::move(message), std::move(handler));
-	}
-
-	auto ws_connection::send_binary(
-		std::vector<uint8_t>&& data,
-		std::function<void(std::error_code, std::size_t)> handler) -> VoidResult
-	{
-		return pimpl_->send_binary(std::move(data), std::move(handler));
-	}
-
-	auto ws_connection::close(internal::ws_close_code code,
-							  const std::string& reason) -> VoidResult
-	{
-		return pimpl_->close(code, reason);
-	}
-
-	auto ws_connection::connection_id() const -> const std::string&
-	{
-		return pimpl_->connection_id();
-	}
-
 	auto ws_connection::remote_endpoint() const -> std::string
 	{
 		return pimpl_->remote_endpoint();
@@ -400,40 +371,6 @@ namespace kcenon::network::core
 	}
 
 	// ========================================================================
-	// Legacy API callback setters
-	// ========================================================================
-
-	auto messaging_ws_server::set_connection_callback(connection_callback_t callback) -> void
-	{
-		callbacks_.set<kConnectionCallbackIndex>(std::move(callback));
-	}
-
-	auto messaging_ws_server::set_disconnection_callback(disconnection_callback_t callback) -> void
-	{
-		callbacks_.set<kDisconnectionCallbackIndex>(std::move(callback));
-	}
-
-	auto messaging_ws_server::set_message_callback(message_callback_t callback) -> void
-	{
-		callbacks_.set<kMessageCallbackIndex>(std::move(callback));
-	}
-
-	auto messaging_ws_server::set_text_message_callback(text_message_callback_t callback) -> void
-	{
-		callbacks_.set<kTextMessageCallbackIndex>(std::move(callback));
-	}
-
-	auto messaging_ws_server::set_binary_message_callback(binary_message_callback_t callback) -> void
-	{
-		callbacks_.set<kBinaryMessageCallbackIndex>(std::move(callback));
-	}
-
-	auto messaging_ws_server::set_error_callback(error_callback_t callback) -> void
-	{
-		callbacks_.set<kErrorCallbackIndex>(std::move(callback));
-	}
-
-	// ========================================================================
 	// Internal Implementation
 	// ========================================================================
 
@@ -564,7 +501,7 @@ namespace kcenon::network::core
 		auto conns = session_mgr_->get_all_connections();
 		for (auto& conn : conns)
 		{
-			conn->send_text(std::string(message), nullptr);
+			(void)conn->send_text(std::string(message));
 		}
 	}
 
@@ -578,7 +515,7 @@ namespace kcenon::network::core
 		auto conns = session_mgr_->get_all_connections();
 		for (auto& conn : conns)
 		{
-			conn->send_binary(std::vector<uint8_t>(data), nullptr);
+			(void)conn->send_binary(std::vector<uint8_t>(data));
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Remove deprecated WebSocket API methods from `messaging_ws_client`, `ws_connection`, and `messaging_ws_server`
- Methods superseded by interface-compliant versions have been removed
- Users should migrate to the new interface methods

## Changes

### messaging_ws_client.h
- Removed `close(internal::ws_close_code, const std::string&)`
- Removed legacy callback setters: `set_message_callback()`, `set_text_message_callback()`, `set_binary_message_callback()`, `set_disconnected_callback()`

### messaging_ws_server.h (ws_connection)
- Removed `send_text(std::string&&, handler)`
- Removed `send_binary(std::vector<uint8_t>&&, handler)`
- Removed `close(internal::ws_close_code, const std::string&)`
- Removed `connection_id()` (use `id()` instead)

### messaging_ws_server.h (messaging_ws_server)
- Removed legacy callback setters: `set_connection_callback()`, `set_disconnection_callback()`, `set_message_callback()`, `set_text_message_callback()`, `set_binary_message_callback()`, `set_error_callback()`

## Migration Guide

| Deprecated Method | New Method |
|-------------------|------------|
| `close(ws_close_code, string)` | `close(uint16_t, string_view)` |
| `connection_id()` | `id()` |
| `set_message_callback()` | Use `set_text_callback()` and `set_binary_callback()` |
| `set_text_message_callback()` | `set_text_callback()` |
| `set_binary_message_callback()` | `set_binary_callback()` |

## Test Plan
- [x] Build succeeds on all platforms
- [x] All existing tests pass (99% pass rate, 3 pre-existing failures unrelated to this change)

Closes #482
Part of #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)