### PR TITLE
refactor(core): replace magic callback indices with named enum types

### DIFF
--- a/include/kcenon/network/core/callback_indices.h
+++ b/include/kcenon/network/core/callback_indices.h
@@ -1,0 +1,167 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, 🍀☀🌕🌥 🌊
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+namespace kcenon::network {
+
+/**
+ * \brief Callback indices for messaging_client and secure_messaging_client.
+ *
+ * These clients use callbacks for: receive, connected, disconnected, error.
+ */
+enum class tcp_client_callback : std::size_t {
+	receive = 0,
+	connected = 1,
+	disconnected = 2,
+	error = 3
+};
+
+/**
+ * \brief Callback indices for messaging_server and secure_messaging_server.
+ *
+ * These servers use callbacks for: connection, disconnection, receive, error.
+ */
+enum class tcp_server_callback : std::size_t {
+	connection = 0,
+	disconnection = 1,
+	receive = 2,
+	error = 3
+};
+
+/**
+ * \brief Callback indices for messaging_udp_client.
+ *
+ * UDP client uses callbacks for: receive, error.
+ */
+enum class udp_client_callback : std::size_t {
+	receive = 0,
+	error = 1
+};
+
+/**
+ * \brief Callback indices for secure_messaging_udp_client.
+ *
+ * Secure UDP client uses callbacks for: receive, connected, disconnected, error.
+ */
+enum class secure_udp_client_callback : std::size_t {
+	receive = 0,
+	connected = 1,
+	disconnected = 2,
+	error = 3
+};
+
+/**
+ * \brief Callback indices for messaging_udp_server.
+ *
+ * UDP server uses callbacks for: receive, error.
+ */
+enum class udp_server_callback : std::size_t {
+	receive = 0,
+	error = 1
+};
+
+/**
+ * \brief Callback indices for messaging_ws_client.
+ *
+ * WebSocket client uses callbacks for: message, text_message, binary_message,
+ * connected, disconnected, error.
+ */
+enum class ws_client_callback : std::size_t {
+	message = 0,
+	text_message = 1,
+	binary_message = 2,
+	connected = 3,
+	disconnected = 4,
+	error = 5
+};
+
+/**
+ * \brief Callback indices for messaging_ws_server.
+ *
+ * WebSocket server uses callbacks for: connection, disconnection, message,
+ * text_message, binary_message, error.
+ */
+enum class ws_server_callback : std::size_t {
+	connection = 0,
+	disconnection = 1,
+	message = 2,
+	text_message = 3,
+	binary_message = 4,
+	error = 5
+};
+
+/**
+ * \brief Callback indices for messaging_quic_client.
+ *
+ * QUIC client uses callbacks for: receive, stream_receive, connected,
+ * disconnected, error.
+ */
+enum class quic_client_callback : std::size_t {
+	receive = 0,
+	stream_receive = 1,
+	connected = 2,
+	disconnected = 3,
+	error = 4
+};
+
+/**
+ * \brief Callback indices for messaging_quic_server.
+ *
+ * QUIC server uses callbacks for: connection, disconnection, receive,
+ * stream_receive, error.
+ */
+enum class quic_server_callback : std::size_t {
+	connection = 0,
+	disconnection = 1,
+	receive = 2,
+	stream_receive = 3,
+	error = 4
+};
+
+/**
+ * \brief Helper to convert enum to std::size_t for callback_manager access.
+ * \tparam E The enum type.
+ * \param e The enum value.
+ * \return The underlying std::size_t value.
+ */
+template <typename E>
+constexpr auto to_index(E e) noexcept -> std::size_t
+{
+	static_assert(std::is_enum_v<E>, "to_index requires an enum type");
+	return static_cast<std::size_t>(e);
+}
+
+} // namespace kcenon::network

--- a/include/kcenon/network/core/messaging_client.h
+++ b/include/kcenon/network/core/messaging_client.h
@@ -44,6 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <asio.hpp>
 
+#include "kcenon/network/core/callback_indices.h"
 #include "kcenon/network/internal/tcp_socket.h"
 #include "kcenon/network/integration/io_context_thread_manager.h"
 #include "kcenon/network/utils/startable_base.h"
@@ -316,13 +317,8 @@ namespace kcenon::network::core
 		auto on_connection_failed(std::error_code ec) -> void;
 
 	private:
-		// =====================================================================
-		// Callback indices for callback_manager
-		// =====================================================================
-		static constexpr std::size_t kReceiveCallback = 0;
-		static constexpr std::size_t kConnectedCallback = 1;
-		static constexpr std::size_t kDisconnectedCallback = 2;
-		static constexpr std::size_t kErrorCallback = 3;
+		//! \brief Callback index type alias for clarity
+		using callback_index = tcp_client_callback;
 
 		//! \brief Callback manager type for this client
 		using callbacks_t = utils::callback_manager<

--- a/include/kcenon/network/core/messaging_quic_client.h
+++ b/include/kcenon/network/core/messaging_quic_client.h
@@ -47,6 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <asio.hpp>
 
+#include "kcenon/network/core/callback_indices.h"
 #include "kcenon/network/core/network_context.h"
 #include "kcenon/network/interfaces/i_quic_client.h"
 #include "kcenon/network/integration/thread_integration.h"
@@ -566,14 +567,8 @@ namespace kcenon::network::core
 		 */
 		auto invoke_error_callback(std::error_code ec) -> void;
 
-		// =====================================================================
-		// Callback indices for callback_manager
-		// =====================================================================
-		static constexpr std::size_t kReceiveCallbackIndex = 0;
-		static constexpr std::size_t kStreamReceiveCallbackIndex = 1;
-		static constexpr std::size_t kConnectedCallbackIndex = 2;
-		static constexpr std::size_t kDisconnectedCallbackIndex = 3;
-		static constexpr std::size_t kErrorCallbackIndex = 4;
+		//! \brief Callback index type alias for clarity
+		using callback_index = quic_client_callback;
 
 		//! \brief Callback manager type for this client
 		using callbacks_t = utils::callback_manager<

--- a/include/kcenon/network/core/messaging_quic_server.h
+++ b/include/kcenon/network/core/messaging_quic_server.h
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <kcenon/network/config/feature_flags.h>
 
+#include "kcenon/network/core/callback_indices.h"
 #include "kcenon/network/core/messaging_quic_client.h"
 #include "kcenon/network/core/network_context.h"
 #include "kcenon/network/interfaces/i_quic_server.h"
