### PR TITLE
refactor(policy): define TLS policy interfaces and protocol tags

### DIFF
--- a/include/kcenon/network/policy/tls_policy.h
+++ b/include/kcenon/network/policy/tls_policy.h
@@ -1,0 +1,118 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, 🍀☀🌕🌥 🌊
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include <concepts>
+#include <string>
+#include <type_traits>
+
+namespace kcenon::network::policy {
+
+/*!
+ * \struct no_tls
+ * \brief Policy type indicating no TLS/SSL encryption.
+ *
+ * This policy is used as a template parameter to indicate that
+ * plain-text communication should be used without encryption.
+ *
+ * ### Usage
+ * \code
+ * messaging_client<tcp_protocol, no_tls> plain_client;
+ * \endcode
+ */
+struct no_tls {
+    static constexpr bool enabled = false;
+};
+
+/*!
+ * \struct tls_enabled
+ * \brief Policy type indicating TLS/SSL encryption is enabled.
+ *
+ * This policy carries configuration for TLS connections including
+ * certificate paths and verification settings.
+ *
+ * ### Usage
+ * \code
+ * tls_enabled tls_config{
+ *     .cert_path = "/path/to/cert.pem",
+ *     .key_path = "/path/to/key.pem",
+ *     .ca_path = "/path/to/ca.pem",
+ *     .verify_peer = true
+ * };
+ * messaging_client<tcp_protocol, tls_enabled> secure_client;
+ * \endcode
+ */
+struct tls_enabled {
+    static constexpr bool enabled = true;
+
+    std::string cert_path{};
+    std::string key_path{};
+    std::string ca_path{};
+    bool verify_peer{true};
+};
+
+/*!
+ * \concept TlsPolicy
+ * \brief Concept that constrains types to be valid TLS policies.
+ *
+ * A valid TLS policy must have a static constexpr bool member `enabled`
+ * that indicates whether TLS is active.
+ *
+ * ### Satisfied Types
+ * - `no_tls` - TLS disabled
+ * - `tls_enabled` - TLS enabled with configuration
+ *
+ * ### Usage
+ * \code
+ * template<TlsPolicy Policy>
+ * class connection_handler { ... };
+ * \endcode
+ */
+template <typename T>
+concept TlsPolicy = requires {
+    { T::enabled } -> std::convertible_to<bool>;
+};
+
+/*!
+ * \brief Helper variable template to check if TLS is enabled at compile time.
+ */
+template <TlsPolicy Policy>
+inline constexpr bool is_tls_enabled_v = Policy::enabled;
+
+/*!
+ * \brief Type trait to check if a policy enables TLS.
+ */
+template <TlsPolicy Policy>
+struct is_tls_enabled : std::bool_constant<Policy::enabled> {};
+
+}  // namespace kcenon::network::policy

