### PR TITLE
feat(protocol): implement UDP factory functions (Phase 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,9 +283,12 @@ add_library(NetworkSystem
     # Unified interface adapters (Issue #521 Phase 2)
     src/unified/adapters/tcp_connection_adapter.cpp
     src/unified/adapters/tcp_listener_adapter.cpp
+    src/unified/adapters/udp_connection_adapter.cpp
+    src/unified/adapters/udp_listener_adapter.cpp
 
     # Protocol factory functions (Issue #521 Phase 2)
     src/protocol/tcp.cpp
+    src/protocol/udp.cpp
 
     # Internal implementation
     src/internal/tcp_socket.cpp

--- a/include/kcenon/network/protocol/protocol.h
+++ b/include/kcenon/network/protocol/protocol.h
@@ -44,9 +44,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * | Namespace | Factory Functions |
  * |-----------|-------------------|
  * | `protocol::tcp` | `connect()`, `listen()`, `create_connection()`, `create_listener()` |
+ * | `protocol::udp` | `connect()`, `listen()`, `create_connection()`, `create_listener()` |
  *
  * ### Future Protocol Support
- * - `protocol::udp` - UDP datagram connections (planned)
  * - `protocol::websocket` - WebSocket connections (planned)
  * - `protocol::quic` - QUIC connections (planned)
  *
@@ -72,6 +72,25 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *         std::cout << "New connection: " << conn_id << "\n";
  *     }
  * });
+ *
+ * // UDP client
+ * auto udp_conn = protocol::udp::connect({"localhost", 5555});
+ * udp_conn->set_callbacks({
+ *     .on_data = [](std::span<const std::byte> data) {
+ *         // Handle received datagram
+ *     }
+ * });
+ *
+ * // UDP server
+ * auto udp_server = protocol::udp::listen(5555);
+ * udp_server->set_callbacks({
+ *     .on_accept = [](std::string_view conn_id) {
+ *         std::cout << "New endpoint: " << conn_id << "\n";
+ *     },
+ *     .on_data = [](std::string_view conn_id, std::span<const std::byte> data) {
+ *         // Handle received datagram from conn_id
+ *     }
+ * });
  * @endcode
  *
  * @see unified::i_connection
@@ -81,6 +100,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // Protocol factory headers
 #include "tcp.h"
+#include "udp.h"
 
 // Protocol tag types
 #include "protocol_tags.h"

