### PR TITLE
refactor(samples): migrate quic_client_example to facade API

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -86,6 +86,15 @@ foreach(SAMPLE ${SAMPLE_PROGRAMS})
         endif()
     endif()
 
+    # Additional linking for QUIC samples requiring network-quic library
+    if(SAMPLE MATCHES "quic")
+        if(TARGET network-quic)
+            target_link_libraries(network_${SAMPLE} PRIVATE
+                network-quic
+            )
+        endif()
+    endif()
+
     # Configure ASIO for all samples
     setup_asio_integration(network_${SAMPLE})
     


### PR DESCRIPTION
Closes #620

## Summary
- Migrated `quic_client_example.cpp` to use the QUIC facade API
- Replaced direct `messaging_quic_client` instantiation with `quic_facade::create_client()`
- Updated CMakeLists.txt to link `network-quic` library for QUIC samples
- Added `NETWORK_USE_EXPERIMENTAL` define for experimental API opt-in

## Changes Made
### quic_client_example.cpp
- Replaced `#include "kcenon/network/core/messaging_quic_client.h"` with facade headers
- Used structured configuration with named parameters
- Simplified ALPN configuration through facade config

### samples/CMakeLists.txt
- Added conditional linking of `network-quic` library for QUIC samples

## Test Plan
- [x] Sample compiles successfully without warnings
- [x] Build verified: `cmake --build build/ --target network_quic_client_example`
- [x] No direct include of deprecated core header
- [x] Uses `quic_facade::create_client()` factory method
- [ ] Manual runtime test (requires QUIC server)

## Part of
- Epic #577 (Apply Facade pattern to reduce protocol header complexity)
- Issue #612 (Sample migration effort)