### PR TITLE
refactor(network): add unified core interfaces (Phase 1 of #521)

### DIFF
--- a/include/kcenon/network/unified/i_connection.h
+++ b/include/kcenon/network/unified/i_connection.h
@@ -1,0 +1,235 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include "i_transport.h"
+#include "types.h"
+
+#include <chrono>
+
+namespace kcenon::network::unified {
+
+/**
+ * @interface i_connection
+ * @brief Core interface for active network connections
+ *
+ * This interface extends i_transport with connection lifecycle operations.
+ * It represents:
+ * - Client-side connections (initiated by connect())
+ * - Accepted connections (from i_listener::accept())
+ *
+ * ### Design Philosophy
+ * By inheriting from i_transport, i_connection provides a unified interface
+ * for data transfer while adding connection-specific operations. This allows
+ * code that only needs to send/receive data to work with just i_transport,
+ * while connection management code uses i_connection.
+ *
+ * ### Lifecycle
+ * 1. Create connection via protocol factory (or accept from listener)
+ * 2. Optionally configure callbacks and options
+ * 3. Connect to remote endpoint (if not already accepted)
+ * 4. Send/receive data via inherited i_transport methods
+ * 5. Close connection when done
+ *
+ * ### Thread Safety
+ * All public methods must be thread-safe.
+ *
+ * ### Usage Example
+ * @code
+ * // Create connection via protocol factory
+ * auto conn = protocol::tcp::connect({"localhost", 8080});
+ *
+ * // Set callbacks
+ * conn->set_callbacks({
+ *     .on_connected = []() { std::cout << "Connected!\n"; },
+ *     .on_data = [](std::span<const std::byte> data) {
+ *         // Process received data
+ *     },
+ *     .on_disconnected = []() { std::cout << "Disconnected\n"; },
+ *     .on_error = [](std::error_code ec) {
+ *         std::cerr << "Error: " << ec.message() << "\n";
+ *     }
+ * });
+ *
+ * // Connect (may be async depending on implementation)
+ * if (auto result = conn->connect({"remote.host.com", 9000}); !result) {
+ *     std::cerr << "Connect failed\n";
+ *     return;
+ * }
+ *
+ * // Send data (inherited from i_transport)
+ * std::vector<std::byte> data = ...;
+ * conn->send(data);
+ *
+ * // Close when done
+ * conn->close();
+ * @endcode
+ *
+ * @see i_transport - Base data transport interface
+ * @see i_listener - Server-side connection acceptor
+ */
+class i_connection : public i_transport {
+public:
+    /**
+     * @brief Virtual destructor
+     *
+     * Closing the connection is implicit when the i_connection is destroyed.
+     */
+    ~i_connection() override = default;
+
+    // Non-copyable, movable (inherited from i_transport)
+    i_connection(const i_connection&) = delete;
+    i_connection& operator=(const i_connection&) = delete;
+    i_connection(i_connection&&) = default;
+    i_connection& operator=(i_connection&&) = default;
+
+    // =========================================================================
+    // Connection Lifecycle Operations
+    // =========================================================================
+
+    /**
+     * @brief Connects to a remote endpoint using host/port
+     * @param endpoint The remote endpoint to connect to
+     * @return VoidResult indicating success or failure
+     *
+     * ### Behavior
+     * - Initiates connection to the specified endpoint
+     * - May block until connection is established (sync mode)
+     * - May return immediately and notify via callback (async mode)
+     *
+     * ### Error Conditions
+     * - Returns error if already connected
+     * - Returns error if connection fails
+     * - Returns error if host resolution fails
+     * - Returns error if connection timeout expires
+     *
+     * ### Thread Safety
+     * Thread-safe. Only one connect operation can succeed at a time.
+     */
+    [[nodiscard]] virtual auto connect(const endpoint_info& endpoint) -> VoidResult = 0;
+
+    /**
+     * @brief Connects to a remote endpoint using URL
+     * @param url The URL to connect to (e.g., "wss://example.com/ws")
+     * @return VoidResult indicating success or failure
+     *
+     * This overload is primarily for URL-based protocols like WebSocket
+     * and HTTP. For socket-based protocols, use the endpoint_info overload.
+     *
+     * ### Error Conditions
+     * Same as connect(endpoint_info) plus:
+     * - Returns error if URL is malformed
+     * - Returns error if protocol is not supported
+     */
+    [[nodiscard]] virtual auto connect(std::string_view url) -> VoidResult = 0;
+
+    /**
+     * @brief Closes the connection gracefully
+     *
+     * ### Behavior
+     * - Initiates graceful shutdown
+     * - Pending sends may be completed before close
+     * - Triggers on_disconnected callback when fully closed
+     *
+     * ### Thread Safety
+     * Thread-safe. Safe to call multiple times.
+     *
+     * ### Note
+     * After close(), is_connected() returns false and send() returns error.
+     */
+    virtual auto close() noexcept -> void = 0;
+
+    // =========================================================================
+    // Configuration Operations
+    // =========================================================================
+
+    /**
+     * @brief Sets all connection callbacks at once
+     * @param callbacks The callback structure with handlers
+     *
+     * Replaces all previously set callbacks. Empty callback functions
+     * in the structure will clear the corresponding handler.
+     *
+     * ### Thread Safety
+     * Thread-safe, but callbacks may be invoked from I/O threads.
+     */
+    virtual auto set_callbacks(connection_callbacks callbacks) -> void = 0;
+
+    /**
+     * @brief Sets connection options
+     * @param options The configuration options
+     *
+     * Some options may only be effective before connect() is called.
+     *
+     * ### Thread Safety
+     * Thread-safe. Changes may not affect in-flight operations.
+     */
+    virtual auto set_options(connection_options options) -> void = 0;
+
+    /**
+     * @brief Sets the connection timeout
+     * @param timeout Timeout duration (0 = no timeout)
+     *
+     * Shorthand for setting just the connect_timeout option.
+     */
+    virtual auto set_timeout(std::chrono::milliseconds timeout) -> void = 0;
+
+    // =========================================================================
+    // State Query Operations
+    // =========================================================================
+
+    /**
+     * @brief Checks if the connection is in the process of connecting
+     * @return true if connect() was called but not yet completed
+     */
+    [[nodiscard]] virtual auto is_connecting() const noexcept -> bool = 0;
+
+    /**
+     * @brief Blocks until the component has stopped
+     *
+     * Waits for all pending operations to complete and the connection
+     * to be fully closed.
+     *
+     * ### Thread Safety
+     * Safe to call from any thread. Uses internal synchronization.
+     */
+    virtual auto wait_for_stop() -> void = 0;
+
+protected:
+    /**
+     * @brief Default constructor (only for derived classes)
+     */
+    i_connection() = default;
+};
+
+}  // namespace kcenon::network::unified

--- a/include/kcenon/network/unified/i_listener.h
+++ b/include/kcenon/network/unified/i_listener.h
@@ -1,0 +1,279 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include "i_connection.h"
+#include "types.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+namespace kcenon::network::unified {
+
+/**
+ * @interface i_listener
+ * @brief Core interface for passive network listeners (server-side)
+ *
+ * This interface represents a server-side network component that listens
+ * for incoming connections. It provides:
+ * - Binding to local addresses
+ * - Accepting incoming connections
+ * - Connection management via callbacks
+ *
+ * ### Design Philosophy
+ * The i_listener interface separates server-side concerns from client-side
+ * concerns, while accepted connections share the same i_connection interface
+ * as client-initiated connections. This allows code to work with connections
+ * regardless of their origin.
+ *
+ * ### Lifecycle
+ * 1. Create listener via protocol factory
+ * 2. Configure callbacks for connection events
+ * 3. Start listening on a local endpoint
+ * 4. Handle incoming connections via callbacks
+ * 5. Stop listening when done
+ *
+ * ### Thread Safety
+ * All public methods must be thread-safe. Callbacks may be invoked from
+ * I/O threads.
+ *
+ * ### Usage Example
+ * @code
+ * // Create listener via protocol factory
+ * auto listener = protocol::tcp::listen({"0.0.0.0", 8080});
+ *
+ * // Set callbacks for connection events
+ * listener->set_callbacks({
+ *     .on_accept = [](std::string_view conn_id) {
+ *         std::cout << "New connection: " << conn_id << "\n";
+ *     },
+ *     .on_data = [](std::string_view conn_id, std::span<const std::byte> data) {
+ *         // Process received data from connection
+ *     },
+ *     .on_disconnect = [](std::string_view conn_id) {
+ *         std::cout << "Connection closed: " << conn_id << "\n";
+ *     },
+ *     .on_error = [](std::string_view conn_id, std::error_code ec) {
+ *         std::cerr << "Error on " << conn_id << ": " << ec.message() << "\n";
+ *     }
+ * });
+ *
+ * // Start listening
+ * if (auto result = listener->start({"::", 8080}); !result) {
+ *     std::cerr << "Failed to start listener\n";
+ *     return;
+ * }
+ *
+ * // Server is now accepting connections...
+ * // Later, stop the listener
+ * listener->stop();
+ * @endcode
+ *
+ * @see i_connection - Interface for accepted connections
+ * @see i_transport - Base data transport interface
+ */
+class i_listener {
+public:
+    /**
+     * @brief Callback for accepted connections
+     *
+     * Called when a new connection is accepted. The callback receives
+     * ownership of the connection via unique_ptr.
+     */
+    using accept_callback_t = std::function<void(std::unique_ptr<i_connection>)>;
+
+    /**
+     * @brief Virtual destructor
+     *
+     * Stops listening and closes all connections when destroyed.
+     */
+    virtual ~i_listener() = default;
+
+    // Non-copyable (interface class)
+    i_listener(const i_listener&) = delete;
+    i_listener& operator=(const i_listener&) = delete;
+
+    // Movable
+    i_listener(i_listener&&) = default;
+    i_listener& operator=(i_listener&&) = default;
+
+    // =========================================================================
+    // Listener Lifecycle Operations
+    // =========================================================================
+
+    /**
+     * @brief Starts listening for incoming connections
+     * @param bind_address The local address to bind to
+     * @return VoidResult indicating success or failure
+     *
+     * ### Behavior
+     * - Binds to the specified local address
+     * - Begins accepting incoming connections
+     * - Accepted connections are delivered via callbacks
+     *
+     * ### Error Conditions
+     * - Returns error if already listening
+     * - Returns error if bind fails (e.g., address in use)
+     * - Returns error if listen fails
+     *
+     * ### Thread Safety
+     * Thread-safe. Only one start operation can succeed at a time.
+     */
+    [[nodiscard]] virtual auto start(const endpoint_info& bind_address) -> VoidResult = 0;
+
+    /**
+     * @brief Starts listening on a specific port (all interfaces)
+     * @param port The port number to listen on
+     * @return VoidResult indicating success or failure
+     *
+     * Convenience overload that binds to all interfaces (0.0.0.0 / ::).
+     */
+    [[nodiscard]] virtual auto start(uint16_t port) -> VoidResult = 0;
+
+    /**
+     * @brief Stops listening and closes all connections
+     *
+     * ### Behavior
+     * - Stops accepting new connections
+     * - Closes all active connections
+     * - Triggers on_disconnect callback for each connection
+     *
+     * ### Thread Safety
+     * Thread-safe. Safe to call multiple times.
+     */
+    virtual auto stop() noexcept -> void = 0;
+
+    // =========================================================================
+    // Configuration Operations
+    // =========================================================================
+
+    /**
+     * @brief Sets all listener callbacks at once
+     * @param callbacks The callback structure with handlers
+     *
+     * Replaces all previously set callbacks.
+     *
+     * ### Thread Safety
+     * Thread-safe, but callbacks are invoked from I/O threads.
+     */
+    virtual auto set_callbacks(listener_callbacks callbacks) -> void = 0;
+
+    /**
+     * @brief Sets the accept callback for new connections
+     * @param callback Called when a connection is accepted
+     *
+     * This callback receives ownership of the connection object.
+     * If set, the on_accept callback in listener_callbacks is not called.
+     *
+     * ### Thread Safety
+     * Thread-safe. Callback invoked from I/O thread.
+     */
+    virtual auto set_accept_callback(accept_callback_t callback) -> void = 0;
+
+    // =========================================================================
+    // State Query Operations
+    // =========================================================================
+
+    /**
+     * @brief Checks if the listener is currently listening
+     * @return true if listening for connections, false otherwise
+     */
+    [[nodiscard]] virtual auto is_listening() const noexcept -> bool = 0;
+
+    /**
+     * @brief Gets the local endpoint the listener is bound to
+     * @return endpoint_info of the local binding
+     *
+     * Returns valid information only when listening.
+     * Returns empty endpoint_info if not bound.
+     */
+    [[nodiscard]] virtual auto local_endpoint() const noexcept -> endpoint_info = 0;
+
+    /**
+     * @brief Gets the number of active connections
+     * @return The count of currently connected clients
+     */
+    [[nodiscard]] virtual auto connection_count() const noexcept -> size_t = 0;
+
+    /**
+     * @brief Sends data to a specific connection
+     * @param connection_id The ID of the target connection
+     * @param data The data to send
+     * @return VoidResult indicating success or failure
+     *
+     * ### Error Conditions
+     * - Returns error if connection_id not found
+     * - Returns error if send fails
+     */
+    [[nodiscard]] virtual auto send_to(std::string_view connection_id,
+                                       std::span<const std::byte> data) -> VoidResult = 0;
+
+    /**
+     * @brief Broadcasts data to all connected clients
+     * @param data The data to send to all connections
+     * @return VoidResult indicating success or failure
+     *
+     * ### Behavior
+     * - Sends data to all currently connected clients
+     * - Returns success if at least one send succeeded
+     * - Failures on individual connections are logged but don't fail the call
+     */
+    [[nodiscard]] virtual auto broadcast(std::span<const std::byte> data) -> VoidResult = 0;
+
+    /**
+     * @brief Closes a specific connection
+     * @param connection_id The ID of the connection to close
+     *
+     * Triggers the on_disconnect callback for the connection.
+     */
+    virtual auto close_connection(std::string_view connection_id) noexcept -> void = 0;
+
+    /**
+     * @brief Blocks until the listener has stopped
+     *
+     * Waits for all connections to close and the listener to fully stop.
+     *
+     * ### Thread Safety
+     * Safe to call from any thread.
+     */
+    virtual auto wait_for_stop() -> void = 0;
+
+protected:
+    /**
+     * @brief Default constructor (only for derived classes)
+     */
+    i_listener() = default;
+};
+
+}  // namespace kcenon::network::unified

