### PR TITLE
docs(compat): add backward compatibility aliases and migration guide

### DIFF
--- a/docs/guides/MIGRATION_UNIFIED_API.md
+++ b/docs/guides/MIGRATION_UNIFIED_API.md
@@ -1,0 +1,391 @@
+# Migration Guide: Unified Interface API
+
+This guide helps you migrate from the legacy protocol-specific interfaces (12+ interfaces) to the new unified interface API (3 core interfaces).
+
+## Overview
+
+### Interface Consolidation
+
+The network_system library has evolved from having many protocol-specific interfaces to a cleaner, unified design:
+
+| Count | Old Design | New Design |
+|-------|------------|------------|
+| **Client interfaces** | `i_client`, `i_tcp_client`, `i_udp_client`, `i_websocket_client`, `i_quic_client` | `i_connection` |
+| **Server interfaces** | `i_server`, `i_tcp_server`, `i_udp_server`, `i_websocket_server`, `i_quic_server` | `i_listener` |
+| **Session interface** | `i_session` | `i_connection` (accepted) |
+| **Base interface** | `i_network_component` | `i_transport` |
+
+**Result**: 12+ interfaces → 3 core interfaces
+
+### Why This Change?
+
+1. **Reduced cognitive load**: Learn 3 interfaces instead of 12+
+2. **Protocol-agnostic code**: Write code that works with any protocol
+3. **Simplified testing**: Mock fewer interfaces
+4. **Better discoverability**: Clear, minimal API surface
+
+## Quick Migration Reference
+
+### Include Changes
+
+```cpp
+// Before
+#include <kcenon/network/interfaces/interfaces.h>
+#include <kcenon/network/interfaces/i_tcp_client.h>
+
+// After
+#include <kcenon/network/unified/unified.h>
+#include <kcenon/network/protocol/protocol.h>
+```
+
+### Namespace Changes
+
+```cpp
+// Before
+using namespace kcenon::network::interfaces;
+
+// After
+using namespace kcenon::network::unified;
+using namespace kcenon::network::protocol;
+```
+
+### Type Mappings
+
+| Legacy Type | Unified Type | Notes |
+|-------------|--------------|-------|
+| `i_client*` | `i_connection*` | Use protocol factory |
+| `i_tcp_client*` | `i_connection*` | Via `protocol::tcp::connect()` |
+| `i_udp_client*` | `i_connection*` | Via `protocol::udp::connect()` |
+| `i_websocket_client*` | `i_connection*` | Via `protocol::websocket::connect()` |
+| `i_server*` | `i_listener*` | Use protocol factory |
+| `i_tcp_server*` | `i_listener*` | Via `protocol::tcp::listen()` |
+| `i_udp_server*` | `i_listener*` | Via `protocol::udp::listen()` |
+| `i_websocket_server*` | `i_listener*` | Via `protocol::websocket::listen()` |
+| `i_session*` | `i_connection*` | Accepted connections |
+
+## Step-by-Step Migration
+
+### Step 1: Client Migration
+
+#### Before (Legacy)
+
+```cpp
+#include <kcenon/network/interfaces/i_tcp_client.h>
+
+void setup_client() {
+    // Create client (implementation-specific)
+    auto client = create_tcp_client();  // Returns i_tcp_client*
+
+    // Set individual callbacks
+    client->set_receive_callback([](const std::vector<uint8_t>& data) {
+        std::cout << "Received " << data.size() << " bytes\n";
+    });
+
+    client->set_connected_callback([]() {
+        std::cout << "Connected!\n";
+    });
+
+    client->set_disconnected_callback([]() {
+        std::cout << "Disconnected\n";
+    });
+
+    client->set_error_callback([](std::error_code ec) {
+        std::cerr << "Error: " << ec.message() << "\n";
+    });
+
+    // Connect
+    if (auto result = client->start("localhost", 8080); !result) {
+        std::cerr << "Failed to connect\n";
+        return;
+    }
+
+    // Send data
+    std::vector<uint8_t> data = {'H', 'e', 'l', 'l', 'o'};
+    client->send(std::move(data));
+}
+```
+
+#### After (Unified)
+
+```cpp
+#include <kcenon/network/protocol/protocol.h>
+
+void setup_client() {
+    using namespace kcenon::network;
+
+    // Create connection via protocol factory
+    auto conn = protocol::tcp::connect({"localhost", 8080});
+
+    // Set all callbacks at once (cleaner API)
+    conn->set_callbacks({
+        .on_connected = []() {
+            std::cout << "Connected!\n";
+        },
+        .on_data = [](std::span<const std::byte> data) {
+            std::cout << "Received " << data.size() << " bytes\n";
+        },
+        .on_disconnected = []() {
+            std::cout << "Disconnected\n";
+        },
+        .on_error = [](std::error_code ec) {
+            std::cerr << "Error: " << ec.message() << "\n";
+        }
+    });
+
+    // Connect (endpoint already specified in factory)
+    // Or connect to a different endpoint:
+    if (auto result = conn->connect({"remote.host.com", 9000}); !result) {
+        std::cerr << "Failed to connect\n";
+        return;
+    }
+
+    // Send data (uses std::span<const std::byte>)
+    std::vector<std::byte> data = {
+        std::byte{'H'}, std::byte{'e'}, std::byte{'l'}, std::byte{'l'}, std::byte{'o'}
+    };
+    conn->send(data);
+}
+```
+
+### Step 2: Server Migration
+
+#### Before (Legacy)
+
+```cpp
+#include <kcenon/network/interfaces/i_tcp_server.h>
+
+void setup_server() {
+    auto server = create_tcp_server();  // Returns i_tcp_server*
+
+    server->set_connection_callback([](std::shared_ptr<i_session> session) {
+        std::cout << "New connection: " << session->id() << "\n";
+    });
+
+    server->set_receive_callback(
+        [](std::string_view session_id, const std::vector<uint8_t>& data) {
+            std::cout << "Data from " << session_id << "\n";
+        });
+
+    server->set_disconnection_callback([](std::string_view session_id) {
+        std::cout << "Disconnected: " << session_id << "\n";
+    });
+
+    server->set_error_callback(
+        [](std::string_view session_id, std::error_code ec) {
+            std::cerr << "Error on " << session_id << ": " << ec.message() << "\n";
+        });
+
+    if (auto result = server->start(8080); !result) {
+        std::cerr << "Failed to start server\n";
+        return;
+    }
+}
+```
+
+#### After (Unified)
+
+```cpp
+#include <kcenon/network/protocol/protocol.h>
+
+void setup_server() {
+    using namespace kcenon::network;
+
+    // Create listener via protocol factory
+    auto listener = protocol::tcp::listen(8080);
+
+    // Set all callbacks at once
+    listener->set_callbacks({
+        .on_accept = [](std::string_view conn_id) {
+            std::cout << "New connection: " << conn_id << "\n";
+        },
+        .on_data = [](std::string_view conn_id, std::span<const std::byte> data) {
+            std::cout << "Data from " << conn_id << "\n";
+        },
+        .on_disconnect = [](std::string_view conn_id) {
+            std::cout << "Disconnected: " << conn_id << "\n";
+        },
+        .on_error = [](std::string_view conn_id, std::error_code ec) {
+            std::cerr << "Error on " << conn_id << ": " << ec.message() << "\n";
+        }
+    });
+
+    // Start (already bound in factory, or specify endpoint)
+    if (auto result = listener->start({"::", 8080}); !result) {
+        std::cerr << "Failed to start listener\n";
+        return;
+    }
+}
+```
+
+### Step 3: Protocol-Agnostic Code
+
+The unified API enables writing protocol-agnostic code:
+
+```cpp
+#include <kcenon/network/unified/unified.h>
+
+// Works with TCP, UDP, WebSocket, QUIC - any protocol!
+void process_connection(std::unique_ptr<unified::i_connection> conn) {
+    conn->set_callbacks({
+        .on_data = [](std::span<const std::byte> data) {
+            // Process data regardless of protocol
+        }
+    });
+
+    // Send works the same for all protocols
+    std::vector<std::byte> response = prepare_response();
+    conn->send(response);
+}
+
+// Accept connections from any protocol listener
+void run_server(std::unique_ptr<unified::i_listener> listener) {
+    listener->set_accept_callback([](std::unique_ptr<unified::i_connection> conn) {
+        process_connection(std::move(conn));
+    });
+
+    listener->start(8080);
+}
+```
+
+## Callback Migration
+
+### Data Callback Changes
+
+```cpp
+// Before: std::vector<uint8_t>
+void on_data(const std::vector<uint8_t>& data);
+
+// After: std::span<const std::byte>
+void on_data(std::span<const std::byte> data);
+
+// Conversion if needed:
+std::vector<uint8_t> vec(data.size());
+std::memcpy(vec.data(), data.data(), data.size());
+```
+
+### Callback Structure
+
+```cpp
+// Before: Individual setters
+client->set_receive_callback(...);
+client->set_connected_callback(...);
+client->set_disconnected_callback(...);
+client->set_error_callback(...);
+
+// After: Single callback structure
+conn->set_callbacks({
+    .on_connected = ...,
+    .on_data = ...,
+    .on_disconnected = ...,
+    .on_error = ...
+});
+```
+
+## Protocol Factory Usage
+
+### TCP
+
+```cpp
+using namespace kcenon::network::protocol;
+
+// Client
+auto client = tcp::connect({"localhost", 8080});
+auto secure_client = tcp::connect_secure({"localhost", 443}, tls_config);
+
+// Server
+auto server = tcp::listen(8080);
+auto secure_server = tcp::listen_secure(8080, tls_config);
+```
+
+### UDP
+
+```cpp
+using namespace kcenon::network::protocol;
+
+// Client (connected mode)
+auto client = udp::connect({"localhost", 5555});
+
+// Server
+auto server = udp::listen(5555);
+```
+
+### WebSocket
+
+```cpp
+using namespace kcenon::network::protocol;
+
+// Client (URL-based)
+auto client = websocket::connect("ws://localhost:8080/ws");
+auto secure_client = websocket::connect("wss://example.com/ws");
+
+// Server
+auto server = websocket::listen(8080, "/ws");
+```
+
+## Compatibility Header
+
+For gradual migration, use the compatibility header:
+
+```cpp
+#include <kcenon/network/compat/legacy_aliases.h>
+
+using namespace kcenon::network::compat;
+
+// These aliases compile but produce deprecation warnings
+i_client_compat* client;      // Warning: use unified::i_connection
+i_server_compat* server;      // Warning: use unified::i_listener
+i_session_compat* session;    // Warning: use unified::i_connection
+```
+
+## Common Migration Patterns
+
+### Pattern 1: Factory Function Migration
+
+```cpp
+// Before: Implementation-specific factory
+std::unique_ptr<i_tcp_client> create_tcp_client();
+
+// After: Protocol factory
+auto conn = protocol::tcp::connect(endpoint);
+```
+
+### Pattern 2: Interface Parameter Migration
+
+```cpp
+// Before: Protocol-specific interface
+void process(i_tcp_client* client);
+
+// After: Unified interface
+void process(i_connection* conn);
+// Or better:
+void process(std::unique_ptr<i_connection> conn);
+```
+
+### Pattern 3: Connection Storage Migration
+
+```cpp
+// Before: Storing protocol-specific pointers
+std::map<std::string, std::shared_ptr<i_session>> sessions_;
+
+// After: Unified connection storage
+std::map<std::string, std::unique_ptr<i_connection>> connections_;
+```
+
+## Breaking Changes
+
+1. **Callback signatures**: Use `std::span<const std::byte>` instead of `std::vector<uint8_t>`
+2. **Ownership**: `std::unique_ptr` instead of `std::shared_ptr` for connections
+3. **Factory functions**: Protocol-specific creation via namespace factories
+4. **Callback setup**: Single `set_callbacks()` instead of individual setters
+
+## Timeline
+
+- **Current release**: Unified API available, legacy API deprecated
+- **Next major release**: Legacy interfaces may be removed
+- **Recommendation**: Migrate new code immediately, refactor existing code gradually
+
+## Getting Help
+
+- Check the [API Reference](../API_REFERENCE.md) for unified interface details
+- See [examples/unified/](../../examples/unified/) for complete examples
+- Report issues at the project repository