--- a/include/kcenon/network/protocol/udp.h
+++ b/include/kcenon/network/protocol/udp.h
@@ -1,0 +1,172 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include "kcenon/network/unified/i_connection.h"
+#include "kcenon/network/unified/i_listener.h"
+#include "kcenon/network/unified/types.h"
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace kcenon::network::protocol::udp {
+
+/**
+ * @brief Creates a UDP connection (not yet started)
+ * @param id Optional unique identifier for the connection
+ * @return Unique pointer to an i_connection instance
+ *
+ * The returned connection is not started. Call connect() to set the
+ * target endpoint and start the UDP client.
+ *
+ * ### UDP Semantics
+ * Unlike TCP, UDP is connectionless. The "connection" object manages
+ * a UDP socket that sends datagrams to a configured target endpoint.
+ * - connect() sets the target and starts the client
+ * - is_connected() returns true while the client is running
+ * - send() sends datagrams to the target endpoint
+ *
+ * ### Usage Example
+ * @code
+ * auto conn = protocol::udp::create_connection("my-udp-client");
+ * conn->set_callbacks({
+ *     .on_connected = []() { std::cout << "Started!\n"; },
+ *     .on_data = [](std::span<const std::byte> data) {
+ *         // Handle received datagram
+ *     }
+ * });
+ * conn->connect({"localhost", 5555});
+ * @endcode
+ */
+[[nodiscard]] auto create_connection(std::string_view id = "")
+    -> std::unique_ptr<unified::i_connection>;
+
+/**
+ * @brief Creates and starts a UDP connection in one call
+ * @param endpoint The target endpoint to send datagrams to
+ * @param id Optional unique identifier for the connection
+ * @return Unique pointer to an i_connection instance (running)
+ *
+ * This is a convenience function that creates a UDP connection and
+ * immediately starts it with the specified target endpoint.
+ *
+ * ### Usage Example
+ * @code
+ * auto conn = protocol::udp::connect({"localhost", 5555});
+ * conn->set_callbacks({
+ *     .on_data = [](std::span<const std::byte> data) { }
+ * });
+ * // UDP client is already running
+ * @endcode
+ */
+[[nodiscard]] auto connect(const unified::endpoint_info& endpoint,
+                           std::string_view id = "")
+    -> std::unique_ptr<unified::i_connection>;
+
+/**
+ * @brief Creates and starts a UDP connection using URL format
+ * @param url The URL to connect to (format: "udp://host:port" or "host:port")
+ * @param id Optional unique identifier for the connection
+ * @return Unique pointer to an i_connection instance (running)
+ */
+[[nodiscard]] auto connect(std::string_view url, std::string_view id = "")
+    -> std::unique_ptr<unified::i_connection>;
+
+/**
+ * @brief Creates a UDP listener (not yet listening)
+ * @param id Optional unique identifier for the listener
+ * @return Unique pointer to an i_listener instance
+ *
+ * The returned listener is not listening. Call start() to begin
+ * receiving datagrams.
+ *
+ * ### UDP Semantics
+ * Unlike TCP, UDP servers don't accept connections. Instead, they
+ * receive datagrams from any sender. The listener tracks unique
+ * sender endpoints as virtual "connections" for convenience.
+ * - on_accept is called when a new sender endpoint is seen
+ * - connection_id is formatted as "address:port"
+ * - send_to() sends datagrams back to specific endpoints
+ *
+ * ### Usage Example
+ * @code
+ * auto listener = protocol::udp::create_listener("my-udp-server");
+ * listener->set_callbacks({
+ *     .on_accept = [](std::string_view conn_id) {
+ *         std::cout << "New endpoint: " << conn_id << "\n";
+ *     },
+ *     .on_data = [](std::string_view conn_id, std::span<const std::byte> data) {
+ *         // Handle received datagram from conn_id
+ *     }
+ * });
+ * listener->start(5555);
+ * @endcode
+ */
+[[nodiscard]] auto create_listener(std::string_view id = "")
+    -> std::unique_ptr<unified::i_listener>;
+
+/**
+ * @brief Creates and starts a UDP listener in one call
+ * @param bind_address The local address to bind to
+ * @param id Optional unique identifier for the listener
+ * @return Unique pointer to an i_listener instance (listening)
+ *
+ * This is a convenience function that creates a listener and immediately
+ * starts listening on the specified address.
+ *
+ * ### Usage Example
+ * @code
+ * auto listener = protocol::udp::listen({"0.0.0.0", 5555});
+ * listener->set_callbacks({
+ *     .on_data = [](std::string_view conn_id, std::span<const std::byte> data) { }
+ * });
+ * // Listener is already receiving datagrams
+ * @endcode
+ */
+[[nodiscard]] auto listen(const unified::endpoint_info& bind_address,
+                          std::string_view id = "")
+    -> std::unique_ptr<unified::i_listener>;
+
+/**
+ * @brief Creates and starts a UDP listener on a specific port
+ * @param port The port number to listen on
+ * @param id Optional unique identifier for the listener
+ * @return Unique pointer to an i_listener instance (listening)
+ *
+ * Convenience overload that binds to all interfaces (0.0.0.0).
+ */
+[[nodiscard]] auto listen(uint16_t port, std::string_view id = "")
+    -> std::unique_ptr<unified::i_listener>;
+
+}  // namespace kcenon::network::protocol::udp

