### PR TITLE
refactor(integration): implement ThreadPoolBridge for thread_system integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,7 @@ add_library(network-integration-objects OBJECT
     src/integration/io_context_thread_manager.cpp
     src/integration/monitoring_integration.cpp
     src/integration/thread_system_adapter.cpp
+    src/integration/thread_pool_bridge.cpp
     src/core/network_context.cpp
     src/session/messaging_session.cpp
     src/metrics/network_metrics.cpp
@@ -374,6 +375,9 @@ else()
         target_compile_definitions(network-integration-objects PUBLIC ASIO_STANDALONE)
     endif()
 endif()
+
+# common_system integration for network-integration-objects
+setup_common_system_integration(network-integration-objects)
 
 # Export the OBJECT library for network-tcp to use
 set(NETWORK_INTEGRATION_OBJECTS_TARGET network-integration-objects CACHE INTERNAL "Integration objects target")

--- a/include/kcenon/network/integration/bridge_interface.h
+++ b/include/kcenon/network/integration/bridge_interface.h
@@ -215,7 +215,7 @@ public:
      * }
      * @endcode
      */
-    virtual Result<void> initialize(const BridgeConfig& config) = 0;
+    virtual VoidResult initialize(const BridgeConfig& config) = 0;
 
     /**
      * @brief Shutdown the bridge and release resources
@@ -240,7 +240,7 @@ public:
      * }
      * @endcode
      */