@@ -510,14 +511,8 @@ namespace kcenon::network::core
 		 */
 		auto invoke_error_callback(std::error_code ec) -> void;
 
-		// =====================================================================
-		// Callback indices for callback_manager
-		// =====================================================================
-		static constexpr std::size_t kConnectionCallbackIndex = 0;
-		static constexpr std::size_t kDisconnectionCallbackIndex = 1;
-		static constexpr std::size_t kReceiveCallbackIndex = 2;
-		static constexpr std::size_t kStreamReceiveCallbackIndex = 3;
-		static constexpr std::size_t kErrorCallbackIndex = 4;
+		//! \brief Callback index type alias for clarity
+		using callback_index = quic_server_callback;
 
 		//! \brief Callback manager type for this server
 		using callbacks_t = utils::callback_manager<

--- a/include/kcenon/network/core/messaging_server.h
+++ b/include/kcenon/network/core/messaging_server.h
@@ -44,6 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <asio.hpp>
 
+#include "kcenon/network/core/callback_indices.h"
 #include "kcenon/network/utils/result_types.h"
 #include "kcenon/network/utils/startable_base.h"
 #include "kcenon/network/utils/callback_manager.h"
@@ -339,13 +340,8 @@ namespace kcenon::network::core {
 		auto start_cleanup_timer() -> void;
 
 	private:
-		// =====================================================================
-		// Callback indices for callback_manager
-		// =====================================================================
-		static constexpr std::size_t kConnectionCallback = 0;
-		static constexpr std::size_t kDisconnectionCallback = 1;
-		static constexpr std::size_t kReceiveCallback = 2;
-		static constexpr std::size_t kErrorCallback = 3;
+		//! \brief Callback index type alias for clarity
+		using callback_index = tcp_server_callback;
 
 		//! \brief Callback manager type for this server
 		using callbacks_t = utils::callback_manager<

--- a/include/kcenon/network/core/messaging_udp_client.h
+++ b/include/kcenon/network/core/messaging_udp_client.h
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <asio.hpp>
 
+#include "kcenon/network/core/callback_indices.h"
 #include "kcenon/network/interfaces/i_udp_client.h"
 #include "kcenon/network/utils/result_types.h"
 #include "kcenon/network/utils/lifecycle_manager.h"
@@ -308,11 +309,8 @@ namespace kcenon::network::core
 		 */
 		[[nodiscard]] auto get_error_callback() const -> error_callback_t;
 
-		// =====================================================================
-		// Callback indices for callback_manager
-		// =====================================================================
-		static constexpr std::size_t kReceiveCallbackIndex = 0;
-		static constexpr std::size_t kErrorCallbackIndex = 1;
+		//! \brief Callback index type alias for clarity
+		using callback_index = udp_client_callback;
 
 		//! \brief Callback manager type for this client
 		using callbacks_t = utils::callback_manager<

--- a/include/kcenon/network/core/messaging_udp_server.h
+++ b/include/kcenon/network/core/messaging_udp_server.h
@@ -41,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <asio.hpp>
 
+#include "kcenon/network/core/callback_indices.h"
 #include "kcenon/network/interfaces/i_udp_server.h"
 #include "kcenon/network/utils/result_types.h"
 #include "kcenon/network/utils/lifecycle_manager.h"
@@ -296,11 +297,8 @@ namespace kcenon::network::core
 		 */
 		[[nodiscard]] auto get_error_callback() const -> error_callback_t;
 
-		// =====================================================================
-		// Callback indices for callback_manager
-		// =====================================================================
-		static constexpr std::size_t kReceiveCallbackIndex = 0;
-		static constexpr std::size_t kErrorCallbackIndex = 1;
+		//! \brief Callback index type alias for clarity
+		using callback_index = udp_server_callback;
 
 		//! \brief Callback manager type for this server
 		using callbacks_t = utils::callback_manager<

--- a/include/kcenon/network/core/messaging_ws_client.h
+++ b/include/kcenon/network/core/messaging_ws_client.h
@@ -47,6 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <asio.hpp>
 
 #include "kcenon/network/interfaces/i_websocket_client.h"
+#include "kcenon/network/core/callback_indices.h"
 #include "kcenon/network/internal/websocket_protocol.h"
 #include "kcenon/network/utils/result_types.h"
 #include "kcenon/network/utils/lifecycle_manager.h"
@@ -408,15 +409,8 @@ namespace kcenon::network::core
 		 */
 		auto invoke_error_callback(std::error_code ec) -> void;
 
-		// =====================================================================
-		// Callback indices for callback_manager
-		// =====================================================================
-		static constexpr std::size_t kMessageCallbackIndex = 0;
-		static constexpr std::size_t kTextMessageCallbackIndex = 1;
-		static constexpr std::size_t kBinaryMessageCallbackIndex = 2;
-		static constexpr std::size_t kConnectedCallbackIndex = 3;
-		static constexpr std::size_t kDisconnectedCallbackIndex = 4;
-		static constexpr std::size_t kErrorCallbackIndex = 5;
+		//! \brief Callback index type alias for clarity
+		using callback_index = ws_client_callback;
 
 		//! \brief Callback manager type for this client
 		using callbacks_t = utils::callback_manager<

--- a/include/kcenon/network/core/messaging_ws_server.h
+++ b/include/kcenon/network/core/messaging_ws_server.h
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
+#include "kcenon/network/core/callback_indices.h"
 #include "kcenon/network/interfaces/i_websocket_server.h"
 #include "kcenon/network/internal/websocket_protocol.h"
 #include "kcenon/network/utils/result_types.h"
@@ -491,15 +492,8 @@ namespace kcenon::network::core
 		 */
 		auto invoke_error_callback(const std::string& conn_id, std::error_code ec) -> void;
 
-		// =====================================================================
-		// Callback indices for callback_manager
-		// =====================================================================
-		static constexpr std::size_t kConnectionCallbackIndex = 0;
-		static constexpr std::size_t kDisconnectionCallbackIndex = 1;
-		static constexpr std::size_t kMessageCallbackIndex = 2;
-		static constexpr std::size_t kTextMessageCallbackIndex = 3;
-		static constexpr std::size_t kBinaryMessageCallbackIndex = 4;
-		static constexpr std::size_t kErrorCallbackIndex = 5;
+		//! \brief Callback index type alias for clarity
+		using callback_index = ws_server_callback;
 
 		//! \brief Callback manager type for this server
 		using callbacks_t = utils::callback_manager<

--- a/include/kcenon/network/core/secure_messaging_client.h
+++ b/include/kcenon/network/core/secure_messaging_client.h
@@ -44,6 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <asio.hpp>
 #include <asio/ssl.hpp>
 
+#include "kcenon/network/core/callback_indices.h"
 #include "kcenon/network/internal/secure_tcp_socket.h"
 #include "kcenon/network/integration/thread_integration.h"
 #include "kcenon/network/utils/lifecycle_manager.h"
@@ -282,13 +283,8 @@ namespace kcenon::network::core
 		auto on_error(std::error_code ec) -> void;
 
 	private:
-		// =====================================================================
-		// Callback indices for callback_manager
-		// =====================================================================
-		static constexpr std::size_t kReceiveCallback = 0;
-		static constexpr std::size_t kConnectedCallback = 1;
-		static constexpr std::size_t kDisconnectedCallback = 2;
-		static constexpr std::size_t kErrorCallback = 3;
+		//! \brief Callback index type alias for clarity
+		using callback_index = tcp_client_callback;
 
 		//! \brief Callback manager type for this client
 		using callbacks_t = utils::callback_manager<

--- a/include/kcenon/network/core/secure_messaging_server.h
+++ b/include/kcenon/network/core/secure_messaging_server.h
@@ -46,6 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <asio.hpp>
 #include <asio/ssl.hpp>
 
+#include "kcenon/network/core/callback_indices.h"
 #include "kcenon/network/integration/thread_integration.h"
 #include "kcenon/network/utils/lifecycle_manager.h"
 #include "kcenon/network/utils/callback_manager.h"
@@ -319,13 +320,8 @@ namespace kcenon::network::core
 		auto start_cleanup_timer() -> void;
 
 	private:
-		// =====================================================================
-		// Callback indices for callback_manager
-		// =====================================================================
-		static constexpr std::size_t kConnectionCallback = 0;
-		static constexpr std::size_t kDisconnectionCallback = 1;
-		static constexpr std::size_t kReceiveCallback = 2;
-		static constexpr std::size_t kErrorCallback = 3;
+		//! \brief Callback index type alias for clarity
+		using callback_index = tcp_server_callback;
 
 		//! \brief Callback manager type for this server
 		using callbacks_t = utils::callback_manager<

--- a/include/kcenon/network/core/secure_messaging_udp_client.h
+++ b/include/kcenon/network/core/secure_messaging_udp_client.h
@@ -44,6 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <asio.hpp>
 #include <openssl/ssl.h>
 
+#include "kcenon/network/core/callback_indices.h"
 #include "kcenon/network/integration/thread_integration.h"
 #include "kcenon/network/utils/lifecycle_manager.h"
 #include "kcenon/network/utils/callback_manager.h"
@@ -307,13 +308,8 @@ namespace kcenon::network::core
 		auto invoke_error_callback(std::error_code ec) -> void;
 
 	private:
-		// =====================================================================
-		// Callback indices for callback_manager
-		// =====================================================================
-		static constexpr std::size_t kReceiveCallback = 0;
-		static constexpr std::size_t kConnectedCallback = 1;
-		static constexpr std::size_t kDisconnectedCallback = 2;
-		static constexpr std::size_t kErrorCallback = 3;
+		//! \brief Callback index type alias for clarity
+		using callback_index = secure_udp_client_callback;
 
 		//! \brief Callback manager type for this client
 		using callbacks_t = utils::callback_manager<

--- a/src/core/messaging_client.cpp
+++ b/src/core/messaging_client.cpp
@@ -105,7 +105,7 @@ auto messaging_client::stop_client() -> VoidResult {
 
 auto messaging_client::on_stopped() -> void {
   // Invoke disconnected callback after stop completes
-  callbacks_.invoke<kDisconnectedCallback>();
+  callbacks_.invoke<to_index(callback_index::disconnected)>();
 }
 
 // Note: wait_for_stop() and is_running() are inherited from startable_base
@@ -160,19 +160,19 @@ auto messaging_client::send_packet(std::vector<uint8_t>&& data) -> VoidResult {
 }
 
 auto messaging_client::set_receive_callback(receive_callback_t callback) -> void {
-  callbacks_.set<kReceiveCallback>(std::move(callback));
+  callbacks_.set<to_index(callback_index::receive)>(std::move(callback));
 }
 
 auto messaging_client::set_connected_callback(connected_callback_t callback) -> void {
-  callbacks_.set<kConnectedCallback>(std::move(callback));
+  callbacks_.set<to_index(callback_index::connected)>(std::move(callback));
 }
 
 auto messaging_client::set_disconnected_callback(disconnected_callback_t callback) -> void {
-  callbacks_.set<kDisconnectedCallback>(std::move(callback));
+  callbacks_.set<to_index(callback_index::disconnected)>(std::move(callback));
 }
 
 auto messaging_client::set_error_callback(error_callback_t callback) -> void {
-  callbacks_.set<kErrorCallback>(std::move(callback));
+  callbacks_.set<to_index(callback_index::error)>(std::move(callback));
 }
 
 auto messaging_client::set_connected(bool connected) -> void {
@@ -180,19 +180,19 @@ auto messaging_client::set_connected(bool connected) -> void {
 }
 
 auto messaging_client::invoke_receive_callback(const std::vector<uint8_t>& data) -> void {
-  callbacks_.invoke<kReceiveCallback>(data);
+  callbacks_.invoke<to_index(callback_index::receive)>(data);
 }
 
 auto messaging_client::invoke_connected_callback() -> void {
-  callbacks_.invoke<kConnectedCallback>();
+  callbacks_.invoke<to_index(callback_index::connected)>();
 }
 
 auto messaging_client::invoke_disconnected_callback() -> void {
-  callbacks_.invoke<kDisconnectedCallback>();
+  callbacks_.invoke<to_index(callback_index::disconnected)>();
 }
 
 auto messaging_client::invoke_error_callback(std::error_code ec) -> void {
-  callbacks_.invoke<kErrorCallback>(ec);
+  callbacks_.invoke<to_index(callback_index::error)>(ec);
 }
 
 // TCP-specific implementation of client start

--- a/src/core/messaging_quic_client.cpp
+++ b/src/core/messaging_quic_client.cpp
@@ -687,29 +687,29 @@ auto messaging_quic_client::get_socket() const
 
 auto messaging_quic_client::invoke_receive_callback(const std::vector<uint8_t>& data) -> void
 {
-	callbacks_.invoke<kReceiveCallbackIndex>(data);
+	callbacks_.invoke<to_index(callback_index::receive)>(data);
 }
 
 auto messaging_quic_client::invoke_stream_receive_callback(uint64_t stream_id,
                                                            const std::vector<uint8_t>& data,
                                                            bool fin) -> void
 {
-	callbacks_.invoke<kStreamReceiveCallbackIndex>(stream_id, data, fin);
+	callbacks_.invoke<to_index(callback_index::stream_receive)>(stream_id, data, fin);
 }
 
 auto messaging_quic_client::invoke_connected_callback() -> void
 {
-	callbacks_.invoke<kConnectedCallbackIndex>();
+	callbacks_.invoke<to_index(callback_index::connected)>();
 }
 
 auto messaging_quic_client::invoke_disconnected_callback() -> void
 {
-	callbacks_.invoke<kDisconnectedCallbackIndex>();
+	callbacks_.invoke<to_index(callback_index::disconnected)>();
 }
 
 auto messaging_quic_client::invoke_error_callback(std::error_code ec) -> void
 {
-	callbacks_.invoke<kErrorCallbackIndex>(ec);
+	callbacks_.invoke<to_index(callback_index::error)>(ec);
 }
 
 // =============================================================================
@@ -718,7 +718,7 @@ auto messaging_quic_client::invoke_error_callback(std::error_code ec) -> void
 
 auto messaging_quic_client::set_stream_receive_callback(stream_receive_callback_t callback) -> void
 {
-	callbacks_.set<kStreamReceiveCallbackIndex>(std::move(callback));
+	callbacks_.set<to_index(callback_index::stream_receive)>(std::move(callback));
 }
 
 // =============================================================================
@@ -728,31 +728,31 @@ auto messaging_quic_client::set_stream_receive_callback(stream_receive_callback_
 auto messaging_quic_client::set_receive_callback(
 	interfaces::i_quic_client::receive_callback_t callback) -> void
 {
-	callbacks_.set<kReceiveCallbackIndex>(std::move(callback));
+	callbacks_.set<to_index(callback_index::receive)>(std::move(callback));
 }
 
 auto messaging_quic_client::set_stream_callback(
 	interfaces::i_quic_client::stream_callback_t callback) -> void
 {
-	callbacks_.set<kStreamReceiveCallbackIndex>(std::move(callback));
+	callbacks_.set<to_index(callback_index::stream_receive)>(std::move(callback));
 }
 
 auto messaging_quic_client::set_connected_callback(
 	interfaces::i_quic_client::connected_callback_t callback) -> void
 {
-	callbacks_.set<kConnectedCallbackIndex>(std::move(callback));
+	callbacks_.set<to_index(callback_index::connected)>(std::move(callback));
 }
 
 auto messaging_quic_client::set_disconnected_callback(
 	interfaces::i_quic_client::disconnected_callback_t callback) -> void
 {
-	callbacks_.set<kDisconnectedCallbackIndex>(std::move(callback));
+	callbacks_.set<to_index(callback_index::disconnected)>(std::move(callback));
 }
 
 auto messaging_quic_client::set_error_callback(
 	interfaces::i_quic_client::error_callback_t callback) -> void
 {
-	callbacks_.set<kErrorCallbackIndex>(std::move(callback));
+	callbacks_.set<to_index(callback_index::error)>(std::move(callback));
 }
 
 auto messaging_quic_client::set_session_ticket_callback(

--- a/src/core/messaging_quic_server.cpp
+++ b/src/core/messaging_quic_server.cpp
@@ -732,20 +732,20 @@ auto messaging_quic_server::cleanup_dead_sessions() -> void
 auto messaging_quic_server::invoke_connection_callback(
 	std::shared_ptr<session::quic_session> session) -> void
 {
-	callbacks_.invoke<kConnectionCallbackIndex>(session);
+	callbacks_.invoke<to_index(callback_index::connection)>(session);
 }
 
 auto messaging_quic_server::invoke_disconnection_callback(
 	std::shared_ptr<session::quic_session> session) -> void
 {
-	callbacks_.invoke<kDisconnectionCallbackIndex>(session);
+	callbacks_.invoke<to_index(callback_index::disconnection)>(session);
 }
 
 auto messaging_quic_server::invoke_receive_callback(
 	std::shared_ptr<session::quic_session> session,
 	const std::vector<uint8_t>& data) -> void
 {
-	callbacks_.invoke<kReceiveCallbackIndex>(session, data);
+	callbacks_.invoke<to_index(callback_index::receive)>(session, data);
 }
 
 auto messaging_quic_server::invoke_stream_receive_callback(
@@ -754,12 +754,12 @@ auto messaging_quic_server::invoke_stream_receive_callback(
 	const std::vector<uint8_t>& data,
 	bool fin) -> void
 {
-	callbacks_.invoke<kStreamReceiveCallbackIndex>(session, stream_id, data, fin);
+	callbacks_.invoke<to_index(callback_index::stream_receive)>(session, stream_id, data, fin);
 }
 
 auto messaging_quic_server::invoke_error_callback(std::error_code ec) -> void
 {
-	callbacks_.invoke<kErrorCallbackIndex>(ec);
+	callbacks_.invoke<to_index(callback_index::error)>(ec);
 }
 
 // =============================================================================
@@ -768,27 +768,27 @@ auto messaging_quic_server::invoke_error_callback(std::error_code ec) -> void
 
 auto messaging_quic_server::set_connection_callback(connection_callback_t callback) -> void
 {
-	callbacks_.set<kConnectionCallbackIndex>(std::move(callback));
+	callbacks_.set<to_index(callback_index::connection)>(std::move(callback));
 }
 
 auto messaging_quic_server::set_disconnection_callback(disconnection_callback_t callback) -> void
 {
-	callbacks_.set<kDisconnectionCallbackIndex>(std::move(callback));
+	callbacks_.set<to_index(callback_index::disconnection)>(std::move(callback));
 }
 
 auto messaging_quic_server::set_receive_callback(receive_callback_t callback) -> void
 {
-	callbacks_.set<kReceiveCallbackIndex>(std::move(callback));
+	callbacks_.set<to_index(callback_index::receive)>(std::move(callback));
 }
 
 auto messaging_quic_server::set_stream_receive_callback(stream_receive_callback_t callback) -> void
 {
-	callbacks_.set<kStreamReceiveCallbackIndex>(std::move(callback));
+	callbacks_.set<to_index(callback_index::stream_receive)>(std::move(callback));
 }
 
 auto messaging_quic_server::set_error_callback(error_callback_t callback) -> void
 {
-	callbacks_.set<kErrorCallbackIndex>(std::move(callback));
+	callbacks_.set<to_index(callback_index::error)>(std::move(callback));
 }
 
 // =============================================================================

--- a/src/core/messaging_server.cpp
+++ b/src/core/messaging_server.cpp
@@ -162,22 +162,22 @@ namespace kcenon::network::core
 
 	auto messaging_server::set_connection_callback(connection_callback_t callback) -> void
 	{
-		callbacks_.set<kConnectionCallback>(std::move(callback));
+		callbacks_.set<to_index(callback_index::connection)>(std::move(callback));
 	}
 
 	auto messaging_server::set_disconnection_callback(disconnection_callback_t callback) -> void
 	{
-		callbacks_.set<kDisconnectionCallback>(std::move(callback));
+		callbacks_.set<to_index(callback_index::disconnection)>(std::move(callback));
 	}
 
 	auto messaging_server::set_receive_callback(receive_callback_t callback) -> void
 	{
-		callbacks_.set<kReceiveCallback>(std::move(callback));
+		callbacks_.set<to_index(callback_index::receive)>(std::move(callback));
 	}
 
 	auto messaging_server::set_error_callback(error_callback_t callback) -> void
 	{
-		callbacks_.set<kErrorCallback>(std::move(callback));
+		callbacks_.set<to_index(callback_index::error)>(std::move(callback));
 	}
 
 	// =========================================================================
@@ -186,28 +186,28 @@ namespace kcenon::network::core
 
 	auto messaging_server::get_connection_callback() const -> connection_callback_t
 	{
-		return callbacks_.get<kConnectionCallback>();
+		return callbacks_.get<to_index(callback_index::connection)>();
 	}
 
 	auto messaging_server::get_disconnection_callback() const -> disconnection_callback_t
 	{
-		return callbacks_.get<kDisconnectionCallback>();
+		return callbacks_.get<to_index(callback_index::disconnection)>();
 	}
 
 	auto messaging_server::get_receive_callback() const -> receive_callback_t
 	{
-		return callbacks_.get<kReceiveCallback>();
+		return callbacks_.get<to_index(callback_index::receive)>();
 	}
 
 	auto messaging_server::get_error_callback() const -> error_callback_t
 	{
-		return callbacks_.get<kErrorCallback>();
+		return callbacks_.get<to_index(callback_index::error)>();
 	}
 
 	auto messaging_server::invoke_connection_callback(
 	    std::shared_ptr<session::messaging_session> session) -> void
 	{
-		callbacks_.invoke<kConnectionCallback>(std::move(session));
+		callbacks_.invoke<to_index(callback_index::connection)>(std::move(session));
 	}
 
 	// =========================================================================

--- a/src/core/messaging_udp_client.cpp
+++ b/src/core/messaging_udp_client.cpp
@@ -216,13 +216,13 @@ namespace kcenon::network::core
 		if (!callback)
 		{
 			// Clear the callback
-			callbacks_.set<kReceiveCallbackIndex>(nullptr);
+			callbacks_.set<to_index(callback_index::receive)>(nullptr);
 			return;
 		}
 
 		// Adapt the interface callback to the internal callback type
 		// Convert asio::ip::udp::endpoint to endpoint_info
-		callbacks_.set<kReceiveCallbackIndex>(
+		callbacks_.set<to_index(callback_index::receive)>(
 			[callback = std::move(callback)](
 				const std::vector<uint8_t>& data,
 				const asio::ip::udp::endpoint& endpoint)
@@ -236,12 +236,12 @@ namespace kcenon::network::core
 
 	auto messaging_udp_client::set_receive_callback(receive_callback_t callback) -> void
 	{
-		callbacks_.set<kReceiveCallbackIndex>(std::move(callback));
+		callbacks_.set<to_index(callback_index::receive)>(std::move(callback));
 	}
 
 	auto messaging_udp_client::set_error_callback(error_callback_t callback) -> void
 	{
-		callbacks_.set<kErrorCallbackIndex>(std::move(callback));
+		callbacks_.set<to_index(callback_index::error)>(std::move(callback));
 	}
 
 	// ========================================================================
@@ -398,22 +398,22 @@ namespace kcenon::network::core
 		const std::vector<uint8_t>& data,
 		const asio::ip::udp::endpoint& endpoint) -> void
 	{
-		callbacks_.invoke<kReceiveCallbackIndex>(data, endpoint);
+		callbacks_.invoke<to_index(callback_index::receive)>(data, endpoint);
 	}
 
 	auto messaging_udp_client::invoke_error_callback(std::error_code ec) -> void
 	{
-		callbacks_.invoke<kErrorCallbackIndex>(ec);
+		callbacks_.invoke<to_index(callback_index::error)>(ec);
 	}
 
 	auto messaging_udp_client::get_receive_callback() const -> receive_callback_t
 	{
-		return callbacks_.get<kReceiveCallbackIndex>();
+		return callbacks_.get<to_index(callback_index::receive)>();
 	}
 
 	auto messaging_udp_client::get_error_callback() const -> error_callback_t
 	{
-		return callbacks_.get<kErrorCallbackIndex>();
+		return callbacks_.get<to_index(callback_index::error)>();
 	}
 
 } // namespace kcenon::network::core

--- a/src/core/messaging_udp_server.cpp
+++ b/src/core/messaging_udp_server.cpp
@@ -178,13 +178,13 @@ namespace kcenon::network::core
 		if (!callback)
 		{
 			// Clear the callback
-			callbacks_.set<kReceiveCallbackIndex>(nullptr);
+			callbacks_.set<to_index(callback_index::receive)>(nullptr);
 			return;
 		}
 
 		// Adapt the interface callback to the internal callback type
 		// Convert asio::ip::udp::endpoint to endpoint_info
-		callbacks_.set<kReceiveCallbackIndex>(
+		callbacks_.set<to_index(callback_index::receive)>(
 			[callback = std::move(callback)](
 				const std::vector<uint8_t>& data,
 				const asio::ip::udp::endpoint& endpoint)
@@ -198,12 +198,12 @@ namespace kcenon::network::core
 
 	auto messaging_udp_server::set_receive_callback(receive_callback_t callback) -> void
 	{
-		callbacks_.set<kReceiveCallbackIndex>(std::move(callback));
+		callbacks_.set<to_index(callback_index::receive)>(std::move(callback));
 	}
 
 	auto messaging_udp_server::set_error_callback(error_callback_t callback) -> void
 	{
-		callbacks_.set<kErrorCallbackIndex>(std::move(callback));
+		callbacks_.set<to_index(callback_index::error)>(std::move(callback));
 	}
 
 	// ========================================================================
@@ -341,22 +341,22 @@ namespace kcenon::network::core
 		const std::vector<uint8_t>& data,
 		const asio::ip::udp::endpoint& endpoint) -> void
 	{
-		callbacks_.invoke<kReceiveCallbackIndex>(data, endpoint);
+		callbacks_.invoke<to_index(callback_index::receive)>(data, endpoint);
 	}
 
 	auto messaging_udp_server::invoke_error_callback(std::error_code ec) -> void
 	{
-		callbacks_.invoke<kErrorCallbackIndex>(ec);
+		callbacks_.invoke<to_index(callback_index::error)>(ec);
 	}
 
 	auto messaging_udp_server::get_receive_callback() const -> receive_callback_t
 	{
-		return callbacks_.get<kReceiveCallbackIndex>();
+		return callbacks_.get<to_index(callback_index::receive)>();
 	}
 
 	auto messaging_udp_server::get_error_callback() const -> error_callback_t
 	{
-		return callbacks_.get<kErrorCallbackIndex>();
+		return callbacks_.get<to_index(callback_index::error)>();
 	}
 
 } // namespace kcenon::network::core

--- a/src/core/messaging_ws_client.cpp
+++ b/src/core/messaging_ws_client.cpp
@@ -217,19 +217,19 @@ namespace kcenon::network::core
 	auto messaging_ws_client::set_text_callback(
 		interfaces::i_websocket_client::text_callback_t callback) -> void
 	{
-		callbacks_.set<kTextMessageCallbackIndex>(std::move(callback));
+		callbacks_.set<to_index(callback_index::text_message)>(std::move(callback));
 	}
 
 	auto messaging_ws_client::set_binary_callback(
 		interfaces::i_websocket_client::binary_callback_t callback) -> void
 	{
-		callbacks_.set<kBinaryMessageCallbackIndex>(std::move(callback));
+		callbacks_.set<to_index(callback_index::binary_message)>(std::move(callback));
 	}
 
 	auto messaging_ws_client::set_connected_callback(
 		interfaces::i_websocket_client::connected_callback_t callback) -> void
 	{
-		callbacks_.set<kConnectedCallbackIndex>(std::move(callback));
+		callbacks_.set<to_index(callback_index::connected)>(std::move(callback));
 	}
 
 	auto messaging_ws_client::set_disconnected_callback(
@@ -237,19 +237,19 @@ namespace kcenon::network::core
 	{
 		// Adapt interface callback to internal callback type
 		if (callback) {
-			callbacks_.set<kDisconnectedCallbackIndex>(
+			callbacks_.set<to_index(callback_index::disconnected)>(
 				[callback = std::move(callback)](internal::ws_close_code code, const std::string& reason) {
 					callback(static_cast<uint16_t>(code), reason);
 				});
 		} else {
-			callbacks_.set<kDisconnectedCallbackIndex>(disconnected_callback_t{});
+			callbacks_.set<to_index(callback_index::disconnected)>(disconnected_callback_t{});
 		}
 	}
 
 	auto messaging_ws_client::set_error_callback(
 		interfaces::i_websocket_client::error_callback_t callback) -> void
 	{
-		callbacks_.set<kErrorCallbackIndex>(std::move(callback));
+		callbacks_.set<to_index(callback_index::error)>(std::move(callback));
 	}
 
 	// ========================================================================
@@ -464,32 +464,32 @@ namespace kcenon::network::core
 
 	auto messaging_ws_client::invoke_message_callback(const internal::ws_message& msg) -> void
 	{
-		callbacks_.invoke<kMessageCallbackIndex>(msg);
+		callbacks_.invoke<to_index(callback_index::message)>(msg);
 
 		if (msg.type == internal::ws_message_type::text)
 		{
-			callbacks_.invoke<kTextMessageCallbackIndex>(msg.as_text());
+			callbacks_.invoke<to_index(callback_index::text_message)>(msg.as_text());
 		}
 		else if (msg.type == internal::ws_message_type::binary)
 		{
-			callbacks_.invoke<kBinaryMessageCallbackIndex>(msg.as_binary());
+			callbacks_.invoke<to_index(callback_index::binary_message)>(msg.as_binary());
 		}
 	}
 
 	auto messaging_ws_client::invoke_connected_callback() -> void
 	{
-		callbacks_.invoke<kConnectedCallbackIndex>();
+		callbacks_.invoke<to_index(callback_index::connected)>();
 	}
 
 	auto messaging_ws_client::invoke_disconnected_callback(internal::ws_close_code code,
 	                                                       const std::string& reason) -> void
 	{
-		callbacks_.invoke<kDisconnectedCallbackIndex>(code, reason);
+		callbacks_.invoke<to_index(callback_index::disconnected)>(code, reason);
 	}
 
 	auto messaging_ws_client::invoke_error_callback(std::error_code ec) -> void
 	{
-		callbacks_.invoke<kErrorCallbackIndex>(ec);
+		callbacks_.invoke<to_index(callback_index::error)>(ec);
 	}
 
 } // namespace kcenon::network::core

--- a/src/core/messaging_ws_server.cpp
+++ b/src/core/messaging_ws_server.cpp
@@ -300,13 +300,13 @@ namespace kcenon::network::core
 	{
 		// Adapt interface callback to internal callback type
 		if (callback) {
-			callbacks_.set<kConnectionCallbackIndex>(
+			callbacks_.set<to_index(callback_index::connection)>(
 				[callback = std::move(callback)](std::shared_ptr<ws_connection> conn) {
 					// ws_connection already implements i_websocket_session
 					callback(conn);
 				});
 		} else {
-			callbacks_.set<kConnectionCallbackIndex>(connection_callback_t{});
+			callbacks_.set<to_index(callback_index::connection)>(connection_callback_t{});
 		}
 	}
 
@@ -315,14 +315,14 @@ namespace kcenon::network::core
 	{
 		// Adapt interface callback to internal callback type
 		if (callback) {
-			callbacks_.set<kDisconnectionCallbackIndex>(
+			callbacks_.set<to_index(callback_index::disconnection)>(
 				[callback = std::move(callback)](const std::string& session_id,
 												 internal::ws_close_code code,
 												 const std::string& reason) {
 					callback(session_id, static_cast<uint16_t>(code), reason);
 				});
 		} else {
-			callbacks_.set<kDisconnectionCallbackIndex>(disconnection_callback_t{});
+			callbacks_.set<to_index(callback_index::disconnection)>(disconnection_callback_t{});
 		}
 	}
 
@@ -331,13 +331,13 @@ namespace kcenon::network::core
 	{
 		// Adapt interface callback to internal callback type
 		if (callback) {
-			callbacks_.set<kTextMessageCallbackIndex>(
+			callbacks_.set<to_index(callback_index::text_message)>(
 				[callback = std::move(callback)](std::shared_ptr<ws_connection> conn,
 												 const std::string& message) {
 					callback(conn->id(), message);
 				});
 		} else {
-			callbacks_.set<kTextMessageCallbackIndex>(text_message_callback_t{});
+			callbacks_.set<to_index(callback_index::text_message)>(text_message_callback_t{});
 		}
 	}
 
@@ -346,13 +346,13 @@ namespace kcenon::network::core
 	{
 		// Adapt interface callback to internal callback type
 		if (callback) {
-			callbacks_.set<kBinaryMessageCallbackIndex>(
+			callbacks_.set<to_index(callback_index::binary_message)>(
 				[callback = std::move(callback)](std::shared_ptr<ws_connection> conn,
 												 const std::vector<uint8_t>& data) {
 					callback(conn->id(), data);
 				});
 		} else {
-			callbacks_.set<kBinaryMessageCallbackIndex>(binary_message_callback_t{});
+			callbacks_.set<to_index(callback_index::binary_message)>(binary_message_callback_t{});
 		}
 	}
 
@@ -361,12 +361,12 @@ namespace kcenon::network::core
 	{
 		// Interface and legacy types are compatible
 		if (callback) {
-			callbacks_.set<kErrorCallbackIndex>(
+			callbacks_.set<to_index(callback_index::error)>(
 				[callback = std::move(callback)](const std::string& session_id, std::error_code ec) {
 					callback(session_id, ec);
 				});
 		} else {
-			callbacks_.set<kErrorCallbackIndex>(error_callback_t{});
+			callbacks_.set<to_index(callback_index::error)>(error_callback_t{});
 		}
 	}
 
@@ -697,35 +697,35 @@ namespace kcenon::network::core
 
 	auto messaging_ws_server::invoke_connection_callback(std::shared_ptr<ws_connection> conn) -> void
 	{
-		callbacks_.invoke<kConnectionCallbackIndex>(conn);
+		callbacks_.invoke<to_index(callback_index::connection)>(conn);
 	}
 
 	auto messaging_ws_server::invoke_disconnection_callback(const std::string& conn_id,
 	                                                        internal::ws_close_code code,
 	                                                        const std::string& reason) -> void
 	{
-		callbacks_.invoke<kDisconnectionCallbackIndex>(conn_id, code, reason);
+		callbacks_.invoke<to_index(callback_index::disconnection)>(conn_id, code, reason);
 	}
 
 	auto messaging_ws_server::invoke_message_callback(std::shared_ptr<ws_connection> conn,
 	                                                  const internal::ws_message& msg) -> void
 	{
-		callbacks_.invoke<kMessageCallbackIndex>(conn, msg);
+		callbacks_.invoke<to_index(callback_index::message)>(conn, msg);
 
 		if (msg.type == internal::ws_message_type::text)
 		{
-			callbacks_.invoke<kTextMessageCallbackIndex>(conn, msg.as_text());
+			callbacks_.invoke<to_index(callback_index::text_message)>(conn, msg.as_text());
 		}
 		else if (msg.type == internal::ws_message_type::binary)
 		{
-			callbacks_.invoke<kBinaryMessageCallbackIndex>(conn, msg.as_binary());
+			callbacks_.invoke<to_index(callback_index::binary_message)>(conn, msg.as_binary());
 		}
 	}
 
 	auto messaging_ws_server::invoke_error_callback(const std::string& conn_id,
 	                                                std::error_code ec) -> void
 	{
-		callbacks_.invoke<kErrorCallbackIndex>(conn_id, ec);
+		callbacks_.invoke<to_index(callback_index::error)>(conn_id, ec);
 	}
 
 } // namespace kcenon::network::core

--- a/src/core/secure_messaging_client.cpp
+++ b/src/core/secure_messaging_client.cpp
@@ -199,19 +199,19 @@ auto secure_messaging_client::send_packet(std::vector<uint8_t>&& data) -> VoidRe
 // =====================================================================
 
 auto secure_messaging_client::set_receive_callback(receive_callback_t callback) -> void {
-  callbacks_.set<kReceiveCallback>(std::move(callback));
+  callbacks_.set<to_index(callback_index::receive)>(std::move(callback));
 }
 
 auto secure_messaging_client::set_connected_callback(connected_callback_t callback) -> void {
-  callbacks_.set<kConnectedCallback>(std::move(callback));
+  callbacks_.set<to_index(callback_index::connected)>(std::move(callback));
 }
 
 auto secure_messaging_client::set_disconnected_callback(disconnected_callback_t callback) -> void {
-  callbacks_.set<kDisconnectedCallback>(std::move(callback));
+  callbacks_.set<to_index(callback_index::disconnected)>(std::move(callback));
 }
 
 auto secure_messaging_client::set_error_callback(error_callback_t callback) -> void {
-  callbacks_.set<kErrorCallback>(std::move(callback));
+  callbacks_.set<to_index(callback_index::error)>(std::move(callback));
 }
 
 // =====================================================================
@@ -223,19 +223,19 @@ auto secure_messaging_client::set_connected(bool connected) -> void {
 }
 
 auto secure_messaging_client::invoke_receive_callback(const std::vector<uint8_t>& data) -> void {
-  callbacks_.invoke<kReceiveCallback>(data);
+  callbacks_.invoke<to_index(callback_index::receive)>(data);
 }
 
 auto secure_messaging_client::invoke_connected_callback() -> void {
-  callbacks_.invoke<kConnectedCallback>();
+  callbacks_.invoke<to_index(callback_index::connected)>();
 }
 
 auto secure_messaging_client::invoke_disconnected_callback() -> void {
-  callbacks_.invoke<kDisconnectedCallback>();
+  callbacks_.invoke<to_index(callback_index::disconnected)>();
 }
 
 auto secure_messaging_client::invoke_error_callback(std::error_code ec) -> void {
-  callbacks_.invoke<kErrorCallback>(ec);
+  callbacks_.invoke<to_index(callback_index::error)>(ec);
 }
 
 // =====================================================================

--- a/src/core/secure_messaging_server.cpp
+++ b/src/core/secure_messaging_server.cpp
@@ -183,22 +183,22 @@ namespace kcenon::network::core
 
 	auto secure_messaging_server::set_connection_callback(connection_callback_t callback) -> void
 	{
-		callbacks_.set<kConnectionCallback>(std::move(callback));
+		callbacks_.set<to_index(callback_index::connection)>(std::move(callback));
 	}
 
 	auto secure_messaging_server::set_disconnection_callback(disconnection_callback_t callback) -> void
 	{
-		callbacks_.set<kDisconnectionCallback>(std::move(callback));
+		callbacks_.set<to_index(callback_index::disconnection)>(std::move(callback));
 	}
 
 	auto secure_messaging_server::set_receive_callback(receive_callback_t callback) -> void
 	{
-		callbacks_.set<kReceiveCallback>(std::move(callback));
+		callbacks_.set<to_index(callback_index::receive)>(std::move(callback));
 	}
 
 	auto secure_messaging_server::set_error_callback(error_callback_t callback) -> void
 	{
-		callbacks_.set<kErrorCallback>(std::move(callback));
+		callbacks_.set<to_index(callback_index::error)>(std::move(callback));
 	}
 
 	// =====================================================================
@@ -207,28 +207,28 @@ namespace kcenon::network::core
 
 	auto secure_messaging_server::get_connection_callback() const -> connection_callback_t
 	{
-		return callbacks_.get<kConnectionCallback>();
+		return callbacks_.get<to_index(callback_index::connection)>();
 	}
 
 	auto secure_messaging_server::get_disconnection_callback() const -> disconnection_callback_t
 	{
-		return callbacks_.get<kDisconnectionCallback>();
+		return callbacks_.get<to_index(callback_index::disconnection)>();
 	}
 
 	auto secure_messaging_server::get_receive_callback() const -> receive_callback_t
 	{
-		return callbacks_.get<kReceiveCallback>();
+		return callbacks_.get<to_index(callback_index::receive)>();
 	}
 
 	auto secure_messaging_server::get_error_callback() const -> error_callback_t
 	{
-		return callbacks_.get<kErrorCallback>();
+		return callbacks_.get<to_index(callback_index::error)>();
 	}
 
 	auto secure_messaging_server::invoke_connection_callback(
 		std::shared_ptr<session::secure_session> session) -> void
 	{
-		callbacks_.invoke<kConnectionCallback>(session);
+		callbacks_.invoke<to_index(callback_index::connection)>(session);
 	}
 
 	// =====================================================================

--- a/src/core/secure_messaging_udp_client.cpp
+++ b/src/core/secure_messaging_udp_client.cpp
@@ -205,22 +205,22 @@ auto secure_messaging_udp_client::set_udp_receive_callback(
 
 auto secure_messaging_udp_client::set_receive_callback(receive_callback_t callback) -> void
 {
-	callbacks_.set<kReceiveCallback>(std::move(callback));
+	callbacks_.set<to_index(callback_index::receive)>(std::move(callback));
 }
 
 auto secure_messaging_udp_client::set_connected_callback(connected_callback_t callback) -> void
 {
-	callbacks_.set<kConnectedCallback>(std::move(callback));
+	callbacks_.set<to_index(callback_index::connected)>(std::move(callback));
 }
 
 auto secure_messaging_udp_client::set_disconnected_callback(disconnected_callback_t callback) -> void
 {
-	callbacks_.set<kDisconnectedCallback>(std::move(callback));
+	callbacks_.set<to_index(callback_index::disconnected)>(std::move(callback));
 }
 
 auto secure_messaging_udp_client::set_error_callback(error_callback_t callback) -> void
 {
-	callbacks_.set<kErrorCallback>(std::move(callback));
+	callbacks_.set<to_index(callback_index::error)>(std::move(callback));
 }
 
 // =====================================================================
@@ -234,22 +234,22 @@ auto secure_messaging_udp_client::set_connected(bool connected) -> void
 
 auto secure_messaging_udp_client::invoke_receive_callback(const std::vector<uint8_t>& data) -> void
 {
-	callbacks_.invoke<kReceiveCallback>(data);
+	callbacks_.invoke<to_index(callback_index::receive)>(data);
 }
 
 auto secure_messaging_udp_client::invoke_connected_callback() -> void
 {
-	callbacks_.invoke<kConnectedCallback>();
+	callbacks_.invoke<to_index(callback_index::connected)>();
 }
 
 auto secure_messaging_udp_client::invoke_disconnected_callback() -> void
 {
-	callbacks_.invoke<kDisconnectedCallback>();
+	callbacks_.invoke<to_index(callback_index::disconnected)>();
 }
 
 auto secure_messaging_udp_client::invoke_error_callback(std::error_code ec) -> void
 {
-	callbacks_.invoke<kErrorCallback>(ec);
+	callbacks_.invoke<to_index(callback_index::error)>(ec);
 }
 
 // =====================================================================


### PR DESCRIPTION
Closes #499

## Summary
- Add `callback_indices.h` with strongly-typed enums for all client/server callback types
- Replace magic number indices (0, 1, 2, 3...) with named enum values
- Add `to_index()` helper function for safe enum-to-size_t conversion
- Update all 10 client/server classes to use the new enum-based approach

## Changes

### New File
- `include/kcenon/network/core/callback_indices.h` - Contains:
  - `tcp_client_callback` / `tcp_server_callback`
  - `udp_client_callback` / `udp_server_callback` / `secure_udp_client_callback`
  - `ws_client_callback` / `ws_server_callback`
  - `quic_client_callback` / `quic_server_callback`
  - `to_index<E>()` helper template

### Modified Headers (11 files)
All client/server headers updated to:
- Include `callback_indices.h`
- Replace `static constexpr std::size_t` indices with `using callback_index = ...` type alias

### Modified Sources (11 files)
All callback usages updated from:
```cpp
callbacks_.invoke<kReceiveCallback>(data);  // What is 0?
```
to:
```cpp
callbacks_.invoke<to_index(callback_index::receive)>(data);  // Clear intent
```

## Test Plan
- [x] Build succeeds with Release configuration
- [x] 99% of tests pass (1166/1170)
- [x] Failed tests are unrelated timing/network tests (pre-existing)