--- a/include/kcenon/network/unified/adapters/udp_connection_adapter.h
+++ b/include/kcenon/network/unified/adapters/udp_connection_adapter.h
@@ -1,0 +1,129 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include "kcenon/network/unified/i_connection.h"
+#include "kcenon/network/core/messaging_udp_client.h"
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace kcenon::network::unified::adapters {
+
+/**
+ * @class udp_connection_adapter
+ * @brief Adapter that wraps messaging_udp_client to implement i_connection
+ *
+ * This adapter bridges the existing UDP client implementation with the new
+ * unified interface. Note that UDP is connectionless - "connect" simply sets
+ * the target endpoint, and the connection is considered "connected" when the
+ * client is running.
+ *
+ * ### Thread Safety
+ * Thread-safe. All methods can be called from any thread.
+ *
+ * ### Ownership
+ * The adapter owns the underlying client via shared_ptr for proper RAII.
+ *
+ * ### UDP Semantics
+ * - connect() sets target endpoint and starts the client
+ * - is_connected() returns true when client is running
+ * - send() sends datagrams to the configured target endpoint
+ * - Data arrives via on_data callback
+ */
+class udp_connection_adapter : public i_connection {
+public:
+    /**
+     * @brief Constructs an adapter with a unique connection ID
+     * @param connection_id Unique identifier for this connection
+     */
+    explicit udp_connection_adapter(std::string_view connection_id);
+
+    /**
+     * @brief Destructor ensures proper cleanup
+     */
+    ~udp_connection_adapter() override;
+
+    // Non-copyable, non-movable (contains mutex)
+    udp_connection_adapter(const udp_connection_adapter&) = delete;
+    udp_connection_adapter& operator=(const udp_connection_adapter&) = delete;
+    udp_connection_adapter(udp_connection_adapter&&) = delete;
+    udp_connection_adapter& operator=(udp_connection_adapter&&) = delete;
+
+    // =========================================================================
+    // i_transport interface implementation
+    // =========================================================================
+
+    [[nodiscard]] auto send(std::span<const std::byte> data) -> VoidResult override;
+    [[nodiscard]] auto send(std::vector<uint8_t>&& data) -> VoidResult override;
+    [[nodiscard]] auto is_connected() const noexcept -> bool override;
+    [[nodiscard]] auto id() const noexcept -> std::string_view override;
+    [[nodiscard]] auto remote_endpoint() const noexcept -> endpoint_info override;
+    [[nodiscard]] auto local_endpoint() const noexcept -> endpoint_info override;
+
+    // =========================================================================
+    // i_connection interface implementation
+    // =========================================================================
+
+    [[nodiscard]] auto connect(const endpoint_info& endpoint) -> VoidResult override;
+    [[nodiscard]] auto connect(std::string_view url) -> VoidResult override;
+    auto close() noexcept -> void override;
+    auto set_callbacks(connection_callbacks callbacks) -> void override;
+    auto set_options(connection_options options) -> void override;
+    auto set_timeout(std::chrono::milliseconds timeout) -> void override;
+    [[nodiscard]] auto is_connecting() const noexcept -> bool override;
+    auto wait_for_stop() -> void override;
+
+private:
+    /**
+     * @brief Sets up internal callbacks to bridge to unified callbacks
+     */
+    auto setup_internal_callbacks() -> void;
+
+    std::string connection_id_;
+    std::shared_ptr<core::messaging_udp_client> client_;
+
+    mutable std::mutex callbacks_mutex_;
+    connection_callbacks callbacks_;
+
+    mutable std::mutex endpoint_mutex_;
+    endpoint_info remote_endpoint_;
+    endpoint_info local_endpoint_;
+
+    std::atomic<bool> is_connecting_{false};
+    connection_options options_;
+};
+
+}  // namespace kcenon::network::unified::adapters