-    virtual Result<void> shutdown() = 0;
+    virtual VoidResult shutdown() = 0;
 
     /**
      * @brief Check if the bridge is initialized and ready for use

--- a/include/kcenon/network/integration/thread_pool_bridge.h
+++ b/include/kcenon/network/integration/thread_pool_bridge.h
@@ -1,0 +1,281 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+/**
+ * @file thread_pool_bridge.h
+ * @brief Thread pool integration bridge for network_system
+ *
+ * This file provides the ThreadPoolBridge class that consolidates thread_system
+ * and common_system thread pool integrations into a single, unified bridge.
+ *
+ * Design Goals:
+ * - Unified interface for thread pool integration
+ * - Support for both thread_system and common_system backends
+ * - Factory methods for common configurations
+ * - Lifecycle management via INetworkBridge interface
+ *
+ * Usage Example:
+ * @code
+ * // Using thread_system backend
+ * auto bridge = ThreadPoolBridge::from_thread_system("network_pool");
+ * bridge->initialize(config);
+ *
+ * // Using common_system backend
+ * auto executor = container.resolve<IExecutor>();
+ * auto bridge = ThreadPoolBridge::from_common_system(executor);
+ * bridge->initialize(config);
+ * @endcode
+ *
+ * Related Issues:
+ * - #582: Implement ThreadPoolBridge for thread_system integration
+ * - #579: Consolidate integration adapters into NetworkSystemBridge
+ *
+ * @author network_system team
+ * @date 2026-02-01
+ */
+
+#include <kcenon/network/integration/bridge_interface.h>
+#include <kcenon/network/integration/thread_integration.h>
+#include <kcenon/network/config/feature_flags.h>
+#include <memory>
+#include <string>
+#include <mutex>
+#include <atomic>
+
+#if KCENON_WITH_COMMON_SYSTEM
+#include <kcenon/common/interfaces/executor_interface.h>
+#endif
+
+namespace kcenon::network::integration {
+
+/**
+ * @class ThreadPoolBridge
+ * @brief Bridge for thread pool integration implementing INetworkBridge
+ *
+ * This class consolidates thread_system and common_system thread pool
+ * integrations into a single, unified bridge. It provides factory methods
+ * for creating bridges from different backend types.
+ *
+ * Backend Types:
+ * - ThreadSystem: Uses thread_system's thread pool directly
+ * - CommonSystem: Adapts common_system's IExecutor
+ * - Custom: Uses user-provided thread_pool_interface
+ *
+ * Lifecycle:
+ * 1. Create using factory method (from_thread_system, from_common_system)
+ *    or direct constructor
+ * 2. Call initialize() with configuration
+ * 3. Use get_thread_pool() to access the underlying pool
+ * 4. Call shutdown() before destruction
+ *
+ * Thread Safety:
+ * - initialize() and shutdown() are not thread-safe (single-threaded usage)
+ * - get_metrics() is thread-safe for concurrent queries
+ * - get_thread_pool() is thread-safe after initialization
+ */
+class ThreadPoolBridge : public INetworkBridge {
+public:
+    /**
+     * @enum BackendType
+     * @brief Type of thread pool backend
+     */
+    enum class BackendType {
+        ThreadSystem,  ///< Uses thread_system's thread pool
+        CommonSystem,  ///< Uses common_system's IExecutor
+        Custom         ///< Uses custom thread_pool_interface
+    };
+
+    /**
+     * @brief Construct bridge with custom thread pool
+     * @param pool Thread pool implementation
+     * @param backend_type Type of backend (default: Custom)
+     * @throws std::invalid_argument if pool is nullptr
+     *
+     * Example:
+     * @code
+     * auto pool = std::make_shared<basic_thread_pool>(8);
+     * auto bridge = std::make_shared<ThreadPoolBridge>(pool);
+     * @endcode
+     */
+    explicit ThreadPoolBridge(
+        std::shared_ptr<thread_pool_interface> pool,
+        BackendType backend_type = BackendType::Custom);
+
+    /**
+     * @brief Destructor
+     *
+     * Automatically calls shutdown() if initialized
+     */
+    ~ThreadPoolBridge() override;
+
+    // INetworkBridge interface implementation
+
+    /**
+     * @brief Initialize the bridge with configuration
+     * @param config Configuration parameters
+     * @return ok() on success, error_info on failure
+     *
+     * Configuration Properties:
+     * - "enabled": "true" or "false" (default: "true")
+     * - "worker_count": Number of worker threads (informational)
+     * - "pool_name": Thread pool identifier (informational)
+     *
+     * Error Conditions:
+     * - Already initialized
+     * - Underlying thread pool not running
+     * - Invalid configuration
+     *
+     * Example:
+     * @code
+     * BridgeConfig config;
+     * config.integration_name = "thread_system";
+     * config.properties["pool_name"] = "network_pool";
+     * config.properties["worker_count"] = "8";
+     *
+     * auto result = bridge->initialize(config);
+     * if (result.is_err()) {
+     *     std::cerr << "Init failed: " << result.error().message << std::endl;
+     * }
+     * @endcode
+     */
+    VoidResult initialize(const BridgeConfig& config) override;
+
+    /**
+     * @brief Shutdown the bridge
+     * @return ok() on success, error_info on failure
+     *
+     * Shuts down the bridge but does not shut down the underlying thread pool.
+     * Thread pool lifecycle is managed externally.
+     *
+     * This method is idempotent - multiple calls are safe.
+     */
+    VoidResult shutdown() override;
+
+    /**
+     * @brief Check if the bridge is initialized
+     * @return true if initialized and ready, false otherwise
+     */
+    bool is_initialized() const override;
+
+    /**
+     * @brief Get current metrics
+     * @return Bridge metrics including thread pool statistics
+     *
+     * Custom Metrics:
+     * - "worker_threads": Number of worker threads
+     * - "pending_tasks": Number of queued tasks
+     * - "backend_type": Backend type (0=ThreadSystem, 1=CommonSystem, 2=Custom)
+     *
+     * Thread Safety: Safe to call concurrently
+     */
+    BridgeMetrics get_metrics() const override;
+
+    // ThreadPoolBridge-specific methods
+
+    /**
+     * @brief Get the underlying thread pool
+     * @return Shared pointer to thread pool, or nullptr if not initialized
+     *
+     * Thread Safety: Safe to call after initialization
+     *
+     * Example:
+     * @code
+     * if (auto pool = bridge->get_thread_pool()) {
+     *     pool->submit([]{ // task implementation here });
+     * }
+     * @endcode
+     */
+    std::shared_ptr<thread_pool_interface> get_thread_pool() const;
+
+    /**
+     * @brief Get the backend type
+     * @return Type of backend this bridge uses
+     */
+    BackendType get_backend_type() const;
+
+    // Factory methods
+
+    /**
+     * @brief Create bridge from thread_system
+     * @param pool_name Thread pool name (default: "network_pool")
+     * @return Shared pointer to ThreadPoolBridge
+     *
+     * Creates a bridge using thread_system's thread pool via
+     * thread_integration_manager.
+     *
+     * Example:
+     * @code
+     * auto bridge = ThreadPoolBridge::from_thread_system("network_pool");
+     * BridgeConfig config;
+     * config.integration_name = "thread_system";
+     * bridge->initialize(config);
+     * @endcode
+     */
+    static std::shared_ptr<ThreadPoolBridge> from_thread_system(
+        const std::string& pool_name = "network_pool");
+
+#if KCENON_WITH_COMMON_SYSTEM
+    /**
+     * @brief Create bridge from common_system executor
+     * @param executor Common system executor to adapt
+     * @return Shared pointer to ThreadPoolBridge
+     * @throws std::invalid_argument if executor is nullptr
+     *
+     * Creates a bridge that adapts common_system's IExecutor to
+     * thread_pool_interface via common_to_network_thread_adapter.
+     *
+     * Example:
+     * @code
+     * auto executor = container.resolve<IExecutor>();
+     * auto bridge = ThreadPoolBridge::from_common_system(executor);
+     * BridgeConfig config;
+     * config.integration_name = "common_system";
+     * bridge->initialize(config);
+     * @endcode
+     */
+    static std::shared_ptr<ThreadPoolBridge> from_common_system(
+        std::shared_ptr<::kcenon::common::interfaces::IExecutor> executor);
+#endif
+
+private:
+    std::shared_ptr<thread_pool_interface> pool_;
+    BackendType backend_type_;
+    std::atomic<bool> initialized_{false};
+    mutable std::mutex metrics_mutex_;
+    mutable BridgeMetrics cached_metrics_;
+};
+
+} // namespace kcenon::network::integration
+
+// Backward compatibility namespace alias
+namespace network_system {
+    namespace integration = kcenon::network::integration;
+}

