### PR TITLE
refactor(session): remove deprecated generate_session_id() method

### DIFF
--- a/include/kcenon/network/core/session_manager.h
+++ b/include/kcenon/network/core/session_manager.h
@@ -100,14 +100,6 @@ public:
         return std::nullopt;
     }
 
-private:
-    /**
-     * @brief Generate session ID (private, for backward compatibility)
-     * @return Generated session ID
-     *
-     * @deprecated Use the static generate_id() method from base class.
-     */
-    auto generate_session_id() -> std::string { return generate_id(); }
 };
 
 } // namespace kcenon::network::core


### PR DESCRIPTION
Closes #484

## Summary
- Remove deprecated `generate_session_id()` private method from `session_manager` class
- This method was a simple wrapper around the static `generate_id()` from base class
- Part of #480 (deprecated code removal)

## Changes
- **include/kcenon/network/core/session_manager.h**: Removed 8 lines (deprecated method and its documentation)

## Impact
- **Breaking change**: None (method was private and unused externally)
- All session-related tests pass (97/97)

## Test Plan
- [x] Build succeeds (Release configuration)
- [x] All session manager tests pass
- [x] No external usages of the deprecated method exist