### PR TITLE
refactor(core): add unified type aliases for WebSocket and QUIC protocols

### DIFF
--- a/include/kcenon/network/core/messaging_quic_client.h
+++ b/include/kcenon/network/core/messaging_quic_client.h
@@ -610,4 +610,39 @@ namespace kcenon::network::core
 		std::atomic<bool> early_data_accepted_{false}; //!< Early data acceptance status
 	};
 
+// =====================================================================
+// Unified Pattern Type Aliases
+// =====================================================================
+// These aliases provide a consistent API pattern across all protocols,
+// making QUIC clients accessible via the unified template naming.
+// See: unified_messaging_client.h for TCP, unified_udp_messaging_client.h for UDP.
+
+/*!
+ * \brief Type alias for QUIC client.
+ *
+ * QUIC (RFC 9000) provides reliable, multiplexed, secure transport.
+ * Note: QUIC always uses TLS 1.3 encryption - there is no "plain" QUIC variant.
+ *
+ * \code
+ * auto client = std::make_shared<quic_client>("client1");
+ * client->start_client("localhost", 4433);
+ * \endcode
+ */
+using quic_client = messaging_quic_client;
+
+/*!
+ * \brief Type alias for secure QUIC client (same as quic_client).
+ *
+ * QUIC inherently uses TLS 1.3 for all connections, so this alias
+ * is provided for API consistency with other protocol patterns.
+ * Both quic_client and secure_quic_client refer to the same implementation.
+ *
+ * \code
+ * // Both are equivalent:
+ * auto client1 = std::make_shared<quic_client>("client1");
+ * auto client2 = std::make_shared<secure_quic_client>("client2");
+ * \endcode
+ */
+using secure_quic_client = messaging_quic_client;
+
 } // namespace kcenon::network::core

--- a/include/kcenon/network/core/messaging_quic_server.h
+++ b/include/kcenon/network/core/messaging_quic_server.h
@@ -565,4 +565,40 @@ namespace kcenon::network::core
 #endif // KCENON_WITH_COMMON_SYSTEM
 	};
 
+// =====================================================================
+// Unified Pattern Type Aliases
+// =====================================================================
+// These aliases provide a consistent API pattern across all protocols,
+// making QUIC servers accessible via the unified template naming.
+// See: unified_messaging_server.h for TCP, unified_udp_messaging_server.h for UDP.
+
+/*!
+ * \brief Type alias for QUIC server.
+ *
+ * QUIC (RFC 9000) provides reliable, multiplexed, secure transport.
+ * Note: QUIC always uses TLS 1.3 encryption - there is no "plain" QUIC variant.
+ *
+ * \code
+ * auto server = std::make_shared<quic_server>("server1");
+ * quic_server_config config{.cert_file = "cert.pem", .key_file = "key.pem"};
+ * server->start_server(4433, config);
+ * \endcode
+ */
+using quic_server = messaging_quic_server;
+
+/*!
+ * \brief Type alias for secure QUIC server (same as quic_server).
+ *
+ * QUIC inherently uses TLS 1.3 for all connections, so this alias
+ * is provided for API consistency with other protocol patterns.
+ * Both quic_server and secure_quic_server refer to the same implementation.
+ *
+ * \code
+ * // Both are equivalent:
+ * auto server1 = std::make_shared<quic_server>("server1");
+ * auto server2 = std::make_shared<secure_quic_server>("server2");
+ * \endcode
+ */
+using secure_quic_server = messaging_quic_server;
+
 } // namespace kcenon::network::core

--- a/include/kcenon/network/core/messaging_ws_client.h
+++ b/include/kcenon/network/core/messaging_ws_client.h
@@ -443,4 +443,40 @@ namespace kcenon::network::core
 		std::mutex ws_socket_mutex_;                     /*!< Protects ws_socket_. */
 	};
 
+// =====================================================================
+// Unified Pattern Type Aliases
+// =====================================================================
+// These aliases provide a consistent API pattern across all protocols,
+// making WebSocket clients accessible via the unified template naming.
+// See: unified_messaging_client.h for TCP, unified_udp_messaging_client.h for UDP.
+
+/*!
+ * \brief Type alias for WebSocket client (plain).
+ *
+ * Provides consistent naming with the unified template pattern.
+ * WebSocket uses HTTP upgrade over TCP, optionally secured via TLS (WSS).
+ *
+ * \code
+ * auto ws_client = std::make_shared<ws_client>("client1");
+ * ws_client->start_client("localhost", 80, "/ws");
+ * \endcode
+ */
+using ws_client = messaging_ws_client;
+
+/*!
+ * \brief Type alias for secure WebSocket client (WSS).
+ *
+ * WebSocket Secure (WSS) uses TLS encryption over the TCP connection.
+ * Note: The actual TLS configuration is handled at the connection level.
+ *
+ * \code
+ * auto wss_client = std::make_shared<secure_ws_client>("client1");
+ * wss_client->start_client("localhost", 443, "/ws");
+ * \endcode
+ *
+ * \note Currently uses the same implementation as messaging_ws_client.
+ *       TLS is negotiated via the wss:// scheme or port configuration.
+ */
+using secure_ws_client = messaging_ws_client;
+
 } // namespace kcenon::network::core