--- a/src/integration/thread_pool_bridge.cpp
+++ b/src/integration/thread_pool_bridge.cpp
@@ -1,0 +1,176 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <kcenon/network/integration/thread_pool_bridge.h>
+
+#if KCENON_WITH_COMMON_SYSTEM
+#include <kcenon/network/integration/thread_pool_adapters.h>
+#endif
+
+#include <stdexcept>
+
+namespace kcenon::network::integration {
+
+ThreadPoolBridge::ThreadPoolBridge(
+    std::shared_ptr<thread_pool_interface> pool,
+    BackendType backend_type)
+    : pool_(std::move(pool)), backend_type_(backend_type) {
+    if (!pool_) {
+        throw std::invalid_argument("ThreadPoolBridge requires non-null thread pool");
+    }
+}
+
+ThreadPoolBridge::~ThreadPoolBridge() {
+    if (initialized_.load()) {
+        shutdown();
+    }
+}
+
+VoidResult ThreadPoolBridge::initialize(const BridgeConfig& config) {
+    if (initialized_.load()) {
+        return error_void(
+            error_codes::common_errors::already_exists,
+            "ThreadPoolBridge already initialized",
+            "ThreadPoolBridge::initialize");
+    }
+
+    if (!pool_) {
+        return error_void(
+            error_codes::common_errors::invalid_argument,
+            "Thread pool is null",
+            "ThreadPoolBridge::initialize");
+    }
+
+    if (!pool_->is_running()) {
+        return error_void(
+            error_codes::common_errors::not_initialized,
+            "Thread pool is not running",
+            "ThreadPoolBridge::initialize");
+    }
+
+    // Check if bridge is enabled (default: true)
+    auto enabled_it = config.properties.find("enabled");
+    if (enabled_it != config.properties.end() && enabled_it->second == "false") {
+        return error_void(
+            error_codes::common_errors::invalid_argument,
+            "Bridge is disabled in configuration",
+            "ThreadPoolBridge::initialize");
+    }
+
+    // Initialize metrics
+    std::lock_guard<std::mutex> lock(metrics_mutex_);
+    cached_metrics_.is_healthy = true;
+    cached_metrics_.last_activity = std::chrono::steady_clock::now();
+    cached_metrics_.custom_metrics["worker_threads"] = static_cast<double>(pool_->worker_count());
+    cached_metrics_.custom_metrics["pending_tasks"] = static_cast<double>(pool_->pending_tasks());
+    cached_metrics_.custom_metrics["backend_type"] = static_cast<double>(backend_type_);
+
+    initialized_.store(true);
+    return ok();
+}
+
+VoidResult ThreadPoolBridge::shutdown() {
+    if (!initialized_.load()) {
+        return ok(); // Idempotent: already shut down
+    }
+
+    // Update metrics to reflect shutdown state
+    {
+        std::lock_guard<std::mutex> lock(metrics_mutex_);
+        cached_metrics_.is_healthy = false;
+        cached_metrics_.last_activity = std::chrono::steady_clock::now();
+    }
+
+    initialized_.store(false);
+    return ok();
+}
+
+bool ThreadPoolBridge::is_initialized() const {
+    return initialized_.load() && pool_ && pool_->is_running();
+}
+
+BridgeMetrics ThreadPoolBridge::get_metrics() const {
+    std::lock_guard<std::mutex> lock(metrics_mutex_);
+
+    if (!initialized_.load() || !pool_) {
+        BridgeMetrics metrics;
+        metrics.is_healthy = false;
+        metrics.last_activity = cached_metrics_.last_activity;
+        return metrics;
+    }
+
+    // Update metrics with current thread pool state
+    BridgeMetrics metrics = cached_metrics_;
+    metrics.is_healthy = pool_->is_running();
+    metrics.last_activity = std::chrono::steady_clock::now();
+    metrics.custom_metrics["worker_threads"] = static_cast<double>(pool_->worker_count());
+    metrics.custom_metrics["pending_tasks"] = static_cast<double>(pool_->pending_tasks());
+    metrics.custom_metrics["backend_type"] = static_cast<double>(backend_type_);
+
+    // Update cached metrics for next call
+    cached_metrics_ = metrics;
+
+    return metrics;
+}
+
+std::shared_ptr<thread_pool_interface> ThreadPoolBridge::get_thread_pool() const {
+    return pool_;
+}
+
+ThreadPoolBridge::BackendType ThreadPoolBridge::get_backend_type() const {
+    return backend_type_;
+}
+
+std::shared_ptr<ThreadPoolBridge> ThreadPoolBridge::from_thread_system(
+    const std::string& pool_name) {
+    (void)pool_name; // Pool name is informational only in current implementation
+
+    auto pool = thread_integration_manager::instance().get_thread_pool();
+    if (!pool) {
+        throw std::runtime_error("Failed to get thread pool from thread_integration_manager");
+    }
+
+    return std::make_shared<ThreadPoolBridge>(pool, BackendType::ThreadSystem);
+}
+
+#if KCENON_WITH_COMMON_SYSTEM
+std::shared_ptr<ThreadPoolBridge> ThreadPoolBridge::from_common_system(
+    std::shared_ptr<::kcenon::common::interfaces::IExecutor> executor) {
+    if (!executor) {
+        throw std::invalid_argument("ThreadPoolBridge::from_common_system requires non-null executor");
+    }
+
+    // Adapt common_system executor to thread_pool_interface
+    auto adapted_pool = std::make_shared<common_to_network_thread_adapter>(std::move(executor));
+
+    return std::make_shared<ThreadPoolBridge>(adapted_pool, BackendType::CommonSystem);
+}
+#endif
+
+} // namespace kcenon::network::integration

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -231,6 +231,48 @@ if(GTest_FOUND OR GTEST_FOUND)
         message(STATUS "Thread pool adapters tests enabled")
     endif()
 
