### PR TITLE
refactor(compat): add backward-compatible type aliases for unified templates

### DIFF
--- a/include/kcenon/network/compat/unified_compat.h
+++ b/include/kcenon/network/compat/unified_compat.h
@@ -1,0 +1,196 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+*****************************************************************************/
+
+#pragma once
+
+/**
+ * @file unified_compat.h
+ * @brief Backward-compatible type aliases for unified messaging templates.
+ *
+ * This header provides type aliases that map the old class names to the new
+ * unified template instantiations. This allows existing code to continue
+ * working while migrating to the new API.
+ *
+ * ## Provided Aliases
+ *
+ * | Old Name | New Type |
+ * |----------|----------|
+ * | `messaging_client_compat` | `unified_messaging_client<tcp_protocol, no_tls>` |
+ * | `secure_messaging_client_compat` | `unified_messaging_client<tcp_protocol, tls_enabled>` |
+ * | `messaging_server_compat` | `unified_messaging_server<tcp_protocol, no_tls>` |
+ * | `secure_messaging_server_compat` | `unified_messaging_server<tcp_protocol, tls_enabled>` |
+ *
+ * ## Migration Guide
+ *
+ * ### Step 1: Include the new header
+ * @code
+ * // Old code:
+ * #include <kcenon/network/core/messaging_client.h>
+ *
+ * // New code:
+ * #include <kcenon/network/core/unified_messaging_client.h>
+ * @endcode
+ *
+ * ### Step 2: Use the new type aliases (optional)
+ * @code
+ * // Old code:
+ * auto client = std::make_shared<messaging_client>("client1");
+ *
+ * // New code (option 1 - use tcp_client alias):
+ * auto client = std::make_shared<tcp_client>("client1");
+ *
+ * // New code (option 2 - use full template):
+ * auto client = std::make_shared<unified_messaging_client<tcp_protocol>>("client1");
+ * @endcode
+ *
+ * ### Step 3: For secure clients
+ * @code
+ * // Old code:
+ * auto client = std::make_shared<secure_messaging_client>("client1");
+ *
+ * // New code:
+ * tls_enabled tls_config{
+ *     .cert_path = "cert.pem",
+ *     .key_path = "key.pem"
+ * };
+ * auto client = std::make_shared<secure_tcp_client>("client1", tls_config);
+ * @endcode
+ *
+ * ## Breaking Changes
+ *
+ * The unified templates are API-compatible with the old classes for most use cases.
+ * Notable differences:
+ *
+ * 1. **TLS Configuration**: Secure variants now require explicit TLS configuration
+ *    passed to the constructor instead of being configured after construction.
+ *
+ * 2. **Template Parameters**: The new API uses template parameters for protocol
+ *    and TLS policy selection, enabling compile-time optimization.
+ *
+ * 3. **Namespace**: Type aliases are in `kcenon::network::core` namespace.
+ *
+ * @see unified_messaging_client
+ * @see unified_messaging_server
+ */
+
+#include "kcenon/network/core/unified_messaging_client.h"
+#include "kcenon/network/core/unified_messaging_server.h"
+
+namespace kcenon::network::compat {
+
+// ============================================================================
+// Deprecation Macros
+// ============================================================================
+
+/**
+ * @def NETWORK_DEPRECATED
+ * @brief Marks a declaration as deprecated with a custom message.
+ *
+ * Uses [[deprecated]] attribute for C++14+ compilers.
+ */
+#if defined(__cplusplus) && __cplusplus >= 201402L
+#    define NETWORK_DEPRECATED(msg) [[deprecated(msg)]]
+#elif defined(__GNUC__) || defined(__clang__)
+#    define NETWORK_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#elif defined(_MSC_VER)
+#    define NETWORK_DEPRECATED(msg) __declspec(deprecated(msg))
+#else
+#    define NETWORK_DEPRECATED(msg)
+#endif
+
+// ============================================================================
+// Backward-Compatible Type Aliases (TCP)
+// ============================================================================
+
+/**
+ * @brief Backward-compatible alias for plain TCP messaging client.
+ *
+ * @deprecated Use `tcp_client` or `unified_messaging_client<tcp_protocol>` instead.
+ *
+ * @code
+ * // Migration:
+ * // Old: std::make_shared<messaging_client_compat>("id")
+ * // New: std::make_shared<tcp_client>("id")
+ * @endcode
+ */
+using messaging_client_compat NETWORK_DEPRECATED(
+    "Use tcp_client or unified_messaging_client<tcp_protocol> instead") =
+    core::unified_messaging_client<protocol::tcp_protocol, policy::no_tls>;
+
+/**
+ * @brief Backward-compatible alias for plain TCP messaging server.
+ *
+ * @deprecated Use `tcp_server` or `unified_messaging_server<tcp_protocol>` instead.
+ */
+using messaging_server_compat NETWORK_DEPRECATED(
+    "Use tcp_server or unified_messaging_server<tcp_protocol> instead") =
+    core::unified_messaging_server<protocol::tcp_protocol, policy::no_tls>;
+
+#ifdef BUILD_TLS_SUPPORT
+/**
+ * @brief Backward-compatible alias for secure TCP messaging client.
+ *
+ * @deprecated Use `secure_tcp_client` or
+ *             `unified_messaging_client<tcp_protocol, tls_enabled>` instead.
+ */
+using secure_messaging_client_compat NETWORK_DEPRECATED(
+    "Use secure_tcp_client or unified_messaging_client<tcp_protocol, tls_enabled> instead") =
+    core::unified_messaging_client<protocol::tcp_protocol, policy::tls_enabled>;
+
+/**
+ * @brief Backward-compatible alias for secure TCP messaging server.
+ *
+ * @deprecated Use `secure_tcp_server` or
+ *             `unified_messaging_server<tcp_protocol, tls_enabled>` instead.
+ */
+using secure_messaging_server_compat NETWORK_DEPRECATED(
+    "Use secure_tcp_server or unified_messaging_server<tcp_protocol, tls_enabled> instead") =
+    core::unified_messaging_server<protocol::tcp_protocol, policy::tls_enabled>;
+#endif  // BUILD_TLS_SUPPORT
+
+// ============================================================================
+// Non-Deprecated Convenience Aliases
+// ============================================================================
+
+/**
+ * @brief Plain TCP client (non-deprecated convenience alias).
+ *
+ * This alias is provided for users who want to use the compatibility header
+ * but don't want deprecation warnings.
+ */
+using plain_tcp_client = core::tcp_client;
+
+/**
+ * @brief Plain TCP server (non-deprecated convenience alias).
+ */
+using plain_tcp_server = core::tcp_server;
+
+#ifdef BUILD_TLS_SUPPORT
+/**
+ * @brief Secure TCP client (non-deprecated convenience alias).
+ */
+using tls_tcp_client = core::secure_tcp_client;
+
+/**
+ * @brief Secure TCP server (non-deprecated convenience alias).
+ */
+using tls_tcp_server = core::secure_tcp_server;
+#endif  // BUILD_TLS_SUPPORT
+
+}  // namespace kcenon::network::compat
+
+// ============================================================================
+// Global Namespace Aliases (for ease of migration)
+// ============================================================================
+
+namespace kcenon::network::core {
+
+// Re-export protocol and policy types for convenience
+using namespace kcenon::network::protocol;
+using namespace kcenon::network::policy;
+
+}  // namespace kcenon::network::core