--- a/include/kcenon/network/protocol/protocol_tags.h
+++ b/include/kcenon/network/protocol/protocol_tags.h
@@ -1,0 +1,175 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, 🍀☀🌕🌥 🌊
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include <concepts>
+#include <string_view>
+#include <type_traits>
+
+namespace kcenon::network::protocol {
+
+/*!
+ * \struct tcp_protocol
+ * \brief Protocol tag for TCP transport.
+ *
+ * Represents the Transmission Control Protocol (TCP), a connection-oriented
+ * protocol that provides reliable, ordered delivery of data streams.
+ *
+ * ### Characteristics
+ * - Connection-oriented
+ * - Reliable delivery with acknowledgments
+ * - Ordered packet delivery
+ * - Flow control and congestion control
+ */
+struct tcp_protocol {
+    static constexpr std::string_view name{"tcp"};
+    static constexpr bool is_connection_oriented = true;
+    static constexpr bool is_reliable = true;
+};
+
+/*!
+ * \struct udp_protocol
+ * \brief Protocol tag for UDP transport.
+ *
+ * Represents the User Datagram Protocol (UDP), a connectionless protocol
+ * that provides fast, unreliable delivery of individual datagrams.
+ *
+ * ### Characteristics
+ * - Connectionless
+ * - Unreliable delivery (best-effort)
+ * - No ordering guarantees
+ * - Low overhead
+ */
+struct udp_protocol {
+    static constexpr std::string_view name{"udp"};
+    static constexpr bool is_connection_oriented = false;
+    static constexpr bool is_reliable = false;
+};
+
+/*!
+ * \struct websocket_protocol
+ * \brief Protocol tag for WebSocket transport.
+ *
+ * Represents the WebSocket protocol, providing full-duplex communication
+ * channels over a single TCP connection with HTTP upgrade handshake.
+ *
+ * ### Characteristics
+ * - Connection-oriented (over TCP)
+ * - Full-duplex communication
+ * - Frame-based messaging
+ * - HTTP upgrade handshake
+ */
+struct websocket_protocol {
+    static constexpr std::string_view name{"websocket"};
+    static constexpr bool is_connection_oriented = true;
+    static constexpr bool is_reliable = true;
+};
+
+/*!
+ * \struct quic_protocol
+ * \brief Protocol tag for QUIC transport.
+ *
+ * Represents the QUIC protocol, a modern transport protocol built on UDP
+ * that provides multiplexed connections with built-in TLS 1.3 encryption.
+ *
+ * ### Characteristics
+ * - Built on UDP with reliability layer
+ * - Multiplexed streams
+ * - Built-in encryption (TLS 1.3)
+ * - Reduced connection establishment latency (0-RTT)
+ */
+struct quic_protocol {
+    static constexpr std::string_view name{"quic"};
+    static constexpr bool is_connection_oriented = true;
+    static constexpr bool is_reliable = true;
+};
+
+/*!
+ * \concept Protocol
+ * \brief Concept that constrains types to be valid protocol tags.
+ *
+ * A valid protocol tag must have:
+ * - A static constexpr `name` member convertible to `std::string_view`
+ * - A static constexpr bool `is_connection_oriented` member
+ * - A static constexpr bool `is_reliable` member
+ *
+ * ### Satisfied Types
+ * - `tcp_protocol`
+ * - `udp_protocol`
+ * - `websocket_protocol`
+ * - `quic_protocol`
+ *
+ * ### Usage
+ * \code
+ * template<Protocol P, TlsPolicy T = no_tls>
+ * class messaging_client { ... };
+ * \endcode
+ */
+template <typename T>
+concept Protocol = requires {
+    { T::name } -> std::convertible_to<std::string_view>;
+    { T::is_connection_oriented } -> std::convertible_to<bool>;
+    { T::is_reliable } -> std::convertible_to<bool>;
+};
+
+/*!
+ * \brief Helper variable template to check if protocol is connection-oriented.
+ */
+template <Protocol P>
+inline constexpr bool is_connection_oriented_v = P::is_connection_oriented;
+
+/*!
+ * \brief Helper variable template to check if protocol is reliable.
+ */
+template <Protocol P>
+inline constexpr bool is_reliable_v = P::is_reliable;
+
+/*!
+ * \brief Helper variable template to get protocol name.
+ */
+template <Protocol P>
+inline constexpr std::string_view protocol_name_v = P::name;
+
+/*!
+ * \brief Type trait to check if a protocol is connection-oriented.
+ */
+template <Protocol P>
+struct is_connection_oriented : std::bool_constant<P::is_connection_oriented> {};
+
+/*!
+ * \brief Type trait to check if a protocol is reliable.
+ */
+template <Protocol P>
+struct is_reliable : std::bool_constant<P::is_reliable> {};
+
+}  // namespace kcenon::network::protocol

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -533,6 +533,38 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
     message(STATUS "Interface tests enabled")
 