+    # Thread pool bridge tests
+    add_executable(network_thread_pool_bridge_test
+        unit/test_thread_pool_bridge.cpp
+    )
+
+    target_link_libraries(network_thread_pool_bridge_test PRIVATE
+        NetworkSystem
+        GTest::gtest
+        GTest::gtest_main
+        Threads::Threads
+    )
+
+    # Setup ASIO integration
+    setup_asio_integration(network_thread_pool_bridge_test)
+
+    # Add system integration paths if available
+    if(COMMON_SYSTEM_INCLUDE_DIR)
+        target_include_directories(network_thread_pool_bridge_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+        target_compile_definitions(network_thread_pool_bridge_test PRIVATE WITH_COMMON_SYSTEM)
+    endif()
+
+    if(THREAD_SYSTEM_INCLUDE_DIR)
+        target_include_directories(network_thread_pool_bridge_test PRIVATE ${THREAD_SYSTEM_INCLUDE_DIR})
+        target_compile_definitions(network_thread_pool_bridge_test PRIVATE WITH_THREAD_SYSTEM)
+    endif()
+
+    if(LOGGER_SYSTEM_INCLUDE_DIR)
+        target_include_directories(network_thread_pool_bridge_test PRIVATE ${LOGGER_SYSTEM_INCLUDE_DIR})
+        target_compile_definitions(network_thread_pool_bridge_test PRIVATE WITH_LOGGER_SYSTEM)
+    endif()
+
+    set_target_properties(network_thread_pool_bridge_test PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    )
+
+    network_gtest_discover_tests(network_thread_pool_bridge_test
+        DISCOVERY_TIMEOUT 60
+    )
+    message(STATUS "Thread pool bridge tests enabled")
+
     # TCP socket callback tests
     add_executable(network_tcp_socket_test
         unit/tcp_socket_test.cpp

--- a/tests/unit/test_thread_pool_bridge.cpp
+++ b/tests/unit/test_thread_pool_bridge.cpp
@@ -1,0 +1,305 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file test_thread_pool_bridge.cpp
+ * @brief Unit tests for ThreadPoolBridge class
+ */
+
+#include <gtest/gtest.h>
+
+#include <kcenon/network/integration/thread_pool_bridge.h>
+#include <kcenon/network/integration/thread_integration.h>
+#include <kcenon/network/config/feature_flags.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+namespace kcenon::network::integration {
+namespace {
+
+// Mock thread pool for testing
+class mock_thread_pool : public thread_pool_interface {
+public:
+    mock_thread_pool() : running_(true), worker_count_(4) {}
+
+    std::future<void> submit(std::function<void()> task) override {
+        std::promise<void> promise;
+        auto future = promise.get_future();
+
+        std::thread([task = std::move(task), promise = std::move(promise)]() mutable {
+            try {
+                task();
+                promise.set_value();
+            } catch (...) {
+                promise.set_exception(std::current_exception());
+            }
+        }).detach();
+
+        return future;
+    }
+
+    std::future<void> submit_delayed(
+        std::function<void()> task,
+        std::chrono::milliseconds delay) override {
+        std::promise<void> promise;
+        auto future = promise.get_future();
+
+        std::thread([task = std::move(task), delay, promise = std::move(promise)]() mutable {
+            std::this_thread::sleep_for(delay);
+            try {
+                task();
+                promise.set_value();
+            } catch (...) {
+                promise.set_exception(std::current_exception());
+            }
+        }).detach();
+
+        return future;
+    }
+
+    size_t worker_count() const override { return worker_count_; }
+    bool is_running() const override { return running_; }
+    size_t pending_tasks() const override { return pending_.load(); }
+
+    void set_running(bool running) { running_ = running; }
+    void set_worker_count(size_t count) { worker_count_ = count; }
+
+private:
+    std::atomic<bool> running_;
+    std::atomic<size_t> pending_{0};
+    size_t worker_count_;
+};
+
+class ThreadPoolBridgeTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        pool_ = std::make_shared<mock_thread_pool>();
+    }
+
+    void TearDown() override {
+        pool_.reset();
+    }
+
+    std::shared_ptr<mock_thread_pool> pool_;
+};
+
+TEST_F(ThreadPoolBridgeTest, ConstructorWithNullPoolThrows) {
+    EXPECT_THROW(
+        ThreadPoolBridge(nullptr, ThreadPoolBridge::BackendType::Custom),
+        std::invalid_argument);
+}
+
+TEST_F(ThreadPoolBridgeTest, ConstructorWithValidPool) {
+    EXPECT_NO_THROW(ThreadPoolBridge(pool_, ThreadPoolBridge::BackendType::Custom));
+}
+
+TEST_F(ThreadPoolBridgeTest, InitializeSuccess) {
+    auto bridge = std::make_shared<ThreadPoolBridge>(pool_, ThreadPoolBridge::BackendType::Custom);
+
+    BridgeConfig config;
+    config.integration_name = "test_pool";
+    config.properties["pool_name"] = "test";
+
+    auto result = bridge->initialize(config);
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_TRUE(bridge->is_initialized());
+}
+
+TEST_F(ThreadPoolBridgeTest, InitializeWithStoppedPoolFails) {
+    pool_->set_running(false);
+    auto bridge = std::make_shared<ThreadPoolBridge>(pool_, ThreadPoolBridge::BackendType::Custom);
+
+    BridgeConfig config;
+    config.integration_name = "test_pool";
+
+    auto result = bridge->initialize(config);
+    ASSERT_TRUE(result.is_err());
+    EXPECT_FALSE(bridge->is_initialized());
+}
+
+TEST_F(ThreadPoolBridgeTest, InitializeDisabledBridgeFails) {
+    auto bridge = std::make_shared<ThreadPoolBridge>(pool_, ThreadPoolBridge::BackendType::Custom);
+
+    BridgeConfig config;
+    config.integration_name = "test_pool";
+    config.properties["enabled"] = "false";
+
+    auto result = bridge->initialize(config);
+    ASSERT_TRUE(result.is_err());
+    EXPECT_FALSE(bridge->is_initialized());
+}
+
+TEST_F(ThreadPoolBridgeTest, InitializeAlreadyInitializedFails) {
+    auto bridge = std::make_shared<ThreadPoolBridge>(pool_, ThreadPoolBridge::BackendType::Custom);
+
+    BridgeConfig config;
+    config.integration_name = "test_pool";
+
+    auto result1 = bridge->initialize(config);
+    ASSERT_TRUE(result1.is_ok());
+
+    auto result2 = bridge->initialize(config);
+    ASSERT_TRUE(result2.is_err());
+}
+
+TEST_F(ThreadPoolBridgeTest, ShutdownSuccess) {
+    auto bridge = std::make_shared<ThreadPoolBridge>(pool_, ThreadPoolBridge::BackendType::Custom);
+
+    BridgeConfig config;
+    config.integration_name = "test_pool";
+
+    auto init_result = bridge->initialize(config);
+    ASSERT_TRUE(init_result.is_ok());
+
+    auto shutdown_result = bridge->shutdown();
+    ASSERT_TRUE(shutdown_result.is_ok());
+    EXPECT_FALSE(bridge->is_initialized());
+}
+
+TEST_F(ThreadPoolBridgeTest, ShutdownIdempotent) {
+    auto bridge = std::make_shared<ThreadPoolBridge>(pool_, ThreadPoolBridge::BackendType::Custom);
+
+    BridgeConfig config;
+    config.integration_name = "test_pool";
+
+    bridge->initialize(config);
+    auto result1 = bridge->shutdown();
+    ASSERT_TRUE(result1.is_ok());
+
+    auto result2 = bridge->shutdown();
+    ASSERT_TRUE(result2.is_ok());
+}
+
+TEST_F(ThreadPoolBridgeTest, GetMetricsBeforeInitialization) {
+    auto bridge = std::make_shared<ThreadPoolBridge>(pool_, ThreadPoolBridge::BackendType::Custom);
+
+    auto metrics = bridge->get_metrics();
+    EXPECT_FALSE(metrics.is_healthy);
+}
+
+TEST_F(ThreadPoolBridgeTest, GetMetricsAfterInitialization) {
+    auto bridge = std::make_shared<ThreadPoolBridge>(pool_, ThreadPoolBridge::BackendType::Custom);
+
+    BridgeConfig config;
+    config.integration_name = "test_pool";
+    bridge->initialize(config);
+
+    auto metrics = bridge->get_metrics();
+    EXPECT_TRUE(metrics.is_healthy);
+    EXPECT_EQ(metrics.custom_metrics["worker_threads"], 4.0);
+    EXPECT_EQ(metrics.custom_metrics["backend_type"],
+              static_cast<double>(ThreadPoolBridge::BackendType::Custom));
+}
+
+TEST_F(ThreadPoolBridgeTest, GetMetricsAfterShutdown) {
+    auto bridge = std::make_shared<ThreadPoolBridge>(pool_, ThreadPoolBridge::BackendType::Custom);
+
+    BridgeConfig config;
+    config.integration_name = "test_pool";
+    bridge->initialize(config);
+    bridge->shutdown();
+
+    auto metrics = bridge->get_metrics();
+    EXPECT_FALSE(metrics.is_healthy);
+}
+
+TEST_F(ThreadPoolBridgeTest, GetThreadPool) {
+    auto bridge = std::make_shared<ThreadPoolBridge>(pool_, ThreadPoolBridge::BackendType::Custom);
+
+    auto retrieved_pool = bridge->get_thread_pool();
+    EXPECT_EQ(retrieved_pool, pool_);
+}
+
+TEST_F(ThreadPoolBridgeTest, GetBackendType) {
+    auto bridge = std::make_shared<ThreadPoolBridge>(
+        pool_, ThreadPoolBridge::BackendType::ThreadSystem);
+
+    EXPECT_EQ(bridge->get_backend_type(), ThreadPoolBridge::BackendType::ThreadSystem);
+}
+
+TEST_F(ThreadPoolBridgeTest, FromThreadSystemFactoryMethod) {
+    auto bridge = ThreadPoolBridge::from_thread_system("test_pool");
+    ASSERT_NE(bridge, nullptr);
+
+    EXPECT_EQ(bridge->get_backend_type(), ThreadPoolBridge::BackendType::ThreadSystem);
+
+    auto pool = bridge->get_thread_pool();
+    ASSERT_NE(pool, nullptr);
+}
+
+TEST_F(ThreadPoolBridgeTest, ThreadPoolFunctionality) {
+    auto bridge = std::make_shared<ThreadPoolBridge>(pool_, ThreadPoolBridge::BackendType::Custom);
+
+    BridgeConfig config;
+    config.integration_name = "test_pool";
+    bridge->initialize(config);
+
+    auto pool = bridge->get_thread_pool();
+    ASSERT_NE(pool, nullptr);
+
+    std::atomic<int> counter{0};
+    auto future = pool->submit([&counter]() {
+        counter.fetch_add(1);
+    });
+
+    future.wait();
+    EXPECT_EQ(counter.load(), 1);
+}
+
+#if KCENON_WITH_COMMON_SYSTEM
+
+TEST_F(ThreadPoolBridgeTest, FromCommonSystemFactoryMethodWithNullExecutorThrows) {
+    EXPECT_THROW(
+        ThreadPoolBridge::from_common_system(nullptr),
+        std::invalid_argument);
+}
+
+// Note: Full test for from_common_system requires a mock IExecutor
+// which is complex to implement. The basic null-check is tested above.
+
+#endif // KCENON_WITH_COMMON_SYSTEM
+
+TEST_F(ThreadPoolBridgeTest, DestructorCallsShutdownIfInitialized) {
+    {
+        auto bridge = std::make_shared<ThreadPoolBridge>(pool_, ThreadPoolBridge::BackendType::Custom);
+
+        BridgeConfig config;
+        config.integration_name = "test_pool";
+        bridge->initialize(config);
+
+        // Destructor should call shutdown automatically
+    }
+    // If shutdown wasn't called, this would be a problem
+    // We can't directly test this, but we ensure no crash occurs
+}
+
+} // namespace
+} // namespace kcenon::network::integration


