### PR TITLE
refactor(types): consolidate Result type aliases and add internal namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Consolidated Result Type Aliases (#494)**
+  - Clarified that `network::Result<T>`, `network::VoidResult`, and `network::error_info` are deprecated for external use
+  - Internal code continues to use these aliases which now directly map to `kcenon::common` types
+  - Added `kcenon::network::internal` namespace with explicit type aliases for internal implementation
+  - Updated documentation to guide migration to `kcenon::common::Result<T>` for external code
+  - `http_types.h` functions now use `::kcenon::network::internal::Result<T>` for clarity
+
 ### Removed
 - **BREAKING: Removed `compatibility.h` and `network_module` Namespace Aliases (#481)**
   - Deleted `include/kcenon/network/compatibility.h` header file

--- a/include/kcenon/network/internal/http_types.h
+++ b/include/kcenon/network/internal/http_types.h
@@ -253,7 +253,7 @@ namespace kcenon::network::internal
      * Possible errors:
      * - invalid_argument: Unknown HTTP method string
      */
-    auto string_to_http_method(const std::string& method_str) -> ::kcenon::network::Result<http_method>;
+    auto string_to_http_method(const std::string& method_str) -> ::kcenon::network::internal::Result<http_method>;
 
     /*!
      * \brief Convert HTTP version enum to string
@@ -270,7 +270,7 @@ namespace kcenon::network::internal
      * Possible errors:
      * - invalid_argument: Unknown HTTP version string
      */
-    auto string_to_http_version(const std::string& version_str) -> ::kcenon::network::Result<http_version>;
+    auto string_to_http_version(const std::string& version_str) -> ::kcenon::network::internal::Result<http_version>;
 
     /*!
      * \brief Get HTTP status message for a status code

--- a/include/kcenon/network/utils/result_types.h
+++ b/include/kcenon/network/utils/result_types.h
@@ -46,49 +46,40 @@ namespace kcenon::network {
 
 #if KCENON_WITH_COMMON_SYSTEM
 	// ============================================================
-	// Primary API: Use common::Result<T> directly
+	// Use common::Result<T> directly for new code
 	// ============================================================
 	//
-	// network_system now uses common_system's Result<T> as the primary
-	// error handling mechanism. While kcenon::network::Result<T> aliases
-	// remain available for backward compatibility, new code should use
-	// kcenon::common::Result<T> directly for ecosystem-wide consistency.
+	// network_system uses common_system's Result<T> as the primary
+	// error handling mechanism. New code should use kcenon::common::Result<T>
+	// directly for ecosystem-wide consistency.
 	//
-	// Migration path:
-	//   Before: kcenon::network::Result<T>
-	//   After:  kcenon::common::Result<T>
+	// The type aliases (network::Result<T>, network::VoidResult,
+	// network::error_info) are provided for internal use and backward
+	// compatibility but are deprecated for external use.
 	//
-	// To enable deprecation warnings for migration preparation, define:
-	//   NETWORK_SYSTEM_ENABLE_DEPRECATION_WARNINGS
+	// Migration path for external code:
+	//   - kcenon::network::Result<T> -> kcenon::common::Result<T>
+	//   - kcenon::network::VoidResult -> kcenon::common::VoidResult
+	//   - kcenon::network::error_info -> kcenon::common::error_info
 	//
-	// See: https://github.com/kcenon/common_system/issues/205
+	// See: https://github.com/kcenon/network_system/issues/494
 	// ============================================================
 
-#ifdef NETWORK_SYSTEM_ENABLE_DEPRECATION_WARNINGS
-	// Deprecated aliases - enable warnings to find usage during migration
-	template<typename T>
-	using Result [[deprecated("Use kcenon::common::Result<T> directly for ecosystem consistency. "
-	                          "See https://github.com/kcenon/common_system/issues/205")]]
-		= ::kcenon::common::Result<T>;
-
-	using VoidResult [[deprecated("Use kcenon::common::VoidResult directly for ecosystem consistency. "
-	                              "See https://github.com/kcenon/common_system/issues/205")]]
-		= ::kcenon::common::VoidResult;
-
-	using error_info [[deprecated("Use kcenon::common::error_info directly for ecosystem consistency. "
-	                              "See https://github.com/kcenon/common_system/issues/205")]]
-		= ::kcenon::common::error_info;
-#else
-	// Backward-compatible aliases (prefer kcenon::common::Result<T> for new code)
-	// These aliases are retained for migration support but may be removed
-	// in a future major version.
+	// Type aliases for internal use (deprecated for external use)
+	// These map directly to common_system types
 	template<typename T>
 	using Result = ::kcenon::common::Result<T>;
-
 	using VoidResult = ::kcenon::common::VoidResult;
-
 	using error_info = ::kcenon::common::error_info;
-#endif
+
+namespace internal {
+	// Internal type aliases - same as namespace-level types
+	// Provided for explicit internal-only usage pattern
+	template<typename T>
+	using Result = ::kcenon::common::Result<T>;
+	using VoidResult = ::kcenon::common::VoidResult;
+	using error_info = ::kcenon::common::error_info;
+} // namespace internal
 
 	// Error code namespace (includes common_errors and network_system)
 	namespace error_codes = ::kcenon::common::error::codes;
@@ -169,6 +160,15 @@ namespace kcenon::network {
 
 	using VoidResult = Result<std::monostate>;
 	using error_info = simple_error;
+
+namespace internal {
+	// Internal type aliases for network_system implementation
+	// These provide a consistent interface regardless of common_system availability
+	template<typename T>
+	using Result = ::kcenon::network::Result<T>;
+	using VoidResult = ::kcenon::network::VoidResult;
+	using error_info = ::kcenon::network::error_info;
+} // namespace internal
 
 	// Minimal error codes (fallback)
 	namespace error_codes {

--- a/src/internal/http_types.cpp
+++ b/src/internal/http_types.cpp
@@ -156,7 +156,7 @@ namespace kcenon::network::internal
         }
     }
 
-    auto string_to_http_method(const std::string& method_str) -> ::kcenon::network::Result<http_method>
+    auto string_to_http_method(const std::string& method_str) -> ::kcenon::network::internal::Result<http_method>
     {
         auto upper_method = method_str;
         std::transform(upper_method.begin(), upper_method.end(), upper_method.begin(),
@@ -189,7 +189,7 @@ namespace kcenon::network::internal
         }
     }
 
-    auto string_to_http_version(const std::string& version_str) -> ::kcenon::network::Result<http_version>
+    auto string_to_http_version(const std::string& version_str) -> ::kcenon::network::internal::Result<http_version>
     {
         if (version_str == "HTTP/1.0") return ::kcenon::network::ok(http_version::HTTP_1_0);
         if (version_str == "HTTP/1.1") return ::kcenon::network::ok(http_version::HTTP_1_1);


### PR DESCRIPTION
Closes #494

## Summary
- Clarified that `network::Result<T>`, `network::VoidResult`, and `network::error_info` are deprecated for external use
- Added `kcenon::network::internal` namespace with explicit type aliases for internal implementation
- Updated `http_types.h` functions to use `internal::Result<T>` for clarity
- Updated documentation with migration guidance to `kcenon::common::Result<T>`

## Test Plan
- [x] Build passes with common_system disabled (`build/`)
- [x] Build passes with common_system enabled (`build_common/`)
- [x] All unit tests pass (15/15 in both configurations)
- [x] Verified internal type aliases work correctly in both build modes