--- a/include/kcenon/network/unified/adapters/udp_listener_adapter.h
+++ b/include/kcenon/network/unified/adapters/udp_listener_adapter.h
@@ -1,0 +1,135 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include "kcenon/network/unified/i_listener.h"
+#include "kcenon/network/core/messaging_udp_server.h"
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace kcenon::network::unified::adapters {
+
+/**
+ * @class udp_listener_adapter
+ * @brief Adapter that wraps messaging_udp_server to implement i_listener
+ *
+ * This adapter bridges the existing UDP server implementation with the new
+ * unified interface. Note that UDP is connectionless - there are no real
+ * "connections" to accept. Instead, we track unique remote endpoints that
+ * send data to us.
+ *
+ * ### Thread Safety
+ * Thread-safe. All methods can be called from any thread.
+ *
+ * ### Ownership
+ * The adapter owns the underlying server via shared_ptr for proper RAII.
+ *
+ * ### UDP Semantics
+ * - start() binds to a local port and begins receiving datagrams
+ * - Each unique sender endpoint is tracked as a virtual "connection"
+ * - on_accept callback is triggered when a new endpoint sends data
+ * - send_to() and broadcast() send datagrams to specific/all endpoints
+ */
+class udp_listener_adapter : public i_listener {
+public:
+    /**
+     * @brief Constructs an adapter with a unique listener ID
+     * @param listener_id Unique identifier for this listener
+     */
+    explicit udp_listener_adapter(std::string_view listener_id);
+
+    /**
+     * @brief Destructor ensures proper cleanup
+     */
+    ~udp_listener_adapter() override;
+
+    // Non-copyable, non-movable (contains mutex)
+    udp_listener_adapter(const udp_listener_adapter&) = delete;
+    udp_listener_adapter& operator=(const udp_listener_adapter&) = delete;
+    udp_listener_adapter(udp_listener_adapter&&) = delete;
+    udp_listener_adapter& operator=(udp_listener_adapter&&) = delete;
+
+    // =========================================================================
+    // i_listener interface implementation
+    // =========================================================================
+
+    [[nodiscard]] auto start(const endpoint_info& bind_address) -> VoidResult override;
+    [[nodiscard]] auto start(uint16_t port) -> VoidResult override;
+    auto stop() noexcept -> void override;
+    auto set_callbacks(listener_callbacks callbacks) -> void override;
+    auto set_accept_callback(accept_callback_t callback) -> void override;
+    [[nodiscard]] auto is_listening() const noexcept -> bool override;
+    [[nodiscard]] auto local_endpoint() const noexcept -> endpoint_info override;
+    [[nodiscard]] auto connection_count() const noexcept -> size_t override;
+    [[nodiscard]] auto send_to(std::string_view connection_id,
+                                std::span<const std::byte> data) -> VoidResult override;
+    [[nodiscard]] auto broadcast(std::span<const std::byte> data) -> VoidResult override;
+    auto close_connection(std::string_view connection_id) noexcept -> void override;
+    auto wait_for_stop() -> void override;
+
+private:
+    /**
+     * @brief Sets up internal callbacks to bridge to unified callbacks
+     */
+    auto setup_internal_callbacks() -> void;
+
+    /**
+     * @brief Generates a connection ID from an endpoint
+     */
+    static auto make_connection_id(const std::string& address, uint16_t port) -> std::string;
+
+    /**
+     * @brief Parses a connection ID back to endpoint info
+     */
+    static auto parse_connection_id(std::string_view connection_id) -> std::optional<endpoint_info>;
+
+    std::string listener_id_;
+    std::shared_ptr<core::messaging_udp_server> server_;
+
+    mutable std::mutex callbacks_mutex_;
+    listener_callbacks callbacks_;
+    accept_callback_t accept_callback_;
+
+    mutable std::mutex endpoint_mutex_;
+    endpoint_info local_endpoint_;
+
+    // Track known remote endpoints (for UDP's virtual "connections")
+    mutable std::mutex connections_mutex_;
+    std::unordered_map<std::string, endpoint_info> known_endpoints_;
+};
+
+}  // namespace kcenon::network::unified::adapters

--- a/src/protocol/udp.cpp
+++ b/src/protocol/udp.cpp
@@ -1,0 +1,103 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include "kcenon/network/protocol/udp.h"
+#include "kcenon/network/unified/adapters/udp_connection_adapter.h"
+#include "kcenon/network/unified/adapters/udp_listener_adapter.h"
+
+#include <atomic>
+#include <chrono>
+#include <sstream>
+
+namespace kcenon::network::protocol::udp {
+
+namespace {
+
+/**
+ * @brief Generates a unique ID if none is provided
+ */
+auto generate_unique_id(std::string_view prefix) -> std::string
+{
+    static std::atomic<uint64_t> counter{0};
+    auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+    auto count = counter.fetch_add(1);
+
+    std::ostringstream oss;
+    oss << prefix << "-" << now << "-" << count;
+    return oss.str();
+}
+
+}  // namespace
+
+auto create_connection(std::string_view id) -> std::unique_ptr<unified::i_connection>
+{
+    std::string connection_id = id.empty() ? generate_unique_id("udp-conn") : std::string(id);
+    return std::make_unique<unified::adapters::udp_connection_adapter>(connection_id);
+}
+
+auto connect(const unified::endpoint_info& endpoint, std::string_view id)
+    -> std::unique_ptr<unified::i_connection>
+{
+    auto conn = create_connection(id);
+    // Initiate "connection" (for UDP, this starts the client with target endpoint)
+    (void)conn->connect(endpoint);
+    return conn;
+}
+
+auto connect(std::string_view url, std::string_view id)
+    -> std::unique_ptr<unified::i_connection>
+{
+    auto conn = create_connection(id);
+    (void)conn->connect(url);
+    return conn;
+}
+
+auto create_listener(std::string_view id) -> std::unique_ptr<unified::i_listener>
+{
+    std::string listener_id = id.empty() ? generate_unique_id("udp-listener") : std::string(id);
+    return std::make_unique<unified::adapters::udp_listener_adapter>(listener_id);
+}
+
+auto listen(const unified::endpoint_info& bind_address, std::string_view id)
+    -> std::unique_ptr<unified::i_listener>
+{
+    auto listener = create_listener(id);
+    (void)listener->start(bind_address);
+    return listener;
+}
+
+auto listen(uint16_t port, std::string_view id) -> std::unique_ptr<unified::i_listener>
+{
+    return listen(unified::endpoint_info{"0.0.0.0", port}, id);
+}
+
+}  // namespace kcenon::network::protocol::udp

