### PR TITLE
refactor(openssl): transition to OpenSSL 3.x only support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,45 +384,16 @@ if(BUILD_TLS_SUPPORT)
     target_compile_definitions(NetworkSystem PUBLIC BUILD_TLS_SUPPORT)
 
     # Find OpenSSL for TLS/SSL
-    # Minimum requirement: OpenSSL 1.1.1 (for TLS 1.3 support)
-    # Recommended: OpenSSL 3.x (1.1.1 reached EOL on September 11, 2023)
-    find_package(OpenSSL 1.1.1 REQUIRED)
+    # Minimum requirement: OpenSSL 3.0.0
+    # OpenSSL 1.1.x reached EOL on September 11, 2023 and is no longer supported
+    find_package(OpenSSL 3.0.0 REQUIRED)
     target_link_libraries(NetworkSystem PUBLIC OpenSSL::SSL OpenSSL::Crypto)
 
     message(STATUS "TLS/SSL support enabled (TLS 1.2/1.3)")
     message(STATUS "  OpenSSL version: ${OPENSSL_VERSION}")
-
-    # OpenSSL version detection and compatibility
-    if(OPENSSL_VERSION VERSION_GREATER_EQUAL "3.0.0")
-        # OpenSSL 3.x - fully supported with modern API
-        message(STATUS "  OpenSSL 3.x: Using modern API")
-        message(STATUS "  TLS 1.3 support: Available")
-        target_compile_definitions(NetworkSystem PRIVATE NETWORK_OPENSSL_3_X)
-    elseif(OPENSSL_VERSION VERSION_GREATER_EQUAL "1.1.1")
-        # OpenSSL 1.1.1 - supported but EOL (September 11, 2023)
-        message(WARNING "")
-        message(WARNING "========================================")
-        message(WARNING "OpenSSL 1.1.1 End-of-Life Warning")
-        message(WARNING "========================================")
-        message(WARNING "")
-        message(WARNING "OpenSSL ${OPENSSL_VERSION} detected.")
-        message(WARNING "OpenSSL 1.1.1 reached End-of-Life on September 11, 2023.")
-        message(WARNING "No security patches are provided for vulnerabilities discovered after EOL.")
-        message(WARNING "")
-        message(WARNING "RECOMMENDATION: Upgrade to OpenSSL 3.x for continued security support.")
-        message(WARNING "")
-        message(WARNING "Installation:")
-        message(WARNING "  macOS:  brew install openssl@3")
-        message(WARNING "  Ubuntu: apt-get install libssl-dev (3.x in Ubuntu 22.04+)")
-        message(WARNING "  vcpkg:  vcpkg install openssl")
-        message(WARNING "========================================")
-        message(WARNING "")
-        message(STATUS "  TLS 1.3 support: Available")
-        target_compile_definitions(NetworkSystem PRIVATE NETWORK_OPENSSL_1_1_X)
-    else()
-        # OpenSSL < 1.1.1 - not supported
-        message(FATAL_ERROR "OpenSSL ${OPENSSL_VERSION} is not supported. Minimum required version is 1.1.1")
-    endif()
+    message(STATUS "  OpenSSL 3.x: Using modern API")
+    message(STATUS "  TLS 1.3 support: Available")
+    target_compile_definitions(NetworkSystem PRIVATE NETWORK_OPENSSL_3_X)
 endif()
 
 # WebSocket support (conditional)
@@ -439,18 +410,10 @@ if(BUILD_WEBSOCKET_SUPPORT)
 
     # Find OpenSSL for SHA-1 hashing in handshake (if not already found)
     if(NOT BUILD_TLS_SUPPORT)
-        find_package(OpenSSL 1.1.1 REQUIRED)
+        find_package(OpenSSL 3.0.0 REQUIRED)
         target_link_libraries(NetworkSystem PRIVATE OpenSSL::Crypto)
         message(STATUS "  OpenSSL version: ${OPENSSL_VERSION}")
-
-        # OpenSSL EOL warning for WebSocket-only builds
-        if(OPENSSL_VERSION VERSION_LESS "3.0.0" AND OPENSSL_VERSION VERSION_GREATER_EQUAL "1.1.1")
-            message(WARNING "OpenSSL ${OPENSSL_VERSION} detected. OpenSSL 1.1.1 reached EOL on September 11, 2023.")
-            message(WARNING "Consider upgrading to OpenSSL 3.x for continued security support.")
-            target_compile_definitions(NetworkSystem PRIVATE NETWORK_OPENSSL_1_1_X)
-        elseif(OPENSSL_VERSION VERSION_GREATER_EQUAL "3.0.0")
-            target_compile_definitions(NetworkSystem PRIVATE NETWORK_OPENSSL_3_X)
-        endif()
+        target_compile_definitions(NetworkSystem PRIVATE NETWORK_OPENSSL_3_X)
     endif()
 
     message(STATUS "WebSocket support enabled")