--- a/include/kcenon/network/unified/i_transport.h
+++ b/include/kcenon/network/unified/i_transport.h
@@ -1,0 +1,189 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include "types.h"
+
+#include <cstddef>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#include "kcenon/network/utils/result_types.h"
+
+namespace kcenon::network::unified {
+
+/**
+ * @interface i_transport
+ * @brief Core interface for data transport abstraction
+ *
+ * This interface defines the fundamental operations for sending and receiving
+ * data across any network transport. It serves as the base abstraction that
+ * all protocol-specific implementations share.
+ *
+ * ### Design Philosophy
+ * The i_transport interface embodies Kent Beck's "Fewest Elements" rule by
+ * providing a minimal, protocol-agnostic API for data transfer. Protocol-
+ * specific details are handled by factory functions, not interface variations.
+ *
+ * ### Supported Operations
+ * - **Send**: Transmit raw bytes to the remote endpoint
+ * - **State Query**: Check connection status
+ * - **Endpoint Info**: Get remote endpoint information
+ *
+ * ### Thread Safety
+ * All public methods must be thread-safe. Implementations should use
+ * appropriate synchronization for internal state.
+ *
+ * ### Usage Example
+ * @code
+ * // Works with any transport implementation
+ * void send_message(i_transport& transport, std::span<const std::byte> data) {
+ *     if (!transport.is_connected()) {
+ *         return; // Not connected
+ *     }
+ *
+ *     auto result = transport.send(data);
+ *     if (!result) {
+ *         // Handle error
+ *         std::cerr << "Send failed: " << result.error().message << std::endl;
+ *     }
+ * }
+ * @endcode
+ *
+ * @see i_connection - Active connection (client-side or accepted)
+ * @see i_listener - Passive listener (server-side)
+ */
+class i_transport {
+public:
+    /**
+     * @brief Virtual destructor for proper cleanup of derived classes
+     */
+    virtual ~i_transport() = default;
+
+    // Non-copyable (interface class, typically used via unique_ptr/shared_ptr)
+    i_transport(const i_transport&) = delete;
+    i_transport& operator=(const i_transport&) = delete;
+
+    // Movable (for transfer of ownership)
+    i_transport(i_transport&&) = default;
+    i_transport& operator=(i_transport&&) = default;
+
+    // =========================================================================
+    // Data Transfer Operations
+    // =========================================================================
+
+    /**
+     * @brief Sends raw data to the remote endpoint
+     * @param data The data to send as a span of bytes
+     * @return VoidResult indicating success or failure
+     *
+     * ### Error Conditions
+     * - Returns error if not connected
+     * - Returns error if send operation fails
+     * - Returns error if data size exceeds protocol limits
+     *
+     * ### Thread Safety
+     * Thread-safe. Multiple sends may be queued internally.
+     *
+     * ### Performance Note
+     * Data is typically copied to an internal send buffer. For zero-copy
+     * sends, see protocol-specific implementations.
+     */
+    [[nodiscard]] virtual auto send(std::span<const std::byte> data) -> VoidResult = 0;
+
+    /**
+     * @brief Sends data from a uint8_t vector
+     * @param data The data to send as a vector of uint8_t
+     * @return VoidResult indicating success or failure
+     *
+     * Convenience overload for compatibility with existing code using
+     * std::vector<uint8_t>.
+     */
+    [[nodiscard]] virtual auto send(std::vector<uint8_t>&& data) -> VoidResult = 0;
+
+    // =========================================================================
+    // State Query Operations
+    // =========================================================================
+
+    /**
+     * @brief Checks if the transport is currently connected
+     * @return true if connected and ready to send/receive, false otherwise
+     *
+     * ### Thread Safety
+     * Thread-safe. Uses atomic operations internally.
+     *
+     * ### Note
+     * A false return may indicate:
+     * - Connection not yet established
+     * - Connection closed by remote peer
+     * - Connection closed locally
+     * - Network error occurred
+     */
+    [[nodiscard]] virtual auto is_connected() const noexcept -> bool = 0;
+
+    /**
+     * @brief Gets the unique identifier for this transport/connection
+     * @return A string view of the transport ID
+     *
+     * The ID is unique within the application and remains constant
+     * for the lifetime of the transport instance.
+     */
+    [[nodiscard]] virtual auto id() const noexcept -> std::string_view = 0;
+
+    /**
+     * @brief Gets the remote endpoint information
+     * @return endpoint_info of the remote peer
+     *
+     * Returns valid information only when connected.
+     * Returns empty endpoint_info if not connected.
+     */
+    [[nodiscard]] virtual auto remote_endpoint() const noexcept -> endpoint_info = 0;
+
+    /**
+     * @brief Gets the local endpoint information
+     * @return endpoint_info of the local side
+     *
+     * Returns valid information only when connected/listening.
+     * Returns empty endpoint_info if not bound.
+     */
+    [[nodiscard]] virtual auto local_endpoint() const noexcept -> endpoint_info = 0;
+
+protected:
+    /**
+     * @brief Default constructor (only for derived classes)
+     */
+    i_transport() = default;
+};
+
+}  // namespace kcenon::network::unified

