### PR TITLE
refactor(network-all): create umbrella package for all protocols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,6 +414,12 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/libs/network-grpc/CMakeLists.txt)
     message(STATUS "network-grpc library enabled")
 endif()
 
+# network-all: Umbrella package aggregating all protocol libraries (Issue #573)
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/libs/network-all/CMakeLists.txt)
+    add_subdirectory(libs/network-all)
+    message(STATUS "network-all umbrella package enabled")
+endif()
+
 ##################################################
 # Create Main Library
 ##################################################

--- a/libs/network-all/CMakeLists.txt
+++ b/libs/network-all/CMakeLists.txt
@@ -1,0 +1,182 @@
+#*****************************************************************************
+# BSD 3-Clause License
+#
+# Copyright (c) 2025, kcenon
+# All rights reserved.
+#*****************************************************************************
+
+cmake_minimum_required(VERSION 3.16)
+
+project(network-all
+    VERSION 0.1.0
+    DESCRIPTION "Umbrella package aggregating all network protocol libraries"
+    LANGUAGES CXX
+)
+
+##################################################
+# network-all Umbrella Library
+#
+# This is an INTERFACE library that aggregates all protocol libraries:
+# - network-core (header-only interfaces)
+# - network-tcp (TCP protocol)
+# - network-udp (UDP protocol)
+# - network-websocket (WebSocket protocol)
+# - network-http2 (HTTP/2 protocol)
+# - network-quic (QUIC protocol)
+# - network-grpc (gRPC protocol)
+#
+# Design Rationale:
+# - Single dependency for applications needing all protocols
+# - Version synchronization across protocol libraries
+# - Simplified migration path from monolithic network_system
+##################################################
+
+add_library(network-all INTERFACE)
+add_library(kcenon::network-all ALIAS network-all)
+
+# C++20 requirement
+target_compile_features(network-all INTERFACE cxx_std_20)
+
+# Include directories for umbrella header
+target_include_directories(network-all INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+##################################################
+# Protocol Library Dependencies
+#
+# All protocol libraries are linked as INTERFACE dependencies,
+# meaning consumers of network-all get all protocol libraries
+# transitively.
+##################################################
+
+# Core interfaces (always available)
+if(TARGET network-core)
+    target_link_libraries(network-all INTERFACE network-core)
+elseif(TARGET kcenon::network-core)
+    target_link_libraries(network-all INTERFACE kcenon::network-core)
+endif()
+
+# TCP protocol
+if(TARGET network-tcp)
+    target_link_libraries(network-all INTERFACE network-tcp)
+elseif(TARGET kcenon::network-tcp)
+    target_link_libraries(network-all INTERFACE kcenon::network-tcp)
+endif()
+
+# UDP protocol
+if(TARGET network-udp)
+    target_link_libraries(network-all INTERFACE network-udp)
+elseif(TARGET kcenon::network-udp)
+    target_link_libraries(network-all INTERFACE kcenon::network-udp)
+endif()
+
+# WebSocket protocol (optional, depends on BUILD_WEBSOCKET_SUPPORT)
+if(TARGET network-websocket)
+    target_link_libraries(network-all INTERFACE network-websocket)
+elseif(TARGET kcenon::network-websocket)
+    target_link_libraries(network-all INTERFACE kcenon::network-websocket)
+endif()
+
+# HTTP/2 protocol
+if(TARGET network-http2)
+    target_link_libraries(network-all INTERFACE network-http2)
+elseif(TARGET kcenon::network-http2)
+    target_link_libraries(network-all INTERFACE kcenon::network-http2)
+endif()
+
+# QUIC protocol
+if(TARGET network-quic)
+    target_link_libraries(network-all INTERFACE network-quic)
+elseif(TARGET kcenon::network-quic)
+    target_link_libraries(network-all INTERFACE kcenon::network-quic)
+endif()
+
+# gRPC protocol
+if(TARGET network-grpc)
+    target_link_libraries(network-all INTERFACE network-grpc)
+elseif(TARGET kcenon::network-grpc)
+    target_link_libraries(network-all INTERFACE kcenon::network-grpc)
+endif()
+
+##################################################
+# Installation
+##################################################
+
+include(GNUInstallDirs)
+
+# Determine export set based on build context
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    # Standalone build - use own export set
+    set(NETWORK_ALL_EXPORT_SET network-all-targets)
+else()
+    # Integrated build - use parent's export set
+    set(NETWORK_ALL_EXPORT_SET NetworkSystemTargets)
+endif()
+
+install(TARGETS network-all
+    EXPORT ${NETWORK_ALL_EXPORT_SET}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# Install umbrella header
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/network_all
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+)
+
+# Standalone build config file
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    # Configure and install the config file
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/network-all-config.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/network-all-config.cmake
+        @ONLY
+    )
+
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/network-all-config.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/network-all
+    )
+
+    install(EXPORT network-all-targets
+        FILE network-all-targets.cmake
+        NAMESPACE kcenon::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/network-all
+    )
+endif()
+
+##################################################
+# Summary
+##################################################
+
+# Collect available protocols for summary
+set(_PROTOCOLS_ENABLED "")
+
+if(TARGET network-core OR TARGET kcenon::network-core)
+    list(APPEND _PROTOCOLS_ENABLED "core")
+endif()
+if(TARGET network-tcp OR TARGET kcenon::network-tcp)
+    list(APPEND _PROTOCOLS_ENABLED "tcp")
+endif()
+if(TARGET network-udp OR TARGET kcenon::network-udp)
+    list(APPEND _PROTOCOLS_ENABLED "udp")
+endif()
+if(TARGET network-websocket OR TARGET kcenon::network-websocket)
+    list(APPEND _PROTOCOLS_ENABLED "websocket")
+endif()
+if(TARGET network-http2 OR TARGET kcenon::network-http2)
+    list(APPEND _PROTOCOLS_ENABLED "http2")
+endif()
+if(TARGET network-quic OR TARGET kcenon::network-quic)
+    list(APPEND _PROTOCOLS_ENABLED "quic")
+endif()
+if(TARGET network-grpc OR TARGET kcenon::network-grpc)
+    list(APPEND _PROTOCOLS_ENABLED "grpc")
+endif()
+
+string(REPLACE ";" ", " _PROTOCOLS_STRING "${_PROTOCOLS_ENABLED}")
+
+message(STATUS "network-all: Umbrella package configured")
+message(STATUS "  Version: ${PROJECT_VERSION}")
+message(STATUS "  Protocols: ${_PROTOCOLS_STRING}")

