### PR TITLE
refactor(udp): remove deprecated UDP API methods

### DIFF
--- a/include/kcenon/network/core/messaging_udp_client.h
+++ b/include/kcenon/network/core/messaging_udp_client.h
@@ -82,11 +82,12 @@ namespace kcenon::network::core
 	 * \code
 	 * auto client = std::make_shared<messaging_udp_client>("UDPClient");
 	 *
-	 * // Set callback to handle received datagrams
+	 * // Set callback to handle received datagrams (using interface callback)
 	 * client->set_receive_callback(
-	 *     [](const std::vector<uint8_t>& data, const asio::ip::udp::endpoint& sender) {
+	 *     [](const std::vector<uint8_t>& data,
+	 *        const interfaces::i_udp_client::endpoint_info& sender) {
 	 *         std::cout << "Received " << data.size() << " bytes from "
-	 *                   << sender.address().to_string() << ":" << sender.port() << "\n";
+	 *                   << sender.address << ":" << sender.port << "\n";
 	 *     });
 	 *
 	 * // Start client targeting localhost:5555
@@ -96,9 +97,9 @@ namespace kcenon::network::core
 	 *     return -1;
 	 * }
 	 *
-	 * // Send a datagram
+	 * // Send a datagram using send()
 	 * std::vector<uint8_t> data = {0x01, 0x02, 0x03};