### PR DESCRIPTION
## Summary
Implements `ThreadPoolBridge` class that consolidates thread_system and common_system thread pool integrations into a single, unified bridge following the `INetworkBridge` interface pattern.

## What Changed
- **Added** `thread_pool_bridge.h` - ThreadPoolBridge class interface
- **Added** `thread_pool_bridge.cpp` - ThreadPoolBridge implementation
- **Added** `test_thread_pool_bridge.cpp` - Comprehensive unit tests (17 tests)
- **Modified** `bridge_interface.h` - Changed `Result<void>` to `VoidResult` for proper type compatibility
- **Modified** `CMakeLists.txt` - Added thread_pool_bridge.cpp to network-integration-objects and configured common_system integration
- **Modified** `tests/CMakeLists.txt` - Added ThreadPoolBridge test target

## Key Features
1. **Unified Interface**: Implements INetworkBridge for consistent lifecycle management
2. **Multiple Backends**: Supports both thread_system and common_system backends via runtime configuration
3. **Factory Methods**: 
   - `from_thread_system()` - Creates bridge using thread_integration_manager
   - `from_common_system()` - Creates bridge adapting common_system's IExecutor
4. **Lifecycle Management**: Initialize and shutdown with proper state tracking
5. **Health Monitoring**: Provides metrics reporting (worker threads, pending tasks, backend type)

## Technical Approach
- Delegates to existing `thread_pool_interface` for actual thread operations
- Uses `common_to_network_thread_adapter` to bridge common_system's IExecutor
- Thread-safe metrics reporting with mutex protection
- Idempotent shutdown for safe cleanup

## Testing
All 17 unit tests pass:
- Constructor validation (null pool checks)
- Initialization (success, failure cases, already initialized)
- Shutdown (success, idempotent behavior)
- Metrics reporting (before init, after init, after shutdown)
- Factory methods (thread_system, common_system)
- Thread pool functionality

## Related Issues
- Closes #582 (Implement ThreadPoolBridge for thread_system integration)
- Part of #579 (Consolidate integration adapters into NetworkSystemBridge)

## Test Plan
- Run `build/bin/network_thread_pool_bridge_test` - All 17 tests pass
- Build completes successfully with no warnings or errors

## Breaking Changes
- Modified `INetworkBridge::initialize()` and `shutdown()` return types from `Result<void>` to `VoidResult` for compatibility with network_system's type system