--- a/include/kcenon/network/core/messaging_ws_server.h
+++ b/include/kcenon/network/core/messaging_ws_server.h
@@ -526,4 +526,40 @@ namespace kcenon::network::core
 		std::shared_ptr<ws_session_manager> session_mgr_; /*!< Session manager. */
 	};
 
+// =====================================================================
+// Unified Pattern Type Aliases
+// =====================================================================
+// These aliases provide a consistent API pattern across all protocols,
+// making WebSocket servers accessible via the unified template naming.
+// See: unified_messaging_server.h for TCP, unified_udp_messaging_server.h for UDP.
+
+/*!
+ * \brief Type alias for WebSocket server (plain).
+ *
+ * Provides consistent naming with the unified template pattern.
+ * WebSocket uses HTTP upgrade over TCP, optionally secured via TLS (WSS).
+ *
+ * \code
+ * auto ws_server = std::make_shared<ws_server>("server1");
+ * ws_server->start_server(8080, "/ws");
+ * \endcode
+ */
+using ws_server = messaging_ws_server;
+
+/*!
+ * \brief Type alias for secure WebSocket server (WSS).
+ *
+ * WebSocket Secure (WSS) uses TLS encryption over the TCP connection.
+ * Note: TLS configuration should be handled at the server setup level.
+ *
+ * \code
+ * auto wss_server = std::make_shared<secure_ws_server>("server1");
+ * wss_server->start_server(8443, "/ws");
+ * \endcode
+ *
+ * \note Currently uses the same implementation as messaging_ws_server.
+ *       TLS should be configured via server configuration options.
+ */
+using secure_ws_server = messaging_ws_server;
+
 } // namespace kcenon::network::core

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -811,6 +811,70 @@ if(GTest_FOUND OR GTEST_FOUND)
             DISCOVERY_TIMEOUT 60
         )
         message(STATUS "WebSocket protocol tests enabled")
+
+        # WebSocket messaging client tests (Phase 3 unified pattern)
+        add_executable(network_messaging_ws_client_test
+            test_messaging_ws_client.cpp
+        )
+
+        target_link_libraries(network_messaging_ws_client_test PRIVATE
+            NetworkSystem
+            GTest::gtest
+            GTest::gtest_main
+            Threads::Threads
+        )
+
+        # Setup ASIO integration
+        setup_asio_integration(network_messaging_ws_client_test)
+
+        # Add system integration paths
+        if(COMMON_SYSTEM_INCLUDE_DIR)
+            target_include_directories(network_messaging_ws_client_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+            target_compile_definitions(network_messaging_ws_client_test PRIVATE WITH_COMMON_SYSTEM)
+        endif()
+
+        set_target_properties(network_messaging_ws_client_test PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON
+            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+        )
+
+        gtest_discover_tests(network_messaging_ws_client_test
+            DISCOVERY_TIMEOUT 60
+        )
+        message(STATUS "WebSocket messaging client tests enabled")
+
+        # WebSocket messaging server tests (Phase 3 unified pattern)
+        add_executable(network_messaging_ws_server_test
+            test_messaging_ws_server.cpp
+        )
+
+        target_link_libraries(network_messaging_ws_server_test PRIVATE
+            NetworkSystem
+            GTest::gtest
+            GTest::gtest_main
+            Threads::Threads
+        )
+
+        # Setup ASIO integration
+        setup_asio_integration(network_messaging_ws_server_test)
+
+        # Add system integration paths
+        if(COMMON_SYSTEM_INCLUDE_DIR)
+            target_include_directories(network_messaging_ws_server_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+            target_compile_definitions(network_messaging_ws_server_test PRIVATE WITH_COMMON_SYSTEM)
+        endif()
+
+        set_target_properties(network_messaging_ws_server_test PROPERTIES
+            CXX_STANDARD 20
+            CXX_STANDARD_REQUIRED ON
+            RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+        )
+
+        gtest_discover_tests(network_messaging_ws_server_test
+            DISCOVERY_TIMEOUT 60
+        )
+        message(STATUS "WebSocket messaging server tests enabled")
     endif()
 
     ##################################################

--- a/tests/test_messaging_quic_client.cpp
+++ b/tests/test_messaging_quic_client.cpp
@@ -390,4 +390,33 @@ TEST_F(MessagingQuicClientTest, ApiConsistencyWithTcpClient)
 	EXPECT_TRUE(stop_result.is_ok());
 }
 
+// =============================================================================
+// Unified Pattern Type Alias Tests
+// =============================================================================
+
+TEST_F(MessagingQuicClientTest, TypeAliasQuicClient)
+{
+	// Verify quic_client is an alias for messaging_quic_client
+	static_assert(std::is_same_v<quic_client, messaging_quic_client>,
+	              "quic_client should be an alias for messaging_quic_client");
+
+	auto client = std::make_shared<quic_client>("alias_test");
+	EXPECT_FALSE(client->is_connected());
+	EXPECT_EQ(client->client_id(), "alias_test");
+}
+
+TEST_F(MessagingQuicClientTest, TypeAliasSecureQuicClient)
+{
+	// Verify secure_quic_client is an alias for messaging_quic_client
+	// QUIC always uses TLS 1.3, so secure_quic_client == quic_client
+	static_assert(std::is_same_v<secure_quic_client, messaging_quic_client>,
+	              "secure_quic_client should be an alias for messaging_quic_client");
+	static_assert(std::is_same_v<quic_client, secure_quic_client>,
+	              "quic_client and secure_quic_client should be the same type");
+
+	auto client = std::make_shared<secure_quic_client>("secure_alias_test");
+	EXPECT_FALSE(client->is_connected());
+	EXPECT_EQ(client->client_id(), "secure_alias_test");
+}
+
 } // namespace kcenon::network::core::test