+    # Policy and Protocol tests
+    add_executable(network_policy_protocol_test
+        unit/test_policy_protocol.cpp
+    )
+
+    target_link_libraries(network_policy_protocol_test PRIVATE
+        NetworkSystem
+        GTest::gtest
+        GTest::gtest_main
+        Threads::Threads
+    )
+
+    # Setup ASIO integration
+    setup_asio_integration(network_policy_protocol_test)
+
+    # Add system integration paths
+    if(COMMON_SYSTEM_INCLUDE_DIR)
+        target_include_directories(network_policy_protocol_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+        target_compile_definitions(network_policy_protocol_test PRIVATE WITH_COMMON_SYSTEM)
+    endif()
+
+    set_target_properties(network_policy_protocol_test PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    )
+
+    gtest_discover_tests(network_policy_protocol_test
+        DISCOVERY_TIMEOUT 60
+    )
+    message(STATUS "Policy and protocol tests enabled")
+
     # UDP composition tests
     add_executable(network_udp_composition_test
         unit/test_udp_composition.cpp

--- a/tests/unit/test_policy_protocol.cpp
+++ b/tests/unit/test_policy_protocol.cpp
@@ -1,0 +1,237 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <type_traits>
+
+#include "kcenon/network/policy/tls_policy.h"
+#include "kcenon/network/protocol/protocol_tags.h"
+
+using namespace kcenon::network::policy;
+using namespace kcenon::network::protocol;
+
+// ============================================================================
+// TLS Policy Tests
+// ============================================================================
+
+class TlsPolicyTest : public ::testing::Test {};
+
+TEST_F(TlsPolicyTest, NoTlsHasEnabledFalse) {
+    EXPECT_FALSE(no_tls::enabled);
+}
+
+TEST_F(TlsPolicyTest, TlsEnabledHasEnabledTrue) {
+    EXPECT_TRUE(tls_enabled::enabled);
+}
+
+TEST_F(TlsPolicyTest, NoTlsSatisfiesTlsPolicyConcept) {
+    EXPECT_TRUE(TlsPolicy<no_tls>);
+}
+
+TEST_F(TlsPolicyTest, TlsEnabledSatisfiesTlsPolicyConcept) {
+    EXPECT_TRUE(TlsPolicy<tls_enabled>);
+}
+
+TEST_F(TlsPolicyTest, IsTlsEnabledVariableTemplate) {
+    EXPECT_FALSE(is_tls_enabled_v<no_tls>);
+    EXPECT_TRUE(is_tls_enabled_v<tls_enabled>);
+}
+
+TEST_F(TlsPolicyTest, IsTlsEnabledTypeTrait) {
+    EXPECT_FALSE(is_tls_enabled<no_tls>::value);
+    EXPECT_TRUE(is_tls_enabled<tls_enabled>::value);
+}
+
+TEST_F(TlsPolicyTest, TlsEnabledDefaultConfiguration) {
+    tls_enabled config{};
+    EXPECT_TRUE(config.cert_path.empty());
+    EXPECT_TRUE(config.key_path.empty());
+    EXPECT_TRUE(config.ca_path.empty());
+    EXPECT_TRUE(config.verify_peer);
+}
+
+TEST_F(TlsPolicyTest, TlsEnabledCustomConfiguration) {
+    tls_enabled config{
+        .cert_path = "/path/to/cert.pem",
+        .key_path = "/path/to/key.pem",
+        .ca_path = "/path/to/ca.pem",
+        .verify_peer = false
+    };
+
+    EXPECT_EQ(config.cert_path, "/path/to/cert.pem");
+    EXPECT_EQ(config.key_path, "/path/to/key.pem");
+    EXPECT_EQ(config.ca_path, "/path/to/ca.pem");
+    EXPECT_FALSE(config.verify_peer);
+}
+
+// ============================================================================
+// Protocol Tags Tests
+// ============================================================================
+
+class ProtocolTagsTest : public ::testing::Test {};
+
+TEST_F(ProtocolTagsTest, TcpProtocolName) {
+    EXPECT_EQ(tcp_protocol::name, "tcp");
+}
+
+TEST_F(ProtocolTagsTest, UdpProtocolName) {
+    EXPECT_EQ(udp_protocol::name, "udp");
+}
+
+TEST_F(ProtocolTagsTest, WebsocketProtocolName) {
+    EXPECT_EQ(websocket_protocol::name, "websocket");
+}
+
+TEST_F(ProtocolTagsTest, QuicProtocolName) {
+    EXPECT_EQ(quic_protocol::name, "quic");
+}
+
+TEST_F(ProtocolTagsTest, TcpProtocolIsConnectionOriented) {
+    EXPECT_TRUE(tcp_protocol::is_connection_oriented);
+}
+
+TEST_F(ProtocolTagsTest, UdpProtocolIsNotConnectionOriented) {
+    EXPECT_FALSE(udp_protocol::is_connection_oriented);
+}
+
+TEST_F(ProtocolTagsTest, WebsocketProtocolIsConnectionOriented) {
+    EXPECT_TRUE(websocket_protocol::is_connection_oriented);
+}
+
+TEST_F(ProtocolTagsTest, QuicProtocolIsConnectionOriented) {
+    EXPECT_TRUE(quic_protocol::is_connection_oriented);
+}
+
+TEST_F(ProtocolTagsTest, TcpProtocolIsReliable) {
+    EXPECT_TRUE(tcp_protocol::is_reliable);
+}
+
+TEST_F(ProtocolTagsTest, UdpProtocolIsNotReliable) {
+    EXPECT_FALSE(udp_protocol::is_reliable);
+}
+
+TEST_F(ProtocolTagsTest, WebsocketProtocolIsReliable) {
+    EXPECT_TRUE(websocket_protocol::is_reliable);
+}
+
+TEST_F(ProtocolTagsTest, QuicProtocolIsReliable) {
+    EXPECT_TRUE(quic_protocol::is_reliable);
+}
+
+// ============================================================================
+// Protocol Concept Tests
+// ============================================================================
+
+TEST_F(ProtocolTagsTest, TcpProtocolSatisfiesProtocolConcept) {
+    EXPECT_TRUE(Protocol<tcp_protocol>);
+}
+
+TEST_F(ProtocolTagsTest, UdpProtocolSatisfiesProtocolConcept) {
+    EXPECT_TRUE(Protocol<udp_protocol>);
+}
+
+TEST_F(ProtocolTagsTest, WebsocketProtocolSatisfiesProtocolConcept) {
+    EXPECT_TRUE(Protocol<websocket_protocol>);
+}
+
+TEST_F(ProtocolTagsTest, QuicProtocolSatisfiesProtocolConcept) {
+    EXPECT_TRUE(Protocol<quic_protocol>);
+}
+
+// ============================================================================
+// Protocol Helper Variable Templates Tests
+// ============================================================================
+
+TEST_F(ProtocolTagsTest, IsConnectionOrientedVariableTemplate) {
+    EXPECT_TRUE(is_connection_oriented_v<tcp_protocol>);
+    EXPECT_FALSE(is_connection_oriented_v<udp_protocol>);
+    EXPECT_TRUE(is_connection_oriented_v<websocket_protocol>);
+    EXPECT_TRUE(is_connection_oriented_v<quic_protocol>);
+}
+
+TEST_F(ProtocolTagsTest, IsReliableVariableTemplate) {
+    EXPECT_TRUE(is_reliable_v<tcp_protocol>);
+    EXPECT_FALSE(is_reliable_v<udp_protocol>);
+    EXPECT_TRUE(is_reliable_v<websocket_protocol>);
+    EXPECT_TRUE(is_reliable_v<quic_protocol>);
+}
+
+TEST_F(ProtocolTagsTest, ProtocolNameVariableTemplate) {
+    EXPECT_EQ(protocol_name_v<tcp_protocol>, "tcp");
+    EXPECT_EQ(protocol_name_v<udp_protocol>, "udp");
+    EXPECT_EQ(protocol_name_v<websocket_protocol>, "websocket");
+    EXPECT_EQ(protocol_name_v<quic_protocol>, "quic");
+}
+
+// ============================================================================
+// Protocol Type Trait Tests
+// ============================================================================
+
+TEST_F(ProtocolTagsTest, IsConnectionOrientedTypeTrait) {
+    EXPECT_TRUE(is_connection_oriented<tcp_protocol>::value);
+    EXPECT_FALSE(is_connection_oriented<udp_protocol>::value);
+}
+
+TEST_F(ProtocolTagsTest, IsReliableTypeTrait) {
+    EXPECT_TRUE(is_reliable<tcp_protocol>::value);
+    EXPECT_FALSE(is_reliable<udp_protocol>::value);
+}
+
+// ============================================================================
+// Compile-Time Usage Tests
+// ============================================================================
+
+namespace {
+
+template <Protocol P, TlsPolicy T>
+struct mock_client {
+    static constexpr std::string_view protocol_name() { return P::name; }
+    static constexpr bool uses_tls() { return T::enabled; }
+};
+
+}  // namespace
+
+TEST_F(ProtocolTagsTest, TemplateInstantiationWithPolicies) {
+    using plain_tcp_client = mock_client<tcp_protocol, no_tls>;
+    using secure_tcp_client = mock_client<tcp_protocol, tls_enabled>;
+    using plain_udp_client = mock_client<udp_protocol, no_tls>;
+
+    EXPECT_EQ(plain_tcp_client::protocol_name(), "tcp");
+    EXPECT_FALSE(plain_tcp_client::uses_tls());
+
+    EXPECT_EQ(secure_tcp_client::protocol_name(), "tcp");
+    EXPECT_TRUE(secure_tcp_client::uses_tls());
+
+    EXPECT_EQ(plain_udp_client::protocol_name(), "udp");
+    EXPECT_FALSE(plain_udp_client::uses_tls());
+}


### PR DESCRIPTION
Closes #506

## Summary

- Add TLS policies (`no_tls`, `tls_enabled`) with compile-time configuration
- Add protocol tags (`tcp_protocol`, `udp_protocol`, `websocket_protocol`, `quic_protocol`)
- Include C++20 concepts (`TlsPolicy`, `Protocol`) for type constraints
- Add helper variable templates and type traits
- Include comprehensive unit tests (30 tests)

This is Part 1 of #503 - establishing the foundation for consolidating secure/non-secure class hierarchies into unified templates.

## Test Plan

- [x] All 30 unit tests pass (`network_policy_protocol_test`)
- [x] Build succeeds with Release configuration
- [x] New headers compile correctly with existing codebase