--- a/libs/network-all/README.md
+++ b/libs/network-all/README.md
@@ -1,0 +1,162 @@
+# network-all
+
+Umbrella package that aggregates all network protocol libraries from `network_system`.
+
+## Overview
+
+`network-all` provides a single dependency for applications requiring multiple network protocols. Instead of linking each protocol library individually, link `network-all` to get:
+
+| Library | Protocol | Description |
+|---------|----------|-------------|
+| network-core | N/A | Core interfaces and types |
+| network-tcp | TCP | Reliable stream connections |
+| network-udp | UDP | Unreliable datagrams |
+| network-websocket | WebSocket | Full-duplex over HTTP |
+| network-http2 | HTTP/2 | Multiplexed HTTP |
+| network-quic | QUIC | UDP-based TLS 1.3 |
+| network-grpc | gRPC | High-performance RPC |
+
+## Installation
+
+### CMake Integration (Recommended)
+
+```cmake
+# Option 1: find_package (after installation)
+find_package(network-all REQUIRED)
+target_link_libraries(my_app PRIVATE kcenon::network-all)
+
+# Option 2: add_subdirectory (source inclusion)
+add_subdirectory(libs/network-all)
+target_link_libraries(my_app PRIVATE kcenon::network-all)
+```
+
+### Header Inclusion
+
+```cpp
+// Include all protocols
+#include <network_all/network.h>
+
+// Or include specific protocols
+#include <network_tcp/protocol/tcp.h>
+#include <network_udp/protocol/udp.h>
+#include <network_websocket/websocket.h>
+#include <network_http2/http2.h>
+#include <network_quic/quic.h>
+#include <network_grpc/grpc.h>
+```
+
+## Quick Start
+
+### TCP Client
+
+```cpp
+#include <network_all/network.h>
+#include <iostream>
+
+int main() {
+    using namespace kcenon::network;
+
+    auto conn = protocol::tcp::connect({"localhost", 8080});
+    conn->set_callbacks({
+        .on_connected = []() {
+            std::cout << "Connected!\n";
+        },
+        .on_data = [](std::span<const std::byte> data) {
+            std::cout << "Received " << data.size() << " bytes\n";
+        },
+        .on_disconnected = [](std::string_view reason) {
+            std::cout << "Disconnected: " << reason << "\n";
+        }
+    });
+
+    // Connection in progress...
+    return 0;
+}
+```
+
+### TCP Server
+
+```cpp
+#include <network_all/network.h>
+
+int main() {
+    using namespace kcenon::network;
+
+    auto listener = protocol::tcp::listen(8080);
+    listener->set_callbacks({
+        .on_accept = [](std::string_view conn_id) {
+            std::cout << "New connection: " << conn_id << "\n";
+        }
+    });
+
+    // Server is listening...
+    return 0;
+}
+```
+
+### gRPC Server
+
+```cpp
+#include <network_all/network.h>
+
+int main() {
+    using namespace kcenon::network::protocols::grpc;
+
+    grpc_server server;
+    server.register_unary_method("/mypackage.Service/Method",
+        [](server_context& ctx, const std::vector<uint8_t>& request) {
+            std::vector<uint8_t> response = process(request);
+            return std::make_pair(grpc_status::ok_status(), response);
+        });
+    server.start(50051);
+
+    return 0;
+}
+```
+
+## Compile-Time Protocol Detection
+
+Check if a protocol is available at compile time:
+
+```cpp
+#include <network_all/network.h>
+
+using namespace kcenon::network;
+
+static_assert(all::protocols::tcp, "TCP protocol required");
+
+#if NETWORK_ALL_HAS_WEBSOCKET
+    // WebSocket-specific code
+#endif
+```
+
+## Selective Linking
+
+For reduced binary size, link only the protocols you need:
+
+```cmake
+# Link only TCP and UDP
+find_package(network-tcp REQUIRED)
+find_package(network-udp REQUIRED)
+target_link_libraries(my_app PRIVATE
+    kcenon::network-tcp
+    kcenon::network-udp
+)
+```
+
+## Dependency Graph
+
+```
+                  network-core
+                  /    |    \
+                 /     |     \
+          network-tcp  |  network-udp
+                |      |      |
+       network-websocket    network-quic
+                |             |
+            network-http2  network-grpc
+```
+
+## License
+
+BSD 3-Clause License. See [LICENSE](../../LICENSE) for details.

