### PR TITLE
docs(core): add deprecation notices to legacy TCP classes

### DIFF
--- a/include/kcenon/network/core/messaging_client.h
+++ b/include/kcenon/network/core/messaging_client.h
@@ -32,6 +32,28 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
+/**
+ * @file messaging_client.h
+ * @brief Legacy TCP client class.
+ *
+ * @deprecated This header is deprecated. Use unified_messaging_client.h instead.
+ *
+ * Migration guide:
+ * @code
+ * // Old code:
+ * #include <kcenon/network/core/messaging_client.h>
+ * auto client = std::make_shared<messaging_client>("client1");
+ *
+ * // New code:
+ * #include <kcenon/network/core/unified_messaging_client.h>
+ * auto client = std::make_shared<tcp_client>("client1");
+ * // Or: auto client = std::make_shared<unified_messaging_client<tcp_protocol>>("client1");
+ * @endcode
+ *
+ * @see unified_messaging_client.h for the new template-based API
+ * @see unified_compat.h for backward-compatible type aliases
+ */
+
 #include <atomic>
 #include <functional>
 #include <future>
@@ -58,6 +80,8 @@ namespace kcenon::network::core
 	/*!
 	 * \class messaging_client
 	 * \brief A basic TCP client that connects to a remote host, sends/receives
+	 *
+	 * @deprecated Use unified_messaging_client<tcp_protocol> or tcp_client instead.
 	 * data using asynchronous operations, and can apply a pipeline for
 	 * transformations.
 	 *

--- a/include/kcenon/network/core/messaging_server.h
+++ b/include/kcenon/network/core/messaging_server.h
@@ -32,6 +32,28 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
+/**
+ * @file messaging_server.h
+ * @brief Legacy TCP server class.
+ *
+ * @deprecated This header is deprecated. Use unified_messaging_server.h instead.
+ *
+ * Migration guide:
+ * @code
+ * // Old code:
+ * #include <kcenon/network/core/messaging_server.h>
+ * auto server = std::make_shared<messaging_server>("server1");
+ *
+ * // New code:
+ * #include <kcenon/network/core/unified_messaging_server.h>
+ * auto server = std::make_shared<tcp_server>("server1");
+ * // Or: auto server = std::make_shared<unified_messaging_server<tcp_protocol>>("server1");
+ * @endcode
+ *
+ * @see unified_messaging_server.h for the new template-based API
+ * @see unified_compat.h for backward-compatible type aliases
+ */
+
 #include <kcenon/network/config/feature_flags.h>
 
 #include <atomic>

--- a/include/kcenon/network/core/secure_messaging_client.h
+++ b/include/kcenon/network/core/secure_messaging_client.h
@@ -32,6 +32,29 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
+/**
+ * @file secure_messaging_client.h
+ * @brief Legacy secure TCP client class.
+ *
+ * @deprecated This header is deprecated. Use unified_messaging_client.h instead.
+ *
+ * Migration guide:
+ * @code
+ * // Old code:
+ * #include <kcenon/network/core/secure_messaging_client.h>
+ * auto client = std::make_shared<secure_messaging_client>("client1");
+ *
+ * // New code:
+ * #include <kcenon/network/core/unified_messaging_client.h>
+ * tls_enabled tls_config{.cert_path = "cert.pem", .key_path = "key.pem"};
+ * auto client = std::make_shared<secure_tcp_client>("client1", tls_config);
+ * // Or: auto client = std::make_shared<unified_messaging_client<tcp_protocol, tls_enabled>>("client1", tls_config);
+ * @endcode
+ *
+ * @see unified_messaging_client.h for the new template-based API
+ * @see unified_compat.h for backward-compatible type aliases
+ */
+
 #include <atomic>
 #include <functional>
 #include <future>
@@ -57,6 +80,8 @@ namespace kcenon::network::core
 	/*!
 	 * \class secure_messaging_client
 	 * \brief A secure client for establishing TLS/SSL encrypted TCP connections to a server.
+	 *
+	 * @deprecated Use unified_messaging_client<tcp_protocol, tls_enabled> or secure_tcp_client instead.
 	 *
 	 * This class uses composition pattern with lifecycle_manager and
 	 * callback_manager for common lifecycle management and callback handling.

--- a/include/kcenon/network/core/secure_messaging_server.h
+++ b/include/kcenon/network/core/secure_messaging_server.h
@@ -32,6 +32,29 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
+/**
+ * @file secure_messaging_server.h
+ * @brief Legacy secure TCP server class.
+ *
+ * @deprecated This header is deprecated. Use unified_messaging_server.h instead.
+ *
+ * Migration guide:
+ * @code
+ * // Old code:
+ * #include <kcenon/network/core/secure_messaging_server.h>
+ * auto server = std::make_shared<secure_messaging_server>("server1");
+ *
+ * // New code:
+ * #include <kcenon/network/core/unified_messaging_server.h>
+ * tls_enabled tls_config{.cert_path = "server.crt", .key_path = "server.key"};
+ * auto server = std::make_shared<secure_tcp_server>("server1", tls_config);
+ * // Or: auto server = std::make_shared<unified_messaging_server<tcp_protocol, tls_enabled>>("server1", tls_config);
+ * @endcode
+ *
+ * @see unified_messaging_server.h for the new template-based API
+ * @see unified_compat.h for backward-compatible type aliases
+ */
+
 #include <kcenon/network/config/feature_flags.h>
 
 #include <atomic>


### PR DESCRIPTION
Closes #514

## Summary
- Add deprecation documentation to legacy TCP client/server headers
- Provide migration guides pointing to unified template-based API
- Mark legacy classes for future removal

## Changes Made
| File | Change |
|------|--------|
| `messaging_client.h` | Added @deprecated notice with migration guide |
| `messaging_server.h` | Added @deprecated notice with migration guide |
| `secure_messaging_client.h` | Added @deprecated notice with migration guide |
| `secure_messaging_server.h` | Added @deprecated notice with migration guide |

## Migration Path

Users should migrate from legacy classes to the new unified templates:

```cpp
// Old (deprecated):
#include <kcenon/network/core/messaging_client.h>
auto client = std::make_shared<messaging_client>("client1");

// New (recommended):
#include <kcenon/network/core/unified_messaging_client.h>
auto client = std::make_shared<tcp_client>("client1");
// Or with explicit template: unified_messaging_client<tcp_protocol>
```

## Related Issues
- Part of #503 (Unify secure and non-secure client/server variants)
- Phase 1 of 3: TCP template unification

## Test Plan
- [x] Build passes
- [x] All 45 unified template tests pass
- [x] Documentation headers compile without errors