### PR TITLE
fix(integration): replace submit_async with submit for thread_system #501 compatibility

### DIFF
--- a/src/integration/thread_integration.cpp
+++ b/src/integration/thread_integration.cpp
@@ -106,9 +106,9 @@ public:
         // which can cause heap corruption during static destruction.
         auto* completed_ptr = &completed_tasks_;
 
-        // Use submit_async which returns a future and throws on failure
+        // Use submit which returns a future and throws on failure
         try {
-            pool_->submit_async([task = std::move(task), promise, completed_ptr]() mutable {
+            pool_->submit([task = std::move(task), promise, completed_ptr]() mutable {
                 try {
                     if (task) task();
                     promise->set_value();
@@ -156,9 +156,9 @@ public:
         // which can cause heap corruption during static destruction.
         auto* completed_ptr = &completed_tasks_;
 
-        // Use submit_async which returns a future and throws on failure
+        // Use submit which returns a future and throws on failure
         try {
-            pool_->submit_async([task = std::move(task), delay, promise, completed_ptr]() mutable {
+            pool_->submit([task = std::move(task), delay, promise, completed_ptr]() mutable {
                 try {
                     std::this_thread::sleep_for(delay);
                     if (task) task();

--- a/src/integration/thread_system_adapter.cpp
+++ b/src/integration/thread_system_adapter.cpp
@@ -74,9 +74,9 @@ std::future<void> thread_system_pool_adapter::submit(std::function<void()> task)
     auto promise = std::make_shared<std::promise<void>>();
     auto future = promise->get_future();
 
-    // Use submit_async which returns a future and throws on failure
+    // Use submit which returns a future and throws on failure
     try {
-        pool_->submit_async([task = std::move(task), promise]() mutable {
+        pool_->submit([task = std::move(task), promise]() mutable {
             try {
                 if (task) task();
                 promise->set_value();
@@ -114,9 +114,9 @@ std::future<void> thread_system_pool_adapter::submit_delayed(
         return future;
     }
 
-    // Use submit_async which returns a future and throws on failure
+    // Use submit which returns a future and throws on failure
     try {
-        pool_->submit_async([task = std::move(task), delay, promise]() mutable {
+        pool_->submit([task = std::move(task), delay, promise]() mutable {
             try {
                 std::this_thread::sleep_for(delay);
                 if (task) task();


### PR DESCRIPTION
## Summary
- Replace deprecated `submit_async()` with new `submit()` API in thread integration files
- Required for compatibility with thread_system PR #501 which removed deprecated API methods

## Changed Files
- `src/integration/thread_integration.cpp`: `pool_->submit_async(...)` → `pool_->submit(...)`
- `src/integration/thread_system_adapter.cpp`: `pool_->submit_async(...)` → `pool_->submit(...)`

## Test Plan
- Build passes with latest thread_system main branch
- Existing functionality unchanged - submit() is a drop-in replacement for submit_async()

## Related Issues
- thread_system PR #501: refactor(thread_pool): remove deprecated API methods