--- a/libs/network-all/include/network_all/network.h
+++ b/libs/network-all/include/network_all/network.h
@@ -1,0 +1,182 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+/*!
+ * \file network.h
+ * \brief Umbrella header for all network protocol libraries
+ *
+ * This header provides a single include point for all network protocols
+ * available in the network_system library collection:
+ *
+ * - TCP: Reliable stream-based communication
+ * - UDP: Unreliable datagram-based communication
+ * - WebSocket: Full-duplex communication over HTTP
+ * - HTTP/2: Modern HTTP with multiplexing and server push
+ * - QUIC: UDP-based reliable transport with TLS 1.3
+ * - gRPC: High-performance RPC framework
+ *
+ * ## Quick Start
+ *
+ * \code
+ * #include <network_all/network.h>
+ *
+ * using namespace kcenon::network;
+ *
+ * // TCP client
+ * auto tcp_conn = protocol::tcp::connect({"localhost", 8080});
+ *
+ * // UDP connection
+ * auto udp_conn = protocol::udp::create_connection();
+ *
+ * // WebSocket client
+ * auto ws_conn = protocol::websocket::connect("ws://localhost:8081/chat");
+ * \endcode
+ *
+ * ## Selective Includes
+ *
+ * For reduced compilation time, include only the protocols you need:
+ *
+ * \code
+ * // TCP only
+ * #include <network_tcp/protocol/tcp.h>
+ *
+ * // UDP only
+ * #include <network_udp/protocol/udp.h>
+ *
+ * // WebSocket only
+ * #include <network_websocket/websocket.h>
+ *
+ * // HTTP/2 only
+ * #include <network_http2/http2.h>
+ *
+ * // QUIC only
+ * #include <network_quic/quic.h>
+ *
+ * // gRPC only
+ * #include <network_grpc/grpc.h>
+ * \endcode
+ */
+
+//=============================================================================
+// Core Interfaces
+//=============================================================================
+
+// Note: Core interfaces are included transitively through protocol headers
+
+//=============================================================================
+// TCP Protocol
+//=============================================================================
+
+#if __has_include(<network_tcp/protocol/tcp.h>)
+#include <network_tcp/protocol/tcp.h>
+#define NETWORK_ALL_HAS_TCP 1
+#else
+#define NETWORK_ALL_HAS_TCP 0
+#endif
+
+//=============================================================================
+// UDP Protocol
+//=============================================================================
+
+#if __has_include(<network_udp/protocol/udp.h>)
+#include <network_udp/protocol/udp.h>
+#define NETWORK_ALL_HAS_UDP 1
+#else
+#define NETWORK_ALL_HAS_UDP 0
+#endif
+
+//=============================================================================
+// WebSocket Protocol
+//=============================================================================
+
+#if __has_include(<network_websocket/websocket.h>)
+#include <network_websocket/websocket.h>
+#define NETWORK_ALL_HAS_WEBSOCKET 1
+#else
+#define NETWORK_ALL_HAS_WEBSOCKET 0
+#endif
+
+//=============================================================================
+// HTTP/2 Protocol
+//=============================================================================
+
+#if __has_include(<network_http2/http2.h>)
+#include <network_http2/http2.h>
+#define NETWORK_ALL_HAS_HTTP2 1
+#else
+#define NETWORK_ALL_HAS_HTTP2 0
+#endif
+
+//=============================================================================
+// QUIC Protocol
+//=============================================================================
+
+#if __has_include(<network_quic/quic.h>)
+#include <network_quic/quic.h>
+#define NETWORK_ALL_HAS_QUIC 1
+#else
+#define NETWORK_ALL_HAS_QUIC 0
+#endif
+
+//=============================================================================
+// gRPC Protocol
+//=============================================================================
+
+#if __has_include(<network_grpc/grpc.h>)
+#include <network_grpc/grpc.h>
+#define NETWORK_ALL_HAS_GRPC 1
+#else
+#define NETWORK_ALL_HAS_GRPC 0
+#endif
+
+//=============================================================================
+// Version Information
+//=============================================================================
+
+namespace kcenon::network::all {
+
+/// Version of the network-all umbrella package
+constexpr const char* version = "0.1.0";
+
+/// Check if a protocol is available at compile time
+struct protocols {
+    static constexpr bool tcp = NETWORK_ALL_HAS_TCP;
+    static constexpr bool udp = NETWORK_ALL_HAS_UDP;
+    static constexpr bool websocket = NETWORK_ALL_HAS_WEBSOCKET;
+    static constexpr bool http2 = NETWORK_ALL_HAS_HTTP2;
+    static constexpr bool quic = NETWORK_ALL_HAS_QUIC;
+    static constexpr bool grpc = NETWORK_ALL_HAS_GRPC;
+};
+
+}  // namespace kcenon::network::all