--- a/include/kcenon/network/compat/legacy_aliases.h
+++ b/include/kcenon/network/compat/legacy_aliases.h
@@ -1,0 +1,297 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+*****************************************************************************/
+
+#pragma once
+
+/**
+ * @file legacy_aliases.h
+ * @brief Deprecated type aliases for legacy interface compatibility
+ *
+ * This header provides backward-compatible type aliases that map legacy
+ * protocol-specific interfaces to the new unified interface API.
+ *
+ * ## Interface Consolidation Summary
+ *
+ * The network_system library has consolidated 12+ protocol-specific interfaces
+ * into 3 core abstractions:
+ *
+ * | Old Interface | New Interface | Factory Function |
+ * |---------------|---------------|------------------|
+ * | `i_client` | `unified::i_connection` | `protocol::*::connect()` |
+ * | `i_tcp_client` | `unified::i_connection` | `protocol::tcp::connect()` |
+ * | `i_udp_client` | `unified::i_connection` | `protocol::udp::connect()` |
+ * | `i_websocket_client` | `unified::i_connection` | `protocol::websocket::connect()` |
+ * | `i_quic_client` | `unified::i_connection` | `protocol::quic::connect()` |
+ * | `i_server` | `unified::i_listener` | `protocol::*::listen()` |
+ * | `i_tcp_server` | `unified::i_listener` | `protocol::tcp::listen()` |
+ * | `i_udp_server` | `unified::i_listener` | `protocol::udp::listen()` |
+ * | `i_websocket_server` | `unified::i_listener` | `protocol::websocket::listen()` |
+ * | `i_quic_server` | `unified::i_listener` | `protocol::quic::listen()` |
+ * | `i_session` | `unified::i_connection` | (accepted connections) |
+ *
+ * ## Migration Path
+ *
+ * 1. Replace interface type with `i_connection` or `i_listener`
+ * 2. Use protocol factory functions instead of direct construction
+ * 3. Update callback signatures to match unified interface
+ *
+ * ## Example Migration
+ *
+ * ### Before (Legacy API)
+ * @code
+ * #include <kcenon/network/interfaces/i_tcp_client.h>
+ *
+ * void legacy_example(interfaces::i_tcp_client* client) {
+ *     client->set_receive_callback([](const std::vector<uint8_t>& data) {
+ *         // Handle data
+ *     });
+ *     client->start("localhost", 8080);
+ * }
+ * @endcode
+ *
+ * ### After (Unified API)
+ * @code
+ * #include <kcenon/network/protocol/protocol.h>
+ *
+ * void unified_example() {
+ *     auto conn = protocol::tcp::connect({"localhost", 8080});
+ *     conn->set_callbacks({
+ *         .on_data = [](std::span<const std::byte> data) {
+ *             // Handle data
+ *         }
+ *     });
+ * }
+ * @endcode
+ *
+ * @see unified::i_connection
+ * @see unified::i_listener
+ * @see unified::i_transport
+ * @see docs/guides/MIGRATION_UNIFIED_API.md for full migration guide
+ */
+
+#include "kcenon/network/unified/unified.h"
+
+namespace kcenon::network::compat {
+
+// ============================================================================
+// Deprecation Macros
+// ============================================================================
+
+/**
+ * @def NETWORK_DEPRECATED_INTERFACE
+ * @brief Marks an interface alias as deprecated with migration guidance.
+ */
+#if defined(__cplusplus) && __cplusplus >= 201402L
+#    define NETWORK_DEPRECATED_INTERFACE(msg) [[deprecated(msg)]]
+#elif defined(__GNUC__) || defined(__clang__)
+#    define NETWORK_DEPRECATED_INTERFACE(msg) __attribute__((deprecated(msg)))
+#elif defined(_MSC_VER)
+#    define NETWORK_DEPRECATED_INTERFACE(msg) __declspec(deprecated(msg))
+#else
+#    define NETWORK_DEPRECATED_INTERFACE(msg)
+#endif
+
+// ============================================================================
+// Client Interface Aliases (-> i_connection)
+// ============================================================================
+
+/**
+ * @brief Deprecated alias for generic client interface
+ *
+ * @deprecated Use `unified::i_connection` with protocol factory functions instead.
+ *
+ * Migration:
+ * @code
+ * // Old: std::unique_ptr<interfaces::i_client> client;
+ * // New: std::unique_ptr<unified::i_connection> conn = protocol::tcp::connect(...);
+ * @endcode
+ */
+using i_client_compat NETWORK_DEPRECATED_INTERFACE(
+    "Use unified::i_connection with protocol factories instead. "
+    "See docs/guides/MIGRATION_UNIFIED_API.md") = unified::i_connection;
+
+/**
+ * @brief Deprecated alias for TCP client interface
+ *
+ * @deprecated Use `protocol::tcp::connect()` to create `i_connection`.
+ */
+using i_tcp_client_compat NETWORK_DEPRECATED_INTERFACE(
+    "Use protocol::tcp::connect() to create unified::i_connection instead") =
+    unified::i_connection;
+
+/**
+ * @brief Deprecated alias for UDP client interface
+ *
+ * @deprecated Use `protocol::udp::connect()` to create `i_connection`.
+ */
+using i_udp_client_compat NETWORK_DEPRECATED_INTERFACE(
+    "Use protocol::udp::connect() to create unified::i_connection instead") =
+    unified::i_connection;
+
+/**
+ * @brief Deprecated alias for WebSocket client interface
+ *
+ * @deprecated Use `protocol::websocket::connect()` to create `i_connection`.
+ */
+using i_websocket_client_compat NETWORK_DEPRECATED_INTERFACE(
+    "Use protocol::websocket::connect() to create unified::i_connection instead") =
+    unified::i_connection;
+
+/**
+ * @brief Deprecated alias for QUIC client interface
+ *
+ * @deprecated Use `protocol::quic::connect()` to create `i_connection`.
+ */
+using i_quic_client_compat NETWORK_DEPRECATED_INTERFACE(
+    "Use protocol::quic::connect() to create unified::i_connection instead") =
+    unified::i_connection;
+
+// ============================================================================
+// Server Interface Aliases (-> i_listener)
+// ============================================================================
+
+/**
+ * @brief Deprecated alias for generic server interface
+ *
+ * @deprecated Use `unified::i_listener` with protocol factory functions instead.
+ *
+ * Migration:
+ * @code
+ * // Old: std::unique_ptr<interfaces::i_server> server;
+ * // New: std::unique_ptr<unified::i_listener> listener = protocol::tcp::listen(...);
+ * @endcode
+ */
+using i_server_compat NETWORK_DEPRECATED_INTERFACE(
+    "Use unified::i_listener with protocol factories instead. "
+    "See docs/guides/MIGRATION_UNIFIED_API.md") = unified::i_listener;
+
+/**
+ * @brief Deprecated alias for TCP server interface
+ *
+ * @deprecated Use `protocol::tcp::listen()` to create `i_listener`.
+ */
+using i_tcp_server_compat NETWORK_DEPRECATED_INTERFACE(
+    "Use protocol::tcp::listen() to create unified::i_listener instead") =
+    unified::i_listener;
+
+/**
+ * @brief Deprecated alias for UDP server interface
+ *
+ * @deprecated Use `protocol::udp::listen()` to create `i_listener`.
+ */
+using i_udp_server_compat NETWORK_DEPRECATED_INTERFACE(
+    "Use protocol::udp::listen() to create unified::i_listener instead") =
+    unified::i_listener;
+
+/**
+ * @brief Deprecated alias for WebSocket server interface
+ *
+ * @deprecated Use `protocol::websocket::listen()` to create `i_listener`.
+ */
+using i_websocket_server_compat NETWORK_DEPRECATED_INTERFACE(
+    "Use protocol::websocket::listen() to create unified::i_listener instead") =
+    unified::i_listener;
+
+/**
+ * @brief Deprecated alias for QUIC server interface
+ *
+ * @deprecated Use `protocol::quic::listen()` to create `i_listener`.
+ */
+using i_quic_server_compat NETWORK_DEPRECATED_INTERFACE(
+    "Use protocol::quic::listen() to create unified::i_listener instead") =
+    unified::i_listener;
+
+// ============================================================================
+// Session Interface Alias (-> i_connection)
+// ============================================================================
+
+/**
+ * @brief Deprecated alias for session interface (accepted connections)
+ *
+ * @deprecated Sessions are now represented as `i_connection` instances.
+ *
+ * In the unified API, accepted connections from a listener are the same
+ * type as client-initiated connections. Both implement `i_connection`.
+ *
+ * Migration:
+ * @code
+ * // Old: void handle_session(std::shared_ptr<interfaces::i_session> session);
+ * // New: void handle_connection(std::unique_ptr<unified::i_connection> conn);
+ * @endcode
+ */
+using i_session_compat NETWORK_DEPRECATED_INTERFACE(
+    "Sessions are now unified::i_connection. Accepted connections share "
+    "the same interface as client connections") = unified::i_connection;
+
+// ============================================================================
+// Non-Deprecated Convenience Type Aliases
+// ============================================================================
+
+/**
+ * @brief Convenience alias for unified connection interface
+ *
+ * Use this alias when you need a protocol-agnostic connection type.
+ */
+using connection = unified::i_connection;
+
+/**
+ * @brief Convenience alias for unified listener interface
+ *
+ * Use this alias when you need a protocol-agnostic listener type.
+ */
+using listener = unified::i_listener;
+
+/**
+ * @brief Convenience alias for unified transport interface
+ *
+ * Use this alias when you only need data transport operations
+ * (send/receive) without connection management.
+ */
+using transport = unified::i_transport;
+
+// ============================================================================
+// Pointer Type Aliases
+// ============================================================================
+
+/**
+ * @brief Unique pointer type for connection
+ */
+using connection_ptr = std::unique_ptr<unified::i_connection>;
+
+/**
+ * @brief Unique pointer type for listener
+ */
+using listener_ptr = std::unique_ptr<unified::i_listener>;
+
+/**
+ * @brief Unique pointer type for transport
+ */
+using transport_ptr = std::unique_ptr<unified::i_transport>;
+
+}  // namespace kcenon::network::compat
+
+// ============================================================================
+// Namespace Shortcuts for Easy Migration
+// ============================================================================
+
+namespace kcenon::network {
+
+/**
+ * @brief Import unified types into the main network namespace
+ *
+ * This allows using `network::i_connection` instead of
+ * `network::unified::i_connection`.
+ */
+using unified::i_connection;
+using unified::i_listener;
+using unified::i_transport;
+using unified::endpoint_info;
+using unified::connection_callbacks;
+using unified::listener_callbacks;
+using unified::connection_options;
+
+}  // namespace kcenon::network