--- a/include/kcenon/network/network_system.h
+++ b/include/kcenon/network/network_system.h
@@ -44,6 +44,14 @@
 #include "kcenon/network/core/messaging_client.h"
 #include "kcenon/network/core/messaging_server.h"
 
+// Unified templates with protocol/TLS policy parameters
+#include "kcenon/network/core/unified_messaging_client.h"
+#include "kcenon/network/core/unified_messaging_server.h"
+
+// Protocol tags and TLS policies for unified templates
+#include "kcenon/network/protocol/protocol_tags.h"
+#include "kcenon/network/policy/tls_policy.h"
+
 // Session management
 #include "kcenon/network/session/messaging_session.h"
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -649,6 +649,48 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
     message(STATUS "Unified messaging server tests enabled")
 
+    # Unified compat alias tests
+    add_executable(network_unified_compat_test
+        unit/test_unified_compat.cpp
+    )
+
+    target_link_libraries(network_unified_compat_test PRIVATE
+        NetworkSystem
+        GTest::gtest
+        GTest::gtest_main
+        Threads::Threads
+    )
+
+    # Setup ASIO integration
+    setup_asio_integration(network_unified_compat_test)
+
+    # Add system integration paths
+    if(COMMON_SYSTEM_INCLUDE_DIR)
+        target_include_directories(network_unified_compat_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+        target_compile_definitions(network_unified_compat_test PRIVATE WITH_COMMON_SYSTEM)
+    endif()
+
+    if(THREAD_SYSTEM_INCLUDE_DIR)
+        target_include_directories(network_unified_compat_test PRIVATE ${THREAD_SYSTEM_INCLUDE_DIR})
+        target_compile_definitions(network_unified_compat_test PRIVATE WITH_THREAD_SYSTEM)
+    endif()
+
+    if(LOGGER_SYSTEM_INCLUDE_DIR)
+        target_include_directories(network_unified_compat_test PRIVATE ${LOGGER_SYSTEM_INCLUDE_DIR})
+        target_compile_definitions(network_unified_compat_test PRIVATE WITH_LOGGER_SYSTEM)
+    endif()
+
+    set_target_properties(network_unified_compat_test PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    )
+
+    gtest_discover_tests(network_unified_compat_test
+        DISCOVERY_TIMEOUT 60
+    )
+    message(STATUS "Unified compat alias tests enabled")
+
     # UDP composition tests
     add_executable(network_udp_composition_test
         unit/test_udp_composition.cpp

--- a/tests/unit/test_unified_compat.cpp
+++ b/tests/unit/test_unified_compat.cpp
@@ -1,0 +1,151 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+*****************************************************************************/
+
+#include "kcenon/network/compat/unified_compat.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <type_traits>
+
+using namespace kcenon::network;
+
+/**
+ * @file test_unified_compat.cpp
+ * @brief Unit tests for backward-compatible type aliases in unified_compat.h
+ *
+ * Tests validate:
+ * - Type aliases resolve to correct unified template instantiations
+ * - Convenience aliases work without deprecation warnings
+ * - Protocol and policy types are accessible via core namespace
+ */
+
+// ============================================================================
+// Type Alias Resolution Tests
+// ============================================================================
+
+class UnifiedCompatTypeAliasTest : public ::testing::Test {};
+
+TEST_F(UnifiedCompatTypeAliasTest, PlainTcpClientAliasEquivalentToTcpClient) {
+    // compat::plain_tcp_client should be the same type as core::tcp_client
+    static_assert(
+        std::is_same_v<compat::plain_tcp_client, core::tcp_client>,
+        "plain_tcp_client should be alias for tcp_client");
+}
+
+TEST_F(UnifiedCompatTypeAliasTest, PlainTcpServerAliasEquivalentToTcpServer) {
+    // compat::plain_tcp_server should be the same type as core::tcp_server
+    static_assert(
+        std::is_same_v<compat::plain_tcp_server, core::tcp_server>,
+        "plain_tcp_server should be alias for tcp_server");
+}
+
+#ifdef BUILD_TLS_SUPPORT
+TEST_F(UnifiedCompatTypeAliasTest, TlsTcpClientAliasEquivalentToSecureTcpClient) {
+    // compat::tls_tcp_client should be the same type as core::secure_tcp_client
+    static_assert(
+        std::is_same_v<compat::tls_tcp_client, core::secure_tcp_client>,
+        "tls_tcp_client should be alias for secure_tcp_client");
+}
+
+TEST_F(UnifiedCompatTypeAliasTest, TlsTcpServerAliasEquivalentToSecureTcpServer) {
+    // compat::tls_tcp_server should be the same type as core::secure_tcp_server
+    static_assert(
+        std::is_same_v<compat::tls_tcp_server, core::secure_tcp_server>,
+        "tls_tcp_server should be alias for secure_tcp_server");
+}
+#endif
+
+// ============================================================================
+// Instantiation Tests
+// ============================================================================
+
+TEST_F(UnifiedCompatTypeAliasTest, PlainTcpClientCanBeInstantiated) {
+    auto client = std::make_shared<compat::plain_tcp_client>("test_client");
+    EXPECT_FALSE(client->is_running());
+    EXPECT_FALSE(client->is_connected());
+}
+
+TEST_F(UnifiedCompatTypeAliasTest, PlainTcpServerCanBeInstantiated) {
+    auto server = std::make_shared<compat::plain_tcp_server>("test_server");
+    EXPECT_FALSE(server->is_running());
+}
+
+#ifdef BUILD_TLS_SUPPORT
+TEST_F(UnifiedCompatTypeAliasTest, TlsTcpClientCanBeInstantiated) {
+    // Note: Client doesn't load certificates at construction time, so this works
+    // even without real certificate files
+    policy::tls_enabled tls_config{
+        .cert_path = "",
+        .key_path = "",
+        .ca_path = "",
+        .verify_peer = false};
+    auto client = std::make_shared<compat::tls_tcp_client>("secure_client", tls_config);
+    EXPECT_FALSE(client->is_running());
+    EXPECT_FALSE(client->is_connected());
+}
+
+// Note: TLS server requires valid certificate files at construction, so we skip
+// the instantiation test. The type alias correctness is verified by the
+// TlsTcpServerAliasEquivalentToSecureTcpServer static_assert test above.
+#endif
+
+// ============================================================================
+// Protocol and Policy Access Tests
+// ============================================================================
+
+TEST_F(UnifiedCompatTypeAliasTest, ProtocolTypesAccessibleViaCore) {
+    // Protocol types should be accessible via core namespace after including unified_compat.h
+    [[maybe_unused]] auto tcp_name = core::tcp_protocol::name;
+    [[maybe_unused]] auto udp_name = core::udp_protocol::name;
+    [[maybe_unused]] auto ws_name = core::websocket_protocol::name;
+    [[maybe_unused]] auto quic_name = core::quic_protocol::name;
+
+    EXPECT_EQ(tcp_name, "tcp");
+    EXPECT_EQ(udp_name, "udp");
+    EXPECT_EQ(ws_name, "websocket");
+    EXPECT_EQ(quic_name, "quic");
+}
+
+TEST_F(UnifiedCompatTypeAliasTest, PolicyTypesAccessibleViaCore) {
+    // Policy types should be accessible via core namespace
+    static_assert(core::no_tls::enabled == false, "no_tls should have enabled=false");
+    static_assert(core::tls_enabled::enabled == true, "tls_enabled should have enabled=true");
+}
+
+// ============================================================================
+// API Compatibility Tests
+// ============================================================================
+
+TEST_F(UnifiedCompatTypeAliasTest, PlainTcpClientHasExpectedApi) {
+    auto client = std::make_shared<compat::plain_tcp_client>("api_test");
+
+    // Verify expected methods exist and return expected types
+    EXPECT_FALSE(client->is_running());
+    EXPECT_FALSE(client->is_connected());
+    EXPECT_EQ(client->client_id(), "api_test");
+
+    // Callback setters should work
+    client->set_receive_callback([](const std::vector<uint8_t>&) {});
+    client->set_connected_callback([]() {});
+    client->set_disconnected_callback([]() {});
+    client->set_error_callback([](std::error_code) {});
+}
+
+TEST_F(UnifiedCompatTypeAliasTest, PlainTcpServerHasExpectedApi) {
+    auto server = std::make_shared<compat::plain_tcp_server>("api_test_server");
+
+    // Verify expected methods exist and return expected types
+    EXPECT_FALSE(server->is_running());
+    EXPECT_EQ(server->server_id(), "api_test_server");
+
+    // Callback setters should work
+    server->set_connection_callback([](auto) {});
+    server->set_disconnection_callback([](const std::string&) {});
+    server->set_receive_callback([](auto, const std::vector<uint8_t>&) {});
+    server->set_error_callback([](auto, std::error_code) {});
+}


### PR DESCRIPTION
Closes #509

## Summary

- Add compatibility header `unified_compat.h` with type aliases mapping old class names to unified templates
- Include deprecation macros for gradual migration with compile-time warnings
- Re-export protocol and policy types via core namespace for convenience
- Update `network_system.h` to include unified templates

## Changes

### New Header: `include/kcenon/network/compat/unified_compat.h`

**Deprecated Aliases** (with deprecation warnings):
- `messaging_client_compat` → `unified_messaging_client<tcp_protocol, no_tls>`
- `messaging_server_compat` → `unified_messaging_server<tcp_protocol, no_tls>`
- `secure_messaging_client_compat` → `unified_messaging_client<tcp_protocol, tls_enabled>`
- `secure_messaging_server_compat` → `unified_messaging_server<tcp_protocol, tls_enabled>`

**Non-deprecated Convenience Aliases**:
- `plain_tcp_client`, `plain_tcp_server`
- `tls_tcp_client`, `tls_tcp_server`

### Updated: `include/kcenon/network/network_system.h`
- Added includes for unified templates
- Added includes for protocol tags and TLS policies

## Migration Example

```cpp
// Old code:
#include <kcenon/network/core/messaging_client.h>
auto client = std::make_shared<messaging_client>("client1");

// New code:
#include <kcenon/network/core/unified_messaging_client.h>
auto client = std::make_shared<tcp_client>("client1");
// or: std::make_shared<unified_messaging_client<tcp_protocol>>("client1")
```

## Test Plan

- [x] All 11 UnifiedCompatTypeAliasTest tests pass
- [x] Type aliases resolve to correct unified template instantiations
- [x] Protocol and policy types accessible via core namespace
- [x] API compatibility verified for client and server
- [x] Full build passes