--- a/include/kcenon/network/unified/types.h
+++ b/include/kcenon/network/unified/types.h
@@ -1,0 +1,229 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+namespace kcenon::network::unified {
+
+/**
+ * @struct endpoint_info
+ * @brief Network endpoint information (host/port or URL)
+ *
+ * Represents a network endpoint that can be either a host:port combination
+ * or a full URL (for protocols like WebSocket that use URLs).
+ *
+ * ### Thread Safety
+ * Immutable after construction, safe for concurrent read access.
+ *
+ * ### Examples
+ * @code
+ * // Host/port style
+ * endpoint_info tcp_ep{"192.168.1.1", 8080};
+ * endpoint_info local_ep{"localhost", 3000};
+ *
+ * // URL style (for WebSocket, HTTP)
+ * endpoint_info ws_ep{"wss://example.com/ws"};
+ *
+ * // Copy and compare
+ * auto ep2 = tcp_ep;
+ * if (tcp_ep == ep2) { ... }
+ * @endcode
+ */
+struct endpoint_info {
+    std::string host;    ///< Hostname, IP address, or full URL
+    uint16_t port = 0;   ///< Port number (0 if embedded in URL)
+
+    /**
+     * @brief Default constructor creates an empty endpoint
+     */
+    endpoint_info() = default;
+
+    /**
+     * @brief Constructs endpoint from host and port
+     * @param h Hostname or IP address
+     * @param p Port number
+     */
+    endpoint_info(const std::string& h, uint16_t p) : host(h), port(p) {}
+
+    /**
+     * @brief Constructs endpoint from C-string host and port
+     * @param h Hostname or IP address (C-string)
+     * @param p Port number
+     */
+    endpoint_info(const char* h, uint16_t p) : host(h), port(p) {}
+
+    /**
+     * @brief Constructs endpoint from URL (port extracted if present)
+     * @param url Full URL (e.g., "wss://example.com:443/ws")
+     *
+     * For URL-based protocols, the host field contains the full URL
+     * and port may be 0 if embedded in the URL.
+     */
+    explicit endpoint_info(const std::string& url) : host(url), port(0) {}
+
+    /**
+     * @brief Constructs endpoint from C-string URL
+     * @param url Full URL (C-string)
+     */
+    explicit endpoint_info(const char* url) : host(url), port(0) {}
+
+    /**
+     * @brief Checks if the endpoint is valid (non-empty host)
+     * @return true if host is not empty
+     */
+    [[nodiscard]] auto is_valid() const noexcept -> bool { return !host.empty(); }
+
+    /**
+     * @brief Returns string representation of the endpoint
+     * @return "host:port" or URL string
+     */
+    [[nodiscard]] auto to_string() const -> std::string {
+        if (port == 0) {
+            return host;
+        }
+        return host + ":" + std::to_string(port);
+    }
+
+    /**
+     * @brief Equality comparison
+     */
+    [[nodiscard]] auto operator==(const endpoint_info& other) const noexcept -> bool {
+        return host == other.host && port == other.port;
+    }
+
+    /**
+     * @brief Inequality comparison
+     */
+    [[nodiscard]] auto operator!=(const endpoint_info& other) const noexcept -> bool {
+        return !(*this == other);
+    }
+};
+
+/**
+ * @struct connection_callbacks
+ * @brief Callback functions for connection events
+ *
+ * Groups all callback functions that can be registered for connection
+ * lifecycle events. All callbacks are optional (can be empty).
+ *
+ * ### Thread Safety
+ * Callbacks may be invoked from I/O threads. Implementations must ensure
+ * their callbacks are thread-safe if they access shared state.
+ *
+ * ### Examples
+ * @code
+ * connection_callbacks cbs;
+ * cbs.on_connected = []() {
+ *     std::cout << "Connected!" << std::endl;
+ * };
+ * cbs.on_data = [](std::span<const std::byte> data) {
+ *     // Process received data
+ * };
+ * cbs.on_disconnected = []() {
+ *     std::cout << "Disconnected!" << std::endl;
+ * };
+ * cbs.on_error = [](std::error_code ec) {
+ *     std::cerr << "Error: " << ec.message() << std::endl;
+ * };
+ * @endcode
+ */
+struct connection_callbacks {
+    /// Called when connection is established
+    std::function<void()> on_connected;
+
+    /// Called when data is received (raw bytes)
+    std::function<void(std::span<const std::byte>)> on_data;
+
+    /// Called when connection is closed
+    std::function<void()> on_disconnected;
+
+    /// Called when an error occurs
+    std::function<void(std::error_code)> on_error;
+};
+
+/**
+ * @struct listener_callbacks
+ * @brief Callback functions for listener/server events
+ *
+ * Groups all callback functions that can be registered for server-side
+ * events including new connections and errors.
+ *
+ * ### Thread Safety
+ * Callbacks may be invoked from I/O threads.
+ */
+struct listener_callbacks {
+    /// Called when a new connection is accepted (connection ID)
+    std::function<void(std::string_view)> on_accept;
+
+    /// Called when data is received from a connection (connection ID, data)
+    std::function<void(std::string_view, std::span<const std::byte>)> on_data;
+
+    /// Called when a connection is closed (connection ID)
+    std::function<void(std::string_view)> on_disconnect;
+
+    /// Called when an error occurs (connection ID, error)
+    std::function<void(std::string_view, std::error_code)> on_error;
+};
+
+/**
+ * @struct connection_options
+ * @brief Configuration options for connections
+ *
+ * Provides optional configuration parameters that can be set on connections.
+ */
+struct connection_options {
+    /// Connection timeout duration (0 = no timeout)
+    std::chrono::milliseconds connect_timeout{0};
+
+    /// Read operation timeout (0 = no timeout)
+    std::chrono::milliseconds read_timeout{0};
+
+    /// Write operation timeout (0 = no timeout)
+    std::chrono::milliseconds write_timeout{0};
+
+    /// Enable TCP keep-alive (where applicable)
+    bool keep_alive = false;
+
+    /// TCP no-delay (disable Nagle's algorithm)
+    bool no_delay = false;
+};
+
+}  // namespace kcenon::network::unified