--- a/src/unified/adapters/udp_connection_adapter.cpp
+++ b/src/unified/adapters/udp_connection_adapter.cpp
@@ -1,0 +1,259 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include "kcenon/network/unified/adapters/udp_connection_adapter.h"
+
+#include <algorithm>
+#include <cstring>
+
+namespace kcenon::network::unified::adapters {
+
+udp_connection_adapter::udp_connection_adapter(std::string_view connection_id)
+    : connection_id_(connection_id)
+    , client_(std::make_shared<core::messaging_udp_client>(connection_id))
+{
+    setup_internal_callbacks();
+}
+
+udp_connection_adapter::~udp_connection_adapter()
+{
+    close();
+}
+
+auto udp_connection_adapter::send(std::span<const std::byte> data) -> VoidResult
+{
+    if (!client_ || !client_->is_running()) {
+        return error_void(
+            static_cast<int>(std::errc::not_connected),
+            "UDP client is not running"
+        );
+    }
+
+    std::vector<uint8_t> buffer(data.size());
+    std::memcpy(buffer.data(), data.data(), data.size());
+
+    return client_->send(std::move(buffer));
+}
+
+auto udp_connection_adapter::send(std::vector<uint8_t>&& data) -> VoidResult
+{
+    if (!client_ || !client_->is_running()) {
+        return error_void(
+            static_cast<int>(std::errc::not_connected),
+            "UDP client is not running"
+        );
+    }
+
+    return client_->send(std::move(data));
+}
+
+auto udp_connection_adapter::is_connected() const noexcept -> bool
+{
+    // For UDP, "connected" means the client is running with a target endpoint
+    return client_ && client_->is_running();
+}
+
+auto udp_connection_adapter::id() const noexcept -> std::string_view
+{
+    return connection_id_;
+}
+
+auto udp_connection_adapter::remote_endpoint() const noexcept -> endpoint_info
+{
+    std::lock_guard lock(endpoint_mutex_);
+    return remote_endpoint_;
+}
+
+auto udp_connection_adapter::local_endpoint() const noexcept -> endpoint_info
+{
+    std::lock_guard lock(endpoint_mutex_);
+    return local_endpoint_;
+}
+
+auto udp_connection_adapter::connect(const endpoint_info& endpoint) -> VoidResult
+{
+    if (!client_) {
+        return error_void(
+            static_cast<int>(std::errc::invalid_argument),
+            "Client is not initialized"
+        );
+    }
+
+    if (client_->is_running()) {
+        return error_void(
+            static_cast<int>(std::errc::already_connected),
+            "Already running"
+        );
+    }
+
+    {
+        std::lock_guard lock(endpoint_mutex_);
+        remote_endpoint_ = endpoint;
+    }
+
+    is_connecting_ = true;
+    auto result = client_->start_client(endpoint.host, endpoint.port);
+
+    if (result.is_ok()) {
+        is_connecting_ = false;
+        // For UDP, we're immediately "connected" once started
+        std::lock_guard lock(callbacks_mutex_);
+        if (callbacks_.on_connected) {
+            callbacks_.on_connected();
+        }
+    } else {
+        is_connecting_ = false;
+    }
+
+    return result;
+}
+
+auto udp_connection_adapter::connect(std::string_view url) -> VoidResult
+{
+    // Parse URL for UDP: expect format "udp://host:port" or just "host:port"
+    std::string url_str(url);
+
+    // Remove udp:// prefix if present
+    const std::string udp_prefix = "udp://";
+    if (url_str.substr(0, udp_prefix.size()) == udp_prefix) {
+        url_str = url_str.substr(udp_prefix.size());
+    }
+
+    // Find the last colon for port separation
+    auto colon_pos = url_str.rfind(':');
+    if (colon_pos == std::string::npos) {
+        return error_void(
+            static_cast<int>(std::errc::invalid_argument),
+            "URL must contain port number (format: host:port)"
+        );
+    }
+
+    std::string host = url_str.substr(0, colon_pos);
+    std::string port_str = url_str.substr(colon_pos + 1);
+
+    uint16_t port = 0;
+    try {
+        port = static_cast<uint16_t>(std::stoi(port_str));
+    } catch (...) {
+        return error_void(
+            static_cast<int>(std::errc::invalid_argument),
+            "Invalid port number in URL"
+        );
+    }
+
+    return connect(endpoint_info{host, port});
+}
+
+auto udp_connection_adapter::close() noexcept -> void
+{
+    if (client_ && client_->is_running()) {
+        (void)client_->stop_client();
+
+        std::lock_guard lock(callbacks_mutex_);
+        if (callbacks_.on_disconnected) {
+            callbacks_.on_disconnected();
+        }
+    }
+    is_connecting_ = false;
+}
+
+auto udp_connection_adapter::set_callbacks(connection_callbacks callbacks) -> void
+{
+    {
+        std::lock_guard lock(callbacks_mutex_);
+        callbacks_ = std::move(callbacks);
+    }
+
+    // Re-setup internal callbacks to use the new user callbacks
+    setup_internal_callbacks();
+}
+
+auto udp_connection_adapter::set_options(connection_options options) -> void
+{
+    options_ = options;
+}
+
+auto udp_connection_adapter::set_timeout(std::chrono::milliseconds timeout) -> void
+{
+    options_.connect_timeout = timeout;
+}
+
+auto udp_connection_adapter::is_connecting() const noexcept -> bool
+{
+    return is_connecting_.load();
+}
+
+auto udp_connection_adapter::wait_for_stop() -> void
+{
+    if (client_) {
+        client_->wait_for_stop();
+    }
+}
+
+auto udp_connection_adapter::setup_internal_callbacks() -> void
+{
+    if (!client_) {
+        return;
+    }
+
+    // Bridge receive callback
+    client_->set_receive_callback(
+        [this](const std::vector<uint8_t>& data,
+               const interfaces::i_udp_client::endpoint_info& sender) {
+            // Update local endpoint information if we receive from the expected target
+            {
+                std::lock_guard ep_lock(endpoint_mutex_);
+                // Note: local_endpoint_ would require socket info which isn't easily available
+            }
+
+            std::lock_guard lock(callbacks_mutex_);
+            if (callbacks_.on_data) {
+                std::span<const std::byte> byte_span(
+                    reinterpret_cast<const std::byte*>(data.data()),
+                    data.size()
+                );
+                callbacks_.on_data(byte_span);
+            }
+        });
+
+    // Bridge error callback
+    client_->set_error_callback([this](std::error_code ec) {
+        is_connecting_ = false;
+
+        std::lock_guard lock(callbacks_mutex_);
+        if (callbacks_.on_error) {
+            callbacks_.on_error(ec);
+        }
+    });
+}
+
+}  // namespace kcenon::network::unified::adapters