--- a/tests/test_messaging_quic_server.cpp
+++ b/tests/test_messaging_quic_server.cpp
@@ -470,4 +470,33 @@ TEST_F(MessagingQuicServerTest, QuicSessionDefaultStats)
 	EXPECT_EQ(stats.cwnd, 0);
 }
 
+// =============================================================================
+// Unified Pattern Type Alias Tests
+// =============================================================================
+
+TEST_F(MessagingQuicServerTest, TypeAliasQuicServer)
+{
+	// Verify quic_server is an alias for messaging_quic_server
+	static_assert(std::is_same_v<quic_server, messaging_quic_server>,
+	              "quic_server should be an alias for messaging_quic_server");
+
+	auto server = std::make_shared<quic_server>("alias_test");
+	EXPECT_FALSE(server->is_running());
+	EXPECT_EQ(server->server_id(), "alias_test");
+}
+
+TEST_F(MessagingQuicServerTest, TypeAliasSecureQuicServer)
+{
+	// Verify secure_quic_server is an alias for messaging_quic_server
+	// QUIC always uses TLS 1.3, so secure_quic_server == quic_server
+	static_assert(std::is_same_v<secure_quic_server, messaging_quic_server>,
+	              "secure_quic_server should be an alias for messaging_quic_server");
+	static_assert(std::is_same_v<quic_server, secure_quic_server>,
+	              "quic_server and secure_quic_server should be the same type");
+
+	auto server = std::make_shared<secure_quic_server>("secure_alias_test");
+	EXPECT_FALSE(server->is_running());
+	EXPECT_EQ(server->server_id(), "secure_alias_test");
+}
+
 } // namespace kcenon::network::core::test