--- a/include/kcenon/network/unified/unified.h
+++ b/include/kcenon/network/unified/unified.h
@@ -1,0 +1,112 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+/**
+ * @file unified.h
+ * @brief Convenience header for the unified network interface API
+ *
+ * This header provides a single include point for the consolidated
+ * network interface architecture (3 core interfaces).
+ *
+ * ### The Three Core Interfaces
+ *
+ * 1. **i_transport** - Data transport abstraction
+ *    - send(), is_connected(), remote_endpoint()
+ *    - Base interface for all data transfer operations
+ *
+ * 2. **i_connection** - Active connection (client-side or accepted)
+ *    - Extends i_transport with connect(), close(), set_callbacks()
+ *    - Used by both client-initiated and server-accepted connections
+ *
+ * 3. **i_listener** - Passive listener (server-side)
+ *    - start(), stop(), set_accept_callback()
+ *    - Accepts incoming connections and manages them
+ *
+ * ### Supporting Types
+ *
+ * - **endpoint_info** - Network endpoint (host:port or URL)
+ * - **connection_callbacks** - Callback functions for connections
+ * - **listener_callbacks** - Callback functions for listeners
+ * - **connection_options** - Configuration options
+ *
+ * ### Usage Example
+ * @code
+ * #include <kcenon/network/unified/unified.h>
+ *
+ * using namespace kcenon::network::unified;
+ *
+ * // Client-side
+ * void client_example(std::unique_ptr<i_connection> conn) {
+ *     conn->set_callbacks({
+ *         .on_connected = []() { },
+ *         .on_data = [](std::span<const std::byte> data) { }
+ *     });
+ *     conn->connect(endpoint_info("localhost", 8080));
+ *     conn->send(some_data);
+ * }
+ *
+ * // Server-side
+ * void server_example(std::unique_ptr<i_listener> listener) {
+ *     listener->set_callbacks({
+ *         .on_accept = [](std::string_view id) { },
+ *         .on_data = [](std::string_view id, std::span<const std::byte> data) { }
+ *     });
+ *     listener->start(8080);
+ * }
+ * @endcode
+ *
+ * ### Migration from Legacy Interfaces
+ *
+ * | Legacy Interface | Unified Interface |
+ * |------------------|-------------------|
+ * | i_client | i_connection |
+ * | i_tcp_client | i_connection (via protocol::tcp) |
+ * | i_udp_client | i_connection (via protocol::udp) |
+ * | i_websocket_client | i_connection (via protocol::websocket) |
+ * | i_quic_client | i_connection (via protocol::quic) |
+ * | i_server | i_listener |
+ * | i_session | i_connection (accepted) |
+ *
+ * @see i_transport
+ * @see i_connection
+ * @see i_listener
+ */
+
+// Core types
+#include "types.h"
+
+// Core interfaces
+#include "i_transport.h"
+#include "i_connection.h"
+#include "i_listener.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1799,6 +1799,40 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
     message(STATUS "QUIC messaging server tests enabled")
 