--- a/src/unified/adapters/udp_listener_adapter.cpp
+++ b/src/unified/adapters/udp_listener_adapter.cpp
@@ -1,0 +1,306 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include "kcenon/network/unified/adapters/udp_listener_adapter.h"
+
+#include <algorithm>
+#include <cstring>
+#include <sstream>
+
+namespace kcenon::network::unified::adapters {
+
+udp_listener_adapter::udp_listener_adapter(std::string_view listener_id)
+    : listener_id_(listener_id)
+    , server_(std::make_shared<core::messaging_udp_server>(listener_id))
+{
+    setup_internal_callbacks();
+}
+
+udp_listener_adapter::~udp_listener_adapter()
+{
+    stop();
+}
+
+auto udp_listener_adapter::start(const endpoint_info& bind_address) -> VoidResult
+{
+    if (!server_) {
+        return error_void(
+            static_cast<int>(std::errc::invalid_argument),
+            "Server is not initialized"
+        );
+    }
+
+    if (server_->is_running()) {
+        return error_void(
+            static_cast<int>(std::errc::already_connected),
+            "Already listening"
+        );
+    }
+
+    {
+        std::lock_guard lock(endpoint_mutex_);
+        local_endpoint_ = bind_address;
+    }
+
+    // Clear known endpoints when starting fresh
+    {
+        std::lock_guard lock(connections_mutex_);
+        known_endpoints_.clear();
+    }
+
+    return server_->start_server(bind_address.port);
+}
+
+auto udp_listener_adapter::start(uint16_t port) -> VoidResult
+{
+    return start(endpoint_info{"0.0.0.0", port});
+}
+
+auto udp_listener_adapter::stop() noexcept -> void
+{
+    if (server_ && server_->is_running()) {
+        // Notify disconnection for all known endpoints
+        {
+            std::lock_guard cb_lock(callbacks_mutex_);
+            std::lock_guard conn_lock(connections_mutex_);
+
+            if (callbacks_.on_disconnect) {
+                for (const auto& [conn_id, _] : known_endpoints_) {
+                    callbacks_.on_disconnect(conn_id);
+                }
+            }
+            known_endpoints_.clear();
+        }
+
+        (void)server_->stop_server();
+    }
+}
+
+auto udp_listener_adapter::set_callbacks(listener_callbacks callbacks) -> void
+{
+    {
+        std::lock_guard lock(callbacks_mutex_);
+        callbacks_ = std::move(callbacks);
+    }
+    setup_internal_callbacks();
+}
+
+auto udp_listener_adapter::set_accept_callback(accept_callback_t callback) -> void
+{
+    std::lock_guard lock(callbacks_mutex_);
+    accept_callback_ = std::move(callback);
+}
+
+auto udp_listener_adapter::is_listening() const noexcept -> bool
+{
+    return server_ && server_->is_running();
+}
+
+auto udp_listener_adapter::local_endpoint() const noexcept -> endpoint_info
+{
+    std::lock_guard lock(endpoint_mutex_);
+    return local_endpoint_;
+}
+
+auto udp_listener_adapter::connection_count() const noexcept -> size_t
+{
+    std::lock_guard lock(connections_mutex_);
+    return known_endpoints_.size();
+}
+
+auto udp_listener_adapter::send_to(std::string_view connection_id,
+                                    std::span<const std::byte> data) -> VoidResult
+{
+    if (!server_ || !server_->is_running()) {
+        return error_void(
+            static_cast<int>(std::errc::not_connected),
+            "Server is not running"
+        );
+    }
+
+    auto ep_opt = parse_connection_id(connection_id);
+    if (!ep_opt) {
+        return error_void(
+            static_cast<int>(std::errc::invalid_argument),
+            "Invalid connection ID format"
+        );
+    }
+
+    interfaces::i_udp_server::endpoint_info target_ep;
+    target_ep.address = ep_opt->host;
+    target_ep.port = ep_opt->port;
+
+    std::vector<uint8_t> buffer(data.size());
+    std::memcpy(buffer.data(), data.data(), data.size());
+
+    return server_->send_to(target_ep, std::move(buffer));
+}
+
+auto udp_listener_adapter::broadcast(std::span<const std::byte> data) -> VoidResult
+{
+    if (!server_ || !server_->is_running()) {
+        return error_void(
+            static_cast<int>(std::errc::not_connected),
+            "Server is not running"
+        );
+    }
+
+    std::vector<std::pair<std::string, endpoint_info>> endpoints_copy;
+    {
+        std::lock_guard lock(connections_mutex_);
+        endpoints_copy.reserve(known_endpoints_.size());
+        for (const auto& [id, ep] : known_endpoints_) {
+            endpoints_copy.emplace_back(id, ep);
+        }
+    }
+
+    if (endpoints_copy.empty()) {
+        return ok();  // No endpoints to broadcast to
+    }
+
+    VoidResult last_result = ok();
+    for (const auto& [conn_id, ep] : endpoints_copy) {
+        auto result = send_to(conn_id, data);
+        if (!result.is_ok()) {
+            last_result = result;  // Return last error if any failed
+        }
+    }
+
+    return last_result;
+}
+
+auto udp_listener_adapter::close_connection(std::string_view connection_id) noexcept -> void
+{
+    std::string conn_id_str(connection_id);
+
+    {
+        std::lock_guard lock(connections_mutex_);
+        known_endpoints_.erase(conn_id_str);
+    }
+
+    std::lock_guard lock(callbacks_mutex_);
+    if (callbacks_.on_disconnect) {
+        callbacks_.on_disconnect(connection_id);
+    }
+}
+
+auto udp_listener_adapter::wait_for_stop() -> void
+{
+    if (server_) {
+        server_->wait_for_stop();
+    }
+}
+
+auto udp_listener_adapter::setup_internal_callbacks() -> void
+{
+    if (!server_) {
+        return;
+    }
+
+    // Bridge receive callback - also handles "connection" tracking for UDP
+    server_->set_receive_callback(
+        [this](const std::vector<uint8_t>& data,
+               const interfaces::i_udp_server::endpoint_info& sender) {
+            std::string conn_id = make_connection_id(sender.address, sender.port);
+            bool is_new_endpoint = false;
+
+            {
+                std::lock_guard lock(connections_mutex_);
+                if (known_endpoints_.find(conn_id) == known_endpoints_.end()) {
+                    known_endpoints_[conn_id] = endpoint_info{sender.address, sender.port};
+                    is_new_endpoint = true;
+                }
+            }
+
+            // If this is a new endpoint, trigger on_accept
+            if (is_new_endpoint) {
+                std::lock_guard lock(callbacks_mutex_);
+                if (callbacks_.on_accept) {
+                    callbacks_.on_accept(conn_id);
+                }
+                // Note: accept_callback_ with unique_ptr<i_connection> doesn't make
+                // sense for UDP since there's no real connection object to hand over
+            }
+
+            // Forward data to callback
+            {
+                std::lock_guard lock(callbacks_mutex_);
+                if (callbacks_.on_data) {
+                    std::span<const std::byte> byte_span(
+                        reinterpret_cast<const std::byte*>(data.data()),
+                        data.size()
+                    );
+                    callbacks_.on_data(conn_id, byte_span);
+                }
+            }
+        });
+
+    // Bridge error callback
+    server_->set_error_callback([this](std::error_code ec) {
+        std::lock_guard lock(callbacks_mutex_);
+        if (callbacks_.on_error) {
+            // For server-level errors, use empty connection ID
+            callbacks_.on_error("", ec);
+        }
+    });
+}
+
+auto udp_listener_adapter::make_connection_id(const std::string& address, uint16_t port) -> std::string
+{
+    std::ostringstream oss;
+    oss << address << ":" << port;
+    return oss.str();
+}
+
+auto udp_listener_adapter::parse_connection_id(std::string_view connection_id) -> std::optional<endpoint_info>
+{
+    std::string conn_str(connection_id);
+    auto colon_pos = conn_str.rfind(':');
+
+    if (colon_pos == std::string::npos) {
+        return std::nullopt;
+    }
+
+    std::string host = conn_str.substr(0, colon_pos);
+    std::string port_str = conn_str.substr(colon_pos + 1);
+
+    uint16_t port = 0;
+    try {
+        port = static_cast<uint16_t>(std::stoi(port_str));
+    } catch (...) {
+        return std::nullopt;
+    }
+
+    return endpoint_info{host, port};
+}
+
+}  // namespace kcenon::network::unified::adapters