--- a/samples/migration/README.md
+++ b/samples/migration/README.md
@@ -1,0 +1,96 @@
+# Migration Examples
+
+This directory contains examples demonstrating the migration from legacy protocol-specific interfaces to the new unified interface API.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `legacy_client_example.cpp` | Shows the OLD (deprecated) client patterns |
+| `unified_client_example.cpp` | Shows the NEW unified client API |
+| `unified_server_example.cpp` | Shows the NEW unified server (listener) API |
+
+## Quick Comparison
+
+### Client Code
+
+**Legacy (Don't use in new code):**
+```cpp
+// Multiple protocol-specific interfaces
+i_tcp_client* client;
+i_udp_client* udp_client;
+i_websocket_client* ws_client;
+
+// Individual callback setters
+client->set_receive_callback(...);
+client->set_connected_callback(...);
+client->set_disconnected_callback(...);
+client->set_error_callback(...);
+
+// Start with separate host/port
+client->start("localhost", 8080);
+```
+
+**Unified (Recommended):**
+```cpp
+// Single interface for all protocols
+auto tcp = protocol::tcp::connect({"localhost", 8080});
+auto udp = protocol::udp::connect({"localhost", 5555});
+auto ws = protocol::websocket::connect("ws://localhost:8080/ws");
+
+// Clean callback structure
+conn->set_callbacks({
+    .on_connected = ...,
+    .on_data = ...,
+    .on_disconnected = ...,
+    .on_error = ...
+});
+
+// Connect with endpoint_info
+conn->connect({"remote.host", 9000});
+```
+
+### Server Code
+
+**Legacy:**
+```cpp
+i_tcp_server* server;
+server->set_connection_callback(...);
+server->set_receive_callback(...);
+server->start(8080);
+```
+
+**Unified:**
+```cpp
+auto listener = protocol::tcp::listen(8080);
+listener->set_callbacks({
+    .on_accept = ...,
+    .on_data = ...,
+    .on_disconnect = ...
+});
+listener->start(8080);
+```
+
+## Key Benefits
+
+1. **Fewer interfaces to learn**: 3 core interfaces vs 12+ protocol-specific
+2. **Protocol-agnostic code**: Write once, use with any protocol
+3. **Cleaner callbacks**: Single `set_callbacks()` with aggregate initialization
+4. **Modern types**: `std::span<std::byte>` instead of `std::vector<uint8_t>`
+5. **Factory pattern**: Protocol selection at creation time
+
+## Building Examples
+
+These examples are for documentation purposes. To compile:
+
+```bash
+# From project root
+cmake -B build
+cmake --build build --target migration_examples
+```
+
+## See Also
+
+- [Migration Guide](../../docs/guides/MIGRATION_UNIFIED_API.md)
+- [Unified API Reference](../../docs/API_REFERENCE.md)
+- [Compatibility Header](../../include/kcenon/network/compat/legacy_aliases.h)

--- a/samples/migration/legacy_client_example.cpp
+++ b/samples/migration/legacy_client_example.cpp
@@ -1,0 +1,117 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+*****************************************************************************/
+
+/**
+ * @file legacy_client_example.cpp
+ * @brief Example showing legacy (deprecated) client interface usage
+ *
+ * This file demonstrates the OLD way of creating network clients.
+ * It is provided for reference only - new code should use the unified API.
+ *
+ * @see unified_client_example.cpp for the new, recommended approach
+ */
+
+// Note: These includes are for reference only
+// #include <kcenon/network/interfaces/i_client.h>
+// #include <kcenon/network/interfaces/i_tcp_client.h>
+
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+// This example shows the LEGACY patterns (deprecated)
+// Do NOT use this in new code
+
+namespace legacy_example {
+
+/**
+ * LEGACY PATTERN: Protocol-specific interface usage
+ *
+ * Problems with this approach:
+ * 1. Must learn different interfaces for each protocol
+ * 2. Code is tightly coupled to specific protocol
+ * 3. Changing protocols requires significant refactoring
+ * 4. More interfaces to test and maintain
+ */
+
+// Simulated legacy interface (for documentation purposes)
+class i_client {
+public:
+    virtual ~i_client() = default;
+
+    using receive_callback_t = std::function<void(const std::vector<uint8_t>&)>;
+    using connected_callback_t = std::function<void()>;
+    using disconnected_callback_t = std::function<void()>;
+    using error_callback_t = std::function<void(std::error_code)>;
+
+    virtual bool start(std::string_view host, uint16_t port) = 0;
+    virtual bool stop() = 0;
+    virtual bool send(std::vector<uint8_t>&& data) = 0;
+    virtual bool is_connected() const = 0;
+
+    virtual void set_receive_callback(receive_callback_t callback) = 0;
+    virtual void set_connected_callback(connected_callback_t callback) = 0;
+    virtual void set_disconnected_callback(disconnected_callback_t callback) = 0;
+    virtual void set_error_callback(error_callback_t callback) = 0;
+};
+
+/**
+ * @brief Legacy client setup example
+ *
+ * This demonstrates the OLD way of setting up a client:
+ * - Individual callback setters
+ * - Protocol-specific interface
+ * - std::vector<uint8_t> for data
+ */
+void setup_legacy_client(std::unique_ptr<i_client> client) {
+    // OLD: Set callbacks individually (verbose)
+    client->set_receive_callback([](const std::vector<uint8_t>& data) {
+        std::cout << "[Legacy] Received " << data.size() << " bytes\n";
+    });
+
+    client->set_connected_callback([]() {
+        std::cout << "[Legacy] Connected!\n";
+    });
+
+    client->set_disconnected_callback([]() {
+        std::cout << "[Legacy] Disconnected\n";
+    });
+
+    client->set_error_callback([](std::error_code ec) {
+        std::cerr << "[Legacy] Error: " << ec.message() << "\n";
+    });
+
+    // OLD: Start with separate host and port
+    if (!client->start("localhost", 8080)) {
+        std::cerr << "[Legacy] Failed to connect\n";
+        return;
+    }
+
+    // OLD: Send using std::vector<uint8_t>
+    std::vector<uint8_t> data = {'H', 'e', 'l', 'l', 'o'};
+    client->send(std::move(data));
+}
+
+}  // namespace legacy_example
+
+int main() {
+    std::cout << "=== Legacy Client Example ===\n";
+    std::cout << "This file demonstrates the DEPRECATED legacy API.\n";
+    std::cout << "See unified_client_example.cpp for the new approach.\n\n";
+
+    std::cout << "Legacy issues:\n";
+    std::cout << "  1. Multiple protocol-specific interfaces to learn\n";
+    std::cout << "  2. Verbose individual callback setters\n";
+    std::cout << "  3. Protocol-coupled code\n";
+    std::cout << "  4. std::vector<uint8_t> instead of std::span<std::byte>\n";
+
+    return 0;
+}

--- a/samples/migration/unified_client_example.cpp
+++ b/samples/migration/unified_client_example.cpp
@@ -1,0 +1,154 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+*****************************************************************************/
+
+/**
+ * @file unified_client_example.cpp
+ * @brief Example showing the new unified client interface usage
+ *
+ * This file demonstrates the NEW, RECOMMENDED way of creating network clients
+ * using the unified interface API.
+ *
+ * Benefits:
+ * - Single interface (i_connection) for all protocols
+ * - Protocol selection via factory functions
+ * - Cleaner callback setup
+ * - Protocol-agnostic business logic
+ *
+ * @see legacy_client_example.cpp for comparison with old approach
+ */
+
+#include <kcenon/network/protocol/protocol.h>
+#include <kcenon/network/unified/unified.h>
+
+#include <cstddef>
+#include <iostream>
+#include <span>
+#include <vector>
+
+using namespace kcenon::network;
+
+/**
+ * @brief Protocol-agnostic connection handler
+ *
+ * This function works with ANY protocol - TCP, UDP, WebSocket, QUIC.
+ * The unified interface enables truly protocol-agnostic code.
+ */
+void handle_connection(std::unique_ptr<unified::i_connection> conn) {
+    // NEW: Set all callbacks at once using aggregate initialization
+    conn->set_callbacks({
+        .on_connected = []() {
+            std::cout << "[Unified] Connected!\n";
+        },
+        .on_data = [](std::span<const std::byte> data) {
+            std::cout << "[Unified] Received " << data.size() << " bytes\n";
+
+            // Easy to work with modern C++ types
+            std::vector<std::byte> buffer(data.begin(), data.end());
+            // Process buffer...
+        },
+        .on_disconnected = []() {
+            std::cout << "[Unified] Disconnected\n";
+        },
+        .on_error = [](std::error_code ec) {
+            std::cerr << "[Unified] Error: " << ec.message() << "\n";
+        }
+    });
+
+    // NEW: Connect using endpoint_info
+    if (auto result = conn->connect({"localhost", 8080}); !result) {
+        std::cerr << "[Unified] Failed to connect\n";
+        return;
+    }
+
+    // NEW: Send using std::span<const std::byte>
+    std::vector<std::byte> data = {
+        std::byte{'H'}, std::byte{'e'}, std::byte{'l'},
+        std::byte{'l'}, std::byte{'o'}
+    };
+    conn->send(data);
+}
+
+/**
+ * @brief TCP client example using unified API
+ */
+void tcp_example() {
+    std::cout << "\n=== TCP Client (Unified API) ===\n";
+
+    // NEW: Create connection via protocol factory
+    auto conn = protocol::tcp::connect({"localhost", 8080});
+    handle_connection(std::move(conn));
+}
+
+/**
+ * @brief UDP client example using unified API
+ */
+void udp_example() {
+    std::cout << "\n=== UDP Client (Unified API) ===\n";
+
+    // Same interface, different protocol factory
+    auto conn = protocol::udp::connect({"localhost", 5555});
+    handle_connection(std::move(conn));
+}
+
+/**
+ * @brief WebSocket client example using unified API
+ */
+void websocket_example() {
+    std::cout << "\n=== WebSocket Client (Unified API) ===\n";
+
+    // WebSocket uses URL-based creation
+    auto conn = protocol::websocket::connect("ws://localhost:8080/ws");
+
+    // Can also use the same handle_connection function!
+    handle_connection(std::move(conn));
+}
+
+/**
+ * @brief Example of protocol selection at runtime
+ */
+std::unique_ptr<unified::i_connection> create_connection(
+    const std::string& protocol,
+    const unified::endpoint_info& endpoint) {
+
+    if (protocol == "tcp") {
+        return protocol::tcp::connect(endpoint);
+    } else if (protocol == "udp") {
+        return protocol::udp::connect(endpoint);
+    } else if (protocol == "websocket") {
+        // Convert endpoint to URL for WebSocket
+        std::string url = "ws://" + std::string(endpoint.host) + ":" +
+                          std::to_string(endpoint.port);
+        return protocol::websocket::connect(url);
+    }
+
+    throw std::invalid_argument("Unknown protocol: " + protocol);
+}
+
+int main() {
+    std::cout << "=== Unified Client Example ===\n";
+    std::cout << "This file demonstrates the NEW unified API.\n\n";
+
+    std::cout << "Benefits of unified API:\n";
+    std::cout << "  1. Single i_connection interface for all protocols\n";
+    std::cout << "  2. Protocol selection via factory functions\n";
+    std::cout << "  3. Cleaner callback setup with aggregate initialization\n";
+    std::cout << "  4. std::span<std::byte> for modern, efficient data handling\n";
+    std::cout << "  5. Protocol-agnostic business logic\n";
+
+    // Note: These examples create connections but won't actually connect
+    // without a running server. They demonstrate the API patterns.
+
+    std::cout << "\nCode patterns shown:\n";
+    std::cout << "  - protocol::tcp::connect(endpoint)\n";
+    std::cout << "  - protocol::udp::connect(endpoint)\n";
+    std::cout << "  - protocol::websocket::connect(url)\n";
+    std::cout << "  - conn->set_callbacks({...})\n";
+    std::cout << "  - conn->connect(endpoint)\n";
+    std::cout << "  - conn->send(data)\n";
+
+    return 0;
+}

--- a/samples/migration/unified_server_example.cpp
+++ b/samples/migration/unified_server_example.cpp
@@ -1,0 +1,196 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+*****************************************************************************/
+
+/**
+ * @file unified_server_example.cpp
+ * @brief Example showing the new unified server (listener) interface usage
+ *
+ * This file demonstrates the NEW, RECOMMENDED way of creating network servers
+ * using the unified interface API.
+ *
+ * Benefits:
+ * - Single interface (i_listener) for all protocols
+ * - Protocol selection via factory functions
+ * - Unified callback structure
+ * - Accepted connections use same i_connection interface
+ */
+
+#include <kcenon/network/protocol/protocol.h>
+#include <kcenon/network/unified/unified.h>
+
+#include <cstddef>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <span>
+#include <string>
+
+using namespace kcenon::network;
+
+/**
+ * @brief Protocol-agnostic server setup
+ *
+ * This function works with ANY protocol - TCP, UDP, WebSocket, QUIC.
+ * The unified interface enables truly protocol-agnostic server code.
+ */
+void setup_server(std::unique_ptr<unified::i_listener> listener) {
+    // NEW: Set all callbacks at once using aggregate initialization
+    listener->set_callbacks({
+        .on_accept = [](std::string_view conn_id) {
+            std::cout << "[Server] New connection: " << conn_id << "\n";
+        },
+        .on_data = [](std::string_view conn_id, std::span<const std::byte> data) {
+            std::cout << "[Server] Received " << data.size()
+                      << " bytes from " << conn_id << "\n";
+
+            // Process data...
+        },
+        .on_disconnect = [](std::string_view conn_id) {
+            std::cout << "[Server] Disconnected: " << conn_id << "\n";
+        },
+        .on_error = [](std::string_view conn_id, std::error_code ec) {
+            std::cerr << "[Server] Error on " << conn_id
+                      << ": " << ec.message() << "\n";
+        }
+    });
+
+    // NEW: Start listening
+    if (auto result = listener->start(8080); !result) {
+        std::cerr << "[Server] Failed to start\n";
+        return;
+    }
+
+    std::cout << "[Server] Listening on port 8080\n";
+}
+
+/**
+ * @brief TCP server example using unified API
+ */
+void tcp_server_example() {
+    std::cout << "\n=== TCP Server (Unified API) ===\n";
+
+    // NEW: Create listener via protocol factory
+    auto listener = protocol::tcp::listen(8080);
+    setup_server(std::move(listener));
+}
+
+/**
+ * @brief UDP server example using unified API
+ */
+void udp_server_example() {
+    std::cout << "\n=== UDP Server (Unified API) ===\n";
+
+    // Same interface, different protocol factory
+    auto listener = protocol::udp::listen(5555);
+    setup_server(std::move(listener));
+}
+
+/**
+ * @brief WebSocket server example using unified API
+ */
+void websocket_server_example() {
+    std::cout << "\n=== WebSocket Server (Unified API) ===\n";
+
+    // WebSocket listener
+    auto listener = protocol::websocket::listen(8080, "/ws");
+    setup_server(std::move(listener));
+}
+
+/**
+ * @brief Advanced example: Managing accepted connections
+ *
+ * Shows how to get ownership of accepted connections for
+ * custom management.
+ */
+class ConnectionManager {
+public:
+    void start(std::unique_ptr<unified::i_listener> listener) {
+        listener_ = std::move(listener);
+
+        // Use accept callback to get connection ownership
+        listener_->set_accept_callback(
+            [this](std::unique_ptr<unified::i_connection> conn) {
+                handle_new_connection(std::move(conn));
+            });
+
+        listener_->start(8080);
+    }
+
+    void broadcast(std::span<const std::byte> data) {
+        for (auto& [id, conn] : connections_) {
+            conn->send(data);
+        }
+    }
+
+private:
+    void handle_new_connection(std::unique_ptr<unified::i_connection> conn) {
+        // Get connection ID from endpoint info
+        auto endpoint = conn->remote_endpoint();
+        std::string id = std::string(endpoint.host) + ":" +
+                         std::to_string(endpoint.port);
+
+        std::cout << "Managing connection: " << id << "\n";
+
+        // Set up connection-specific callbacks
+        conn->set_callbacks({
+            .on_data = [id](std::span<const std::byte> data) {
+                std::cout << "Data from " << id << "\n";
+            },
+            .on_disconnected = [this, id]() {
+                connections_.erase(id);
+                std::cout << "Removed connection: " << id << "\n";
+            }
+        });
+
+        // Store connection
+        connections_[id] = std::move(conn);
+    }
+
+    std::unique_ptr<unified::i_listener> listener_;
+    std::map<std::string, std::unique_ptr<unified::i_connection>> connections_;
+};
+
+/**
+ * @brief Example of protocol selection at runtime
+ */
+std::unique_ptr<unified::i_listener> create_listener(
+    const std::string& protocol,
+    uint16_t port) {
+
+    if (protocol == "tcp") {
+        return protocol::tcp::listen(port);
+    } else if (protocol == "udp") {
+        return protocol::udp::listen(port);
+    } else if (protocol == "websocket") {
+        return protocol::websocket::listen(port, "/");
+    }
+
+    throw std::invalid_argument("Unknown protocol: " + protocol);
+}
+
+int main() {
+    std::cout << "=== Unified Server Example ===\n";
+    std::cout << "This file demonstrates the NEW unified API for servers.\n\n";
+
+    std::cout << "Benefits of unified server API:\n";
+    std::cout << "  1. Single i_listener interface for all protocols\n";
+    std::cout << "  2. Accepted connections are i_connection (same as clients)\n";
+    std::cout << "  3. Protocol selection via factory functions\n";
+    std::cout << "  4. Cleaner callback setup with aggregate initialization\n";
+    std::cout << "  5. Easy connection management with ownership\n";
+
+    std::cout << "\nCode patterns shown:\n";
+    std::cout << "  - protocol::tcp::listen(port)\n";
+    std::cout << "  - protocol::udp::listen(port)\n";
+    std::cout << "  - protocol::websocket::listen(port, path)\n";
+    std::cout << "  - listener->set_callbacks({...})\n";
+    std::cout << "  - listener->set_accept_callback(callback)\n";
+    std::cout << "  - listener->start(port)\n";
+    std::cout << "  - listener->broadcast(data)\n";
+
+    return 0;
+}


### PR DESCRIPTION
Closes #533

## Summary

Add deprecated type aliases for legacy interfaces and comprehensive migration documentation for transitioning to the unified interface API.

### Changes

- **legacy_aliases.h**: Deprecated type aliases mapping legacy interfaces to unified interfaces
  - `i_client_compat` → `unified::i_connection`
  - `i_server_compat` → `unified::i_listener`
  - `i_session_compat` → `unified::i_connection`
  - Protocol-specific aliases (TCP, UDP, WebSocket, QUIC)

- **MIGRATION_UNIFIED_API.md**: Comprehensive migration guide with:
  - Interface mapping table (12+ → 3 interfaces)
  - Step-by-step migration examples
  - Callback migration patterns
  - Protocol factory usage examples
  - Breaking changes documentation

- **Migration examples**: Before/after code samples
  - `legacy_client_example.cpp`: Shows deprecated patterns
  - `unified_client_example.cpp`: Shows new unified API
  - `unified_server_example.cpp`: Shows new listener API

## Test Plan

- [x] Build passes with new header file
- [x] Header syntax verified with clang++ -fsyntax-only
- [x] Documentation follows existing project patterns
- [x] Examples demonstrate correct API usage

## Related Issues

Part of #521 (Unified Interface Refactoring)