+    ##################################################
+    # Unified Interface Tests (Issue #521 Phase 1)
+    ##################################################
+
+    # Unified interfaces tests
+    add_executable(network_unified_interfaces_test
+        unified/unified_interfaces_test.cpp
+    )
+
+    target_link_libraries(network_unified_interfaces_test PRIVATE
+        NetworkSystem
+        GTest::gtest
+        GTest::gtest_main
+        Threads::Threads
+    )
+
+    setup_asio_integration(network_unified_interfaces_test)
+
+    if(COMMON_SYSTEM_INCLUDE_DIR)
+        target_include_directories(network_unified_interfaces_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+        target_compile_definitions(network_unified_interfaces_test PRIVATE WITH_COMMON_SYSTEM)
+    endif()
+
+    set_target_properties(network_unified_interfaces_test PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    )
+
+    gtest_discover_tests(network_unified_interfaces_test
+        DISCOVERY_TIMEOUT 60
+    )
+    message(STATUS "Unified interfaces tests enabled")
+
 else()
     message(WARNING "GTest not found - unit tests will not be built")
 endif()

--- a/tests/unified/unified_interfaces_test.cpp
+++ b/tests/unified/unified_interfaces_test.cpp
@@ -1,0 +1,175 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+*****************************************************************************/
+
+/**
+ * @file unified_interfaces_test.cpp
+ * @brief Tests for unified interface definitions
+ *
+ * These tests verify that the unified interfaces compile correctly and
+ * that the type definitions are usable.
+ */
+
+#include <gtest/gtest.h>
+
+#include "kcenon/network/unified/unified.h"
+
+#include <memory>
+#include <vector>
+
+namespace kcenon::network::unified::test {
+
+// Test that types compile and can be instantiated
+class UnifiedTypesTest : public ::testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(UnifiedTypesTest, EndpointInfoDefaultConstruction) {
+    endpoint_info ep;
+    EXPECT_TRUE(ep.host.empty());
+    EXPECT_EQ(ep.port, 0);
+    EXPECT_FALSE(ep.is_valid());
+}
+
+TEST_F(UnifiedTypesTest, EndpointInfoHostPortConstruction) {
+    endpoint_info ep("localhost", 8080);
+    EXPECT_EQ(ep.host, "localhost");
+    EXPECT_EQ(ep.port, 8080);
+    EXPECT_TRUE(ep.is_valid());
+}
+
+TEST_F(UnifiedTypesTest, EndpointInfoUrlConstruction) {
+    endpoint_info ep(std::string("wss://example.com/ws"));
+    EXPECT_EQ(ep.host, "wss://example.com/ws");
+    EXPECT_EQ(ep.port, 0);
+    EXPECT_TRUE(ep.is_valid());
+}
+
+TEST_F(UnifiedTypesTest, EndpointInfoStringViewConstruction) {
+    std::string host = "192.168.1.1";
+    endpoint_info ep{host, 443};
+    EXPECT_EQ(ep.host, "192.168.1.1");
+    EXPECT_EQ(ep.port, 443);
+}
+
+TEST_F(UnifiedTypesTest, EndpointInfoToString) {
+    endpoint_info ep1{"localhost", 8080};
+    EXPECT_EQ(ep1.to_string(), "localhost:8080");
+
+    endpoint_info ep2{"wss://example.com/ws"};
+    EXPECT_EQ(ep2.to_string(), "wss://example.com/ws");
+}
+
+TEST_F(UnifiedTypesTest, EndpointInfoEquality) {
+    endpoint_info ep1{"localhost", 8080};
+    endpoint_info ep2{"localhost", 8080};
+    endpoint_info ep3{"localhost", 9090};
+    endpoint_info ep4{"127.0.0.1", 8080};
+
+    EXPECT_EQ(ep1, ep2);
+    EXPECT_NE(ep1, ep3);
+    EXPECT_NE(ep1, ep4);
+}
+
+TEST_F(UnifiedTypesTest, ConnectionCallbacksDefaultConstruction) {
+    connection_callbacks cbs;
+    EXPECT_FALSE(cbs.on_connected);
+    EXPECT_FALSE(cbs.on_data);
+    EXPECT_FALSE(cbs.on_disconnected);
+    EXPECT_FALSE(cbs.on_error);
+}
+
+TEST_F(UnifiedTypesTest, ConnectionCallbacksAssignment) {
+    bool connected_called = false;
+    bool data_called = false;
+
+    connection_callbacks cbs;
+    cbs.on_connected = [&]() { connected_called = true; };
+    cbs.on_data = [&](std::span<const std::byte>) { data_called = true; };
+
+    EXPECT_TRUE(cbs.on_connected);
+    EXPECT_TRUE(cbs.on_data);
+
+    cbs.on_connected();
+    EXPECT_TRUE(connected_called);
+
+    std::vector<std::byte> data;
+    cbs.on_data(data);
+    EXPECT_TRUE(data_called);
+}
+
+TEST_F(UnifiedTypesTest, ListenerCallbacksDefaultConstruction) {
+    listener_callbacks cbs;
+    EXPECT_FALSE(cbs.on_accept);
+    EXPECT_FALSE(cbs.on_data);
+    EXPECT_FALSE(cbs.on_disconnect);
+    EXPECT_FALSE(cbs.on_error);
+}
+
+TEST_F(UnifiedTypesTest, ConnectionOptionsDefaultValues) {
+    connection_options opts;
+    EXPECT_EQ(opts.connect_timeout.count(), 0);
+    EXPECT_EQ(opts.read_timeout.count(), 0);
+    EXPECT_EQ(opts.write_timeout.count(), 0);
+    EXPECT_FALSE(opts.keep_alive);
+    EXPECT_FALSE(opts.no_delay);
+}
+
+TEST_F(UnifiedTypesTest, ConnectionOptionsCustomValues) {
+    connection_options opts;
+    opts.connect_timeout = std::chrono::milliseconds{5000};
+    opts.read_timeout = std::chrono::milliseconds{30000};
+    opts.keep_alive = true;
+    opts.no_delay = true;
+
+    EXPECT_EQ(opts.connect_timeout.count(), 5000);
+    EXPECT_EQ(opts.read_timeout.count(), 30000);
+    EXPECT_TRUE(opts.keep_alive);
+    EXPECT_TRUE(opts.no_delay);
+}
+
+// Test that interfaces can be used as types (compile-time check)
+class InterfaceTypeTest : public ::testing::Test {};
+
+TEST_F(InterfaceTypeTest, TransportPointerType) {
+    // Verify i_transport can be used as a pointer type
+    i_transport* transport_ptr = nullptr;
+    EXPECT_EQ(transport_ptr, nullptr);
+
+    std::unique_ptr<i_transport> transport_uptr;
+    EXPECT_EQ(transport_uptr, nullptr);
+}
+
+TEST_F(InterfaceTypeTest, ConnectionPointerType) {
+    // Verify i_connection can be used as a pointer type
+    i_connection* connection_ptr = nullptr;
+    EXPECT_EQ(connection_ptr, nullptr);
+
+    std::unique_ptr<i_connection> connection_uptr;
+    EXPECT_EQ(connection_uptr, nullptr);
+}
+
+TEST_F(InterfaceTypeTest, ListenerPointerType) {
+    // Verify i_listener can be used as a pointer type
+    i_listener* listener_ptr = nullptr;
+    EXPECT_EQ(listener_ptr, nullptr);
+
+    std::unique_ptr<i_listener> listener_uptr;
+    EXPECT_EQ(listener_uptr, nullptr);
+}
+
+TEST_F(InterfaceTypeTest, ConnectionInheritsFromTransport) {
+    // Verify i_connection inherits from i_transport (compile-time)
+    // This compiles only if i_connection publicly inherits from i_transport
+    auto check_inheritance = [](i_transport*) {};
+    i_connection* conn_ptr = nullptr;
+    check_inheritance(conn_ptr);
+    SUCCEED();
+}
+
+}  // namespace kcenon::network::unified::test


### PR DESCRIPTION
## Summary

This PR implements Phase 1 of the interface consolidation effort outlined in #521, introducing the 3 core unified interfaces:

- **`i_transport`** - Base data transport abstraction providing `send()`, `is_connected()`, `id()`, and endpoint queries
- **`i_connection`** - Extends `i_transport` with connection lifecycle: `connect()`, `close()`, callbacks, and options
- **`i_listener`** - Server-side passive listener with `start()`, `stop()`, `broadcast()`, and connection management

### Supporting Types

- `endpoint_info` - Network endpoint representation (host:port or URL)
- `connection_callbacks` - Event handlers for connection events (on_connected, on_data, on_disconnected, on_error)
- `listener_callbacks` - Server-side event handlers (on_accept, on_data, on_disconnect, on_error)
- `connection_options` - Timeout and socket configuration

### Design Decisions

- Pure virtual interfaces with no implementation coupling
- Protocol-agnostic design (TCP, UDP, WebSocket, QUIC via factory methods in future phases)
- Modern C++20 features: `std::span<const std::byte>` for data, `[[nodiscard]]`, trailing return types
- VoidResult/Result<T> error handling pattern consistent with existing codebase
- Non-copyable, movable interface classes

## Test Plan

- [x] All 15 unit tests pass for type compilation and usage
- [x] Interface pointer types compile correctly
- [x] Inheritance hierarchy (i_connection -> i_transport) verified
- [x] Callback assignment and invocation tested
- [x] endpoint_info equality and string conversion tested

## Files Changed

| File | Description |
|------|-------------|
| `include/kcenon/network/unified/types.h` | Supporting types |
| `include/kcenon/network/unified/i_transport.h` | Base transport interface |
| `include/kcenon/network/unified/i_connection.h` | Connection interface |
| `include/kcenon/network/unified/i_listener.h` | Listener interface |
| `include/kcenon/network/unified/unified.h` | Convenience header |
| `tests/unified/unified_interfaces_test.cpp` | Unit tests |
| `tests/CMakeLists.txt` | Test target configuration |

Closes Phase 1 of #521