-	 * client->send_packet(std::move(data),
+	 * client->send(std::move(data),
 	 *     [](std::error_code ec, std::size_t bytes) {
 	 *         if (!ec) {
 	 *             std::cout << "Sent " << bytes << " bytes\n";
@@ -253,22 +254,6 @@ namespace kcenon::network::core
 		 * Also compatible with legacy error_callback_t (same signature).
 		 */
 		auto set_error_callback(error_callback_t callback) -> void override;
-
-		// ========================================================================
-		// Legacy API (maintained for backward compatibility)
-		// ========================================================================
-
-		/*!
-		 * \brief Sends a datagram to the configured target endpoint.
-		 * \param data The data to send (moved for efficiency).
-		 * \param handler Completion handler with signature void(std::error_code, std::size_t).
-		 * \return Result<void> - Success if send initiated, or error if not running.
-		 *
-		 * \deprecated Use send() instead for interface compliance.
-		 */
-		auto send_packet(
-			std::vector<uint8_t>&& data,
-			std::function<void(std::error_code, std::size_t)> handler) -> VoidResult;
 
 	private:
 		// =====================================================================

--- a/integration_tests/performance/udp_load_test.cpp
+++ b/integration_tests/performance/udp_load_test.cpp
@@ -111,7 +111,7 @@ TEST_F(UDPLoadTest, Message_Throughput_64B) {
         auto msg_start = std::chrono::steady_clock::now();
 
         std::vector<uint8_t> data(message.begin(), message.end());
-        auto result = client->send_packet(std::move(data), [](auto, auto){});
+        auto result = client->send(std::move(data), [](auto, auto){});
         if (result.is_ok()) {
             sent_count++;
             auto msg_end = std::chrono::steady_clock::now();
@@ -178,7 +178,7 @@ TEST_F(UDPLoadTest, Message_Throughput_512B) {
     for (size_t i = 0; i < num_messages; ++i) {
         auto msg_start = std::chrono::steady_clock::now();
         std::vector<uint8_t> data(message.begin(), message.end());
-        auto result = client->send_packet(std::move(data), [](auto, auto){});
+        auto result = client->send(std::move(data), [](auto, auto){});
         if (result.is_ok()) {
             sent_count++;
             auto msg_end = std::chrono::steady_clock::now();
@@ -226,7 +226,7 @@ TEST_F(UDPLoadTest, Message_Throughput_1KB) {
     for (size_t i = 0; i < num_messages; ++i) {
         auto msg_start = std::chrono::steady_clock::now();
         std::vector<uint8_t> data(message.begin(), message.end());
-        auto result = client->send_packet(std::move(data), [](auto, auto){});
+        auto result = client->send(std::move(data), [](auto, auto){});
         if (result.is_ok()) {
             sent_count++;
             auto msg_end = std::chrono::steady_clock::now();
@@ -287,7 +287,7 @@ TEST_F(UDPLoadTest, Concurrent_Clients_10) {
 
     for (auto& client : clients_) {
         std::vector<uint8_t> data(test_message.begin(), test_message.end());
-        auto result = client->send_packet(std::move(data), [](auto, auto){});
+        auto result = client->send(std::move(data), [](auto, auto){});
         if (result.is_ok()) {
             success_count.fetch_add(1);
         }
@@ -347,7 +347,7 @@ TEST_F(UDPLoadTest, Send_Latency) {
     for (size_t i = 0; i < num_messages; ++i) {
         auto start = std::chrono::steady_clock::now();
         std::vector<uint8_t> data(test_message.begin(), test_message.end());
-        auto result = client->send_packet(std::move(data), [](auto, auto){});
+        auto result = client->send(std::move(data), [](auto, auto){});
         auto end = std::chrono::steady_clock::now();
 
         if (result.is_ok()) {
@@ -394,7 +394,7 @@ TEST_F(UDPLoadTest, Burst_Send_Performance) {
         size_t sent_in_burst = 0;
         for (size_t i = 0; i < burst_size; ++i) {
             std::vector<uint8_t> data(message.begin(), message.end());
-        auto result = client->send_packet(std::move(data), [](auto, auto){});
+        auto result = client->send(std::move(data), [](auto, auto){});
             if (result.is_ok()) {
                 sent_in_burst++;
             }

--- a/src/core/messaging_udp_server.cpp
+++ b/src/core/messaging_udp_server.cpp
@@ -207,26 +207,6 @@ namespace kcenon::network::core
 	}
 
 	// ========================================================================
-	// Legacy API
-	// ========================================================================
-
-	auto messaging_udp_server::async_send_to(
-		std::vector<uint8_t>&& data,
-		const asio::ip::udp::endpoint& endpoint,
-		std::function<void(std::error_code, std::size_t)> handler) -> void
-	{
-		if (socket_)
-		{
-			socket_->async_send_to(std::move(data), endpoint, std::move(handler));
-		}
-		else if (handler)
-		{
-			// Socket not available, report error
-			handler(asio::error::not_connected, 0);
-		}
-	}
-
-	// ========================================================================
 	// Internal Implementation Methods
 	// ========================================================================
 

--- a/src/core/reliable_udp_client.cpp
+++ b/src/core/reliable_udp_client.cpp
@@ -271,7 +271,7 @@ namespace kcenon::network::core
 
 			auto packet = create_packet(header, data);
 
-			return udp_client_->send_packet(
+			return udp_client_->send(
 				std::move(packet), [this](std::error_code ec, std::size_t) {
 					if (!ec)
 					{
@@ -312,7 +312,7 @@ namespace kcenon::network::core
 			pending_packets_[seq] = std::move(info);
 
 			// Send packet
-			return udp_client_->send_packet(
+			return udp_client_->send(
 				std::move(packet), [this, seq](std::error_code ec, std::size_t) {
 					if (!ec)
 					{
@@ -341,7 +341,7 @@ namespace kcenon::network::core
 
 			auto packet = create_packet(header, data);
 
-			return udp_client_->send_packet(
+			return udp_client_->send(
 				std::move(packet), [this](std::error_code ec, std::size_t) {
 					if (!ec)
 					{
@@ -474,7 +474,7 @@ namespace kcenon::network::core
 
 			auto packet = create_packet(header, {});
 
-			udp_client_->send_packet(std::move(packet), [this](std::error_code ec, std::size_t) {
+			udp_client_->send(std::move(packet), [this](std::error_code ec, std::size_t) {
 				if (!ec)
 				{
 					std::lock_guard<std::mutex> lock(stats_mutex_);
@@ -655,7 +655,7 @@ namespace kcenon::network::core
 									  " (attempt " + std::to_string(it->second.retransmit_count) +
 									  ")");
 
-					udp_client_->send_packet(std::move(packet_copy),
+					udp_client_->send(std::move(packet_copy),
 											 [](std::error_code, std::size_t) {});
 				}
 


### PR DESCRIPTION
Closes #483

## Summary
- Remove deprecated `async_send_to()` from `messaging_udp_server`
- Remove deprecated `send_packet()` from `messaging_udp_client`
- Migrate all usages to interface-compliant `send_to()` and `send()` methods
- Update samples, tests, and documentation examples

## Test Plan
- [x] All UDP composition tests pass (28 tests)
- [x] Build succeeds in Release mode
- [x] Integration tests compile and link successfully

## Breaking Change
Projects using `async_send_to()` or `send_packet()` will need to migrate:
- `server->async_send_to(data, endpoint, handler)` → `server->send_to(endpoint_info, data, handler)`
- `client->send_packet(data, handler)` → `client->send(data, handler)`

Generated with [Claude Code](https://claude.ai/claude-code)