--- a/libs/network-all/network-all-config.cmake.in
+++ b/libs/network-all/network-all-config.cmake.in
@@ -1,0 +1,35 @@
+@PACKAGE_INIT@
+
+# network-all CMake Config File
+#
+# This config file provides the network-all umbrella package that
+# aggregates all network protocol libraries.
+#
+# Usage:
+#   find_package(network-all REQUIRED)
+#   target_link_libraries(my_app PRIVATE kcenon::network-all)
+#
+# This will transitively link all available protocol libraries:
+# - kcenon::network-core
+# - kcenon::network-tcp
+# - kcenon::network-udp
+# - kcenon::network-websocket (if available)
+# - kcenon::network-http2
+# - kcenon::network-quic
+# - kcenon::network-grpc
+
+include(CMakeFindDependencyMacro)
+
+# Find all protocol dependencies
+find_dependency(network-core)
+find_dependency(network-tcp)
+find_dependency(network-udp)
+
+# Optional protocols
+find_package(network-websocket QUIET)
+find_package(network-http2 QUIET)
+find_package(network-quic QUIET)
+find_package(network-grpc QUIET)
+
+# Include the targets file
+include("${CMAKE_CURRENT_LIST_DIR}/network-all-targets.cmake")


### PR DESCRIPTION
## Summary

- Add `network-all` umbrella package aggregating all protocol libraries
- Provide single `find_package(network-all)` for full protocol support
- Create umbrella header with compile-time protocol availability checks
- Add comprehensive README with usage documentation

## What

This PR creates the `network-all` umbrella library as part of Epic #538 (Modularize network_system). The umbrella package provides:

### Files Added
| File | Description |
|------|-------------|
| `libs/network-all/CMakeLists.txt` | INTERFACE library linking all protocol libs |
| `libs/network-all/include/network_all/network.h` | Umbrella header including all protocols |
| `libs/network-all/network-all-config.cmake.in` | CMake config for external projects |
| `libs/network-all/README.md` | Usage documentation |

### Linked Protocol Libraries
- `network-core` - Core interfaces
- `network-tcp` - TCP protocol
- `network-udp` - UDP protocol
- `network-websocket` - WebSocket protocol
- `network-http2` - HTTP/2 protocol
- `network-quic` - QUIC protocol
- `network-grpc` - gRPC protocol

## Why

With individual protocol libraries now extracted (#554-#572), applications needing multiple protocols must link each library individually. The umbrella package:

1. **Simplifies linking**: Single dependency for full functionality
2. **Version synchronization**: All protocols versioned together
3. **Migration path**: Existing monolithic users get familiar API
4. **Compile-time detection**: `NETWORK_ALL_HAS_*` macros for conditional compilation

## Test Plan

- [x] CMake configuration succeeds with umbrella package
- [x] Build completes without errors
- [x] Core tests pass (NetworkTest.Server*, NetworkTest.Client*)
- [x] Umbrella header includes all available protocols

## Related Issues

Closes #573
Part of #538