### PR DESCRIPTION
## Summary

- Implement UDP protocol factory functions using the unified interface pattern
- Add `udp_connection_adapter` to wrap `messaging_udp_client` as `i_connection`
- Add `udp_listener_adapter` to wrap `messaging_udp_server` as `i_listener`
- Add `protocol::udp` namespace with `connect()`, `listen()`, `create_connection()`, `create_listener()` factory functions
- Update `protocol.h` to include UDP factory

Closes #530

## UDP-Specific Semantics

Unlike TCP, UDP is connectionless. The adapters provide unified interface semantics while respecting UDP characteristics:

| Operation | TCP | UDP |
|-----------|-----|-----|
| `connect()` | Establishes connection | Sets target endpoint and starts client |
| `is_connected()` | Returns true if connected | Returns true if client is running |
| Listener `on_accept` | Called for new connections | Called when new sender endpoint is seen |
| `connection_id` | Server-generated ID | `address:port` format |

## Files Changed

| File | Purpose |
|------|---------|
| `include/kcenon/network/protocol/udp.h` | UDP factory function declarations |
| `src/protocol/udp.cpp` | UDP factory function implementations |
| `include/kcenon/network/unified/adapters/udp_connection_adapter.h` | Connection adapter header |
| `src/unified/adapters/udp_connection_adapter.cpp` | Connection adapter implementation |
| `include/kcenon/network/unified/adapters/udp_listener_adapter.h` | Listener adapter header |
| `src/unified/adapters/udp_listener_adapter.cpp` | Listener adapter implementation |
| `include/kcenon/network/protocol/protocol.h` | Updated to include UDP |
| `CMakeLists.txt` | Added new source files |

## Test Plan

- [x] Build succeeds with new files
- [x] Existing tests still pass (except pre-existing failures unrelated to this PR)
- [ ] Manual testing of UDP client/server communication

## Related Issues

- Part of #521 (Simplify interface hierarchy)
- Follows TCP factory pattern from #528