--- a/include/kcenon/network/internal/openssl_compat.h
+++ b/include/kcenon/network/internal/openssl_compat.h
@@ -34,17 +34,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /*!
  * \file openssl_compat.h
- * \brief OpenSSL version compatibility layer
+ * \brief OpenSSL utilities and version definitions
  *
- * This header provides compatibility macros and utilities for supporting
- * both OpenSSL 1.1.x and OpenSSL 3.x APIs.
+ * This header provides utility macros and functions for working with OpenSSL 3.x.
  *
  * OpenSSL Version Support:
- * - OpenSSL 1.1.1: Minimum supported version (EOL: September 11, 2023)
- * - OpenSSL 3.x: Recommended version with full support
+ * - OpenSSL 3.x: Required (minimum version)
  *
- * Note: OpenSSL 1.1.1 reached End-of-Life on September 11, 2023.
- * Users should upgrade to OpenSSL 3.x for continued security support.
+ * Note: OpenSSL 1.1.x support was removed as it reached End-of-Life on
+ * September 11, 2023. Users must use OpenSSL 3.x or later.
  */
 
 #include <openssl/opensslv.h>
@@ -57,21 +55,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // ============================================================================
 
 /*!
- * \brief Check if OpenSSL version is 3.0.0 or newer
+ * \brief Verify OpenSSL 3.x is being used
  *
  * OpenSSL 3.0 introduced significant API changes including:
  * - Provider-based architecture
  * - Deprecated many low-level APIs
  * - New EVP_MAC API replacing HMAC()
+ *
+ * This library requires OpenSSL 3.x. OpenSSL 1.1.x is no longer supported
+ * as it reached End-of-Life on September 11, 2023.
  */
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
     #define NETWORK_OPENSSL_VERSION_3_X 1
-    #define NETWORK_OPENSSL_VERSION_1_1_X 0
-#elif OPENSSL_VERSION_NUMBER >= 0x10101000L
-    #define NETWORK_OPENSSL_VERSION_3_X 0
-    #define NETWORK_OPENSSL_VERSION_1_1_X 1
 #else
-    #error "OpenSSL version 1.1.1 or newer is required"
+    #error "OpenSSL 3.x or newer is required. OpenSSL 1.1.x reached EOL on September 11, 2023."
 #endif
 
 // ============================================================================
@@ -120,37 +117,7 @@ namespace kcenon::network::internal
  */
 inline const char* openssl_version_string() noexcept
 {
-#if NETWORK_OPENSSL_VERSION_3_X
     return OpenSSL_version(OPENSSL_VERSION);
-#else
-    return OpenSSL_version(OPENSSL_VERSION);
-#endif
-}
-
-/*!
- * \brief Check if running on OpenSSL 3.x
- * \return true if OpenSSL 3.x, false otherwise
- */
-constexpr bool is_openssl_3x() noexcept
-{
-#if NETWORK_OPENSSL_VERSION_3_X
-    return true;
-#else
-    return false;
-#endif
-}
-
-/*!
- * \brief Check if running on deprecated OpenSSL 1.1.x
- * \return true if OpenSSL 1.1.x (EOL), false otherwise
- */
-constexpr bool is_openssl_eol() noexcept
-{
-#if NETWORK_OPENSSL_VERSION_1_1_X
-    return true;
-#else
-    return false;
-#endif
 }
 
 /*!
@@ -195,24 +162,11 @@ inline void clear_openssl_errors() noexcept
  * implementations are loaded from providers. The default provider includes
  * all common algorithms.
  *
- * Key differences from 1.1.x:
- *
- * 1. Providers:
+ * Key providers:
  *    - default: Standard cryptographic algorithms
  *    - legacy: Deprecated algorithms (MD4, RC4, DES, etc.)
  *    - fips: FIPS 140-2 validated algorithms
  *
- * 2. API Changes:
- *    - HMAC() function deprecated -> Use EVP_MAC API
- *    - Low-level cipher APIs deprecated -> Use EVP_Cipher APIs
- *    - Engine API deprecated -> Use Provider API
- *
- * 3. Our Approach:
- *    - Use EVP-based APIs which work on both versions
- *    - Avoid deprecated low-level APIs
- *    - No special provider loading needed for standard operations
- *
- * The code in this library uses EVP-based APIs throughout, which provides
- * seamless compatibility between OpenSSL 1.1.x and 3.x without requiring
- * any runtime detection or conditional code paths.
+ * This library uses EVP-based APIs throughout, following OpenSSL 3.x best
+ * practices. No special provider loading is needed for standard operations.
  */


### PR DESCRIPTION
Closes #485

## Summary
- Remove OpenSSL 1.1.x compatibility code (EOL: September 11, 2023)
- Update minimum OpenSSL requirement from 1.1.1 to 3.0.0
- Simplify openssl_compat.h and CMakeLists.txt by removing version branching

## Changes
| File | Change |
|------|--------|
| `openssl_compat.h` | Remove `NETWORK_OPENSSL_VERSION_1_1_X` macro, `is_openssl_3x()`, `is_openssl_eol()` functions |
| `CMakeLists.txt` | Update minimum version to 3.0.0, remove EOL warning and version detection |
| `dtls_test_helpers.h` | Remove OpenSSL 1.1.x RSA key generation code path |

## Breaking Change
Projects using OpenSSL 1.1.x must upgrade to OpenSSL 3.x.

## Test Plan
- [x] Build succeeds with OpenSSL 3.6.0
- [x] All OpenSSL-related tests pass (QUIC, TLS, DTLS, WebSocket)
- [x] 99% of tests pass (1171/1188)