### PR TITLE
refactor(core): extract network-core as header-only interface library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,6 +249,19 @@ find_network_system_dependencies()
 check_network_system_features()
 
 ##################################################
+# Modular Libraries (Issue #538)
+#
+# network-core: Header-only library with core interfaces
+# This enables protocol libraries to depend only on interfaces,
+# reducing coupling and build times.
+##################################################
+
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/libs/network-core/CMakeLists.txt)
+    add_subdirectory(libs/network-core)
+    message(STATUS "network-core library enabled")
+endif()
+
+##################################################
 # Create Main Library
 ##################################################
 
@@ -572,6 +585,11 @@ target_include_directories(NetworkSystem
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
+
+# Link to network-core for shared interfaces (Issue #538, #539)
+if(TARGET network-core)
+    target_link_libraries(NetworkSystem PUBLIC network-core)
+endif()
 
 ##################################################
 # Configure Integrations

--- a/cmake/NetworkSystemInstall.cmake
+++ b/cmake/NetworkSystemInstall.cmake
@@ -11,14 +11,22 @@ include(CMakePackageConfigHelpers)
 # Install library
 ##################################################
 function(install_network_system_library)
-    install(TARGETS NetworkSystem
+    # Build list of targets to install
+    set(_INSTALL_TARGETS NetworkSystem)
+
+    # Include network-core if it exists (Issue #538, #539)
+    if(TARGET network-core)
+        list(APPEND _INSTALL_TARGETS network-core)
+    endif()
+
+    install(TARGETS ${_INSTALL_TARGETS}
         EXPORT NetworkSystemTargets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
-    message(STATUS "Configured library installation")
+    message(STATUS "Configured library installation (targets: ${_INSTALL_TARGETS})")
 endfunction()
 
 ##################################################

--- a/libs/network-core/CMakeLists.txt
+++ b/libs/network-core/CMakeLists.txt
@@ -1,0 +1,113 @@
+#*****************************************************************************
+# BSD 3-Clause License
+#
+# Copyright (c) 2025, kcenon
+# All rights reserved.
+#*****************************************************************************
+
+cmake_minimum_required(VERSION 3.16)
+
+project(network-core
+    VERSION 0.1.0
+    DESCRIPTION "Core interfaces and session management for network_system"
+    LANGUAGES CXX
+)
+
+##################################################
+# network-core Library
+#
+# This is an INTERFACE (header-only) library that provides:
+# - Core network interfaces (i_client, i_server, i_session, i_network_component)
+# - Session management base classes (session_manager_base, session_traits)
+# - Result types for error handling
+#
+# Design Rationale:
+# - Protocol-agnostic interfaces enable dependency inversion
+# - Header-only avoids ABI compatibility issues
+# - Minimal dependencies for easy integration
+##################################################
+
+add_library(network-core INTERFACE)
+add_library(kcenon::network-core ALIAS network-core)
+
+# C++20 requirement
+target_compile_features(network-core INTERFACE cxx_std_20)
+
+# Include directories
+# When built standalone, use local includes
+# When part of network_system, use parent includes
+target_include_directories(network-core INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../include>
+    $<INSTALL_INTERFACE:include>
+)
+
+##################################################
+# Core Interface Files
+#
+# These files define the fundamental network abstractions:
+# - i_network_component: Base for all network components
+# - i_client: Client-side operations
+# - i_server: Server-side operations
+# - i_session: Individual client session on server
+##################################################
+
+# Note: As an INTERFACE library, we don't add sources directly.
+# The headers are exposed through the include directories.
+# Consumers link to this target to get access to the interfaces.
+
+##################################################
+# Dependencies
+#
+# network-core has minimal dependencies:
+# - Standard C++ library (C++20)
+# - Result types from parent project
+##################################################
+
+# If common_system provides Result<T>, link it
+# This is handled by the parent CMakeLists.txt when
+# integrating network-core into network_system
+
+##################################################
+# Installation (when built standalone)
+##################################################
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    # Standalone build - provide installation rules
+    include(GNUInstallDirs)
+
+    install(TARGETS network-core
+        EXPORT network-core-targets
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+
+    install(EXPORT network-core-targets
+        FILE network-core-config.cmake
+        NAMESPACE kcenon::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/network-core
+    )
+
+    # Install interface headers
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../../include/kcenon/network/interfaces/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/kcenon/network/interfaces
+        FILES_MATCHING PATTERN "*.h"
+    )
+
+    install(FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../include/kcenon/network/core/session_traits.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../include/kcenon/network/core/session_info.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../include/kcenon/network/core/session_manager_base.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/kcenon/network/core
+    )
+
+    install(FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../include/kcenon/network/utils/result_types.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/kcenon/network/utils
+    )
+endif()
+
+##################################################
+# Summary
+##################################################
+
+message(STATUS "network-core: Header-only interface library configured")
+message(STATUS "  Include path: ${CMAKE_CURRENT_SOURCE_DIR}/../../include")


### PR DESCRIPTION
## Summary
- Extract network-core as a standalone INTERFACE (header-only) library
- First step in modularizing network_system into protocol-specific libraries (Epic #538)
- Enable protocol libraries to depend only on core interfaces

## What Changed
| File | Change |
|------|--------|
| `libs/network-core/CMakeLists.txt` | New INTERFACE library target with C++20 requirement |
| `CMakeLists.txt` | Add subdirectory for network-core, link NetworkSystem to it |
| `cmake/NetworkSystemInstall.cmake` | Include network-core in export targets |

## Technical Details
The network-core library provides:
- Core interfaces: `i_client`, `i_server`, `i_session`, `i_network_component`
- Session management: `session_manager_base`, `session_traits`, `session_info`
- Result types for error handling

### Design Decisions
1. **Header-only library**: Avoids ABI compatibility issues, minimizes dependencies
2. **INTERFACE target**: No compiled sources, headers exposed via include directories
3. **Backward compatible**: Existing include paths (`kcenon/network/interfaces/`) remain unchanged

## Related Issues
- Closes #539 (Extract network-core library with shared interfaces)
- Part of #538 (Epic: Modularize network_system into protocol-specific libraries)

## Test Plan
- [x] CMake configuration succeeds with network-core enabled
- [x] Full build completes without errors
- [x] All unit tests pass (1283/1284, 1 flaky test unrelated to this change)
- [x] Network-core is included in install export targets