--- a/tests/test_messaging_ws_client.cpp
+++ b/tests/test_messaging_ws_client.cpp
@@ -1,0 +1,94 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "kcenon/network/core/messaging_ws_client.h"
+#include "kcenon/network/utils/result_types.h"
+
+namespace kcenon::network::core::test
+{
+
+class MessagingWsClientTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+	}
+
+	void TearDown() override
+	{
+	}
+};
+
+// =============================================================================
+// Basic Construction Tests
+// =============================================================================
+
+TEST_F(MessagingWsClientTest, BasicConstruction)
+{
+	auto client = std::make_shared<messaging_ws_client>("test_client");
+	EXPECT_FALSE(client->is_running());
+	EXPECT_FALSE(client->is_connected());
+	EXPECT_EQ(client->client_id(), "test_client");
+}
+
+// =============================================================================
+// Unified Pattern Type Alias Tests
+// =============================================================================
+
+TEST_F(MessagingWsClientTest, TypeAliasWsClient)
+{
+	// Verify ws_client is an alias for messaging_ws_client
+	static_assert(std::is_same_v<ws_client, messaging_ws_client>,
+	              "ws_client should be an alias for messaging_ws_client");
+
+	auto client = std::make_shared<ws_client>("alias_test");
+	EXPECT_FALSE(client->is_running());
+	EXPECT_EQ(client->client_id(), "alias_test");
+}
+
+TEST_F(MessagingWsClientTest, TypeAliasSecureWsClient)
+{
+	// Verify secure_ws_client is an alias for messaging_ws_client
+	// WSS (WebSocket Secure) uses TLS, but shares the same base implementation
+	static_assert(std::is_same_v<secure_ws_client, messaging_ws_client>,
+	              "secure_ws_client should be an alias for messaging_ws_client");
+	static_assert(std::is_same_v<ws_client, secure_ws_client>,
+	              "ws_client and secure_ws_client should be the same type");
+
+	auto client = std::make_shared<secure_ws_client>("secure_alias_test");
+	EXPECT_FALSE(client->is_running());
+	EXPECT_EQ(client->client_id(), "secure_alias_test");
+}
+
+} // namespace kcenon::network::core::test

--- a/tests/test_messaging_ws_server.cpp
+++ b/tests/test_messaging_ws_server.cpp
@@ -1,0 +1,93 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include "kcenon/network/core/messaging_ws_server.h"
+#include "kcenon/network/utils/result_types.h"
+
+namespace kcenon::network::core::test
+{
+
+class MessagingWsServerTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+	}
+
+	void TearDown() override
+	{
+	}
+};
+
+// =============================================================================
+// Basic Construction Tests
+// =============================================================================
+
+TEST_F(MessagingWsServerTest, BasicConstruction)
+{
+	auto server = std::make_shared<messaging_ws_server>("test_server");
+	EXPECT_FALSE(server->is_running());
+	EXPECT_EQ(server->server_id(), "test_server");
+}
+
+// =============================================================================
+// Unified Pattern Type Alias Tests
+// =============================================================================
+
+TEST_F(MessagingWsServerTest, TypeAliasWsServer)
+{
+	// Verify ws_server is an alias for messaging_ws_server
+	static_assert(std::is_same_v<ws_server, messaging_ws_server>,
+	              "ws_server should be an alias for messaging_ws_server");
+
+	auto server = std::make_shared<ws_server>("alias_test");
+	EXPECT_FALSE(server->is_running());
+	EXPECT_EQ(server->server_id(), "alias_test");
+}
+
+TEST_F(MessagingWsServerTest, TypeAliasSecureWsServer)
+{
+	// Verify secure_ws_server is an alias for messaging_ws_server
+	// WSS (WebSocket Secure) uses TLS, but shares the same base implementation
+	static_assert(std::is_same_v<secure_ws_server, messaging_ws_server>,
+	              "secure_ws_server should be an alias for messaging_ws_server");
+	static_assert(std::is_same_v<ws_server, secure_ws_server>,
+	              "ws_server and secure_ws_server should be the same type");
+
+	auto server = std::make_shared<secure_ws_server>("secure_alias_test");
+	EXPECT_FALSE(server->is_running());
+	EXPECT_EQ(server->server_id(), "secure_alias_test");
+}
+
+} // namespace kcenon::network::core::test


### PR DESCRIPTION
## Summary
- Add consistent type alias patterns for WebSocket and QUIC to match TCP/UDP unified template naming conventions
- Complete Phase 3 of the messaging unification effort (#503)
- Introduce `ws_client`, `secure_ws_client`, `quic_client`, `secure_quic_client` and their server equivalents

## Changes
- `messaging_ws_client.h`: Add `ws_client` and `secure_ws_client` type aliases
- `messaging_ws_server.h`: Add `ws_server` and `secure_ws_server` type aliases
- `messaging_quic_client.h`: Add `quic_client` and `secure_quic_client` type aliases
- `messaging_quic_server.h`: Add `quic_server` and `secure_quic_server` type aliases
- Add new test files for WebSocket client/server type aliases
- Update existing QUIC tests with type alias verification

## Design Notes
- **QUIC**: Always uses TLS 1.3, so `quic_client == secure_quic_client`
- **WebSocket**: WSS (Secure) is handled at connection-level configuration
- **API Consistency**: Follows the same pattern as TCP (`tcp_client`, `secure_tcp_client`) and UDP (`udp_client`, `secure_udp_client`)

## Test Plan
- [x] All 24 TypeAlias tests pass (including 8 new WebSocket/QUIC tests)
- [x] Build succeeds with Release configuration
- [x] Existing tests unaffected by changes

Closes #516