### PR TITLE
refactor(samples): migrate simple_http_server to facade API

### DIFF
--- a/samples/simple_http_server.cpp
+++ b/samples/simple_http_server.cpp
@@ -5,34 +5,37 @@ Copyright (c) 2024, 🍀☀🌕🌥 🌊
 All rights reserved.
 *****************************************************************************/
 
-#include "kcenon/network/core/http_server.h"
+#include <kcenon/network/facade/http_facade.h>
+#include <kcenon/network/http/http_server.h>
 #include <iostream>
 #include <chrono>
 #include <thread>
 
-using namespace kcenon::network::core;
-using namespace kcenon::network::internal;
+using namespace kcenon::network;
 
 int main()
 {
     std::cout << "=== Simple HTTP Server Demo ===" << std::endl;
 
-    // Create HTTP server
-    auto server = std::make_shared<http_server>("simple_http_server");
+    // Create HTTP server using facade
+    facade::http_facade http;
+    auto server = http.create_server({
+        .server_id = "simple_http_server"
+    });
 
     // Register routes
-    server->get("/", [](const http_request_context&)
+    server->get("/", [](const core::http_request_context&)
     {
-        http_response response;
+        internal::http_response response;
         response.status_code = 200;
         response.set_body_string("Hello, World! Welcome to NetworkSystem HTTP Server.");
         response.set_header("Content-Type", "text/plain");
         return response;
     });
 
-    server->get("/api/hello", [](const http_request_context& ctx)
+    server->get("/api/hello", [](const core::http_request_context& ctx)
     {
-        http_response response;
+        internal::http_response response;
         response.status_code = 200;
 
         auto name = ctx.get_query_param("name").value_or("Guest");
@@ -41,9 +44,9 @@ int main()
         return response;
     });
 
-    server->get("/users/:id", [](const http_request_context& ctx)
+    server->get("/users/:id", [](const core::http_request_context& ctx)
     {
-        http_response response;
+        internal::http_response response;
         response.status_code = 200;
 
         auto user_id = ctx.get_path_param("id").value_or("unknown");
@@ -52,9 +55,9 @@ int main()
         return response;
     });
 
-    server->post("/api/echo", [](const http_request_context& ctx)
+    server->post("/api/echo", [](const core::http_request_context& ctx)
     {
-        http_response response;
+        internal::http_response response;
         response.status_code = 200;
 
         auto body = ctx.request.get_body_string();


### PR DESCRIPTION
Closes #617

## Summary
- Migrated `samples/simple_http_server.cpp` to use the HTTP facade API
- Replaced direct `http_server` instantiation with `http_facade::create_server()`
- Updated namespace qualifiers for HTTP types

## Changes Made
| Item | Before | After |
|------|--------|-------|
| Include | `"kcenon/network/core/http_server.h"` | `<kcenon/network/facade/http_facade.h>` + `<kcenon/network/http/http_server.h>` |
| Instantiation | `make_shared<http_server>("id")` | `http_facade::create_server({.server_id = "id"})` |
| Types | `http_request_context`, `http_response` | `core::http_request_context`, `internal::http_response` |

## Test Plan
- [x] Sample compiles successfully
- [x] No direct include of deprecated core header
- [x] Uses `http_facade::create_server()`
- [x] Build passes (`cmake --build build/`)
- [x] Executable generated (`build/bin/network_simple_http_server`)

## Files Modified
- `samples/simple_http_server.cpp` (16 insertions, 13 deletions)