### PR TITLE
refactor(facade): implement tcp_facade::create_server via adapter pattern

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -493,6 +493,9 @@ add_library(NetworkSystem
     src/facade/websocket_facade.cpp
     src/facade/quic_facade.cpp
 
+    # Protocol adapters - bridge legacy implementations to unified interfaces
+    src/adapters/tcp_server_adapter.cpp
+
     # Basic integration layer - container_integration and messaging_bridge
     # (Other integration sources are in network-integration-objects to avoid ODR violations)
     # messaging_bridge.cpp is here because it depends on messaging_client/server

--- a/src/adapters/tcp_server_adapter.cpp
+++ b/src/adapters/tcp_server_adapter.cpp
@@ -1,0 +1,268 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include "internal/adapters/tcp_server_adapter.h"
+
+#include "internal/core/messaging_server.h"
+#include "kcenon/network/session/messaging_session.h"
+
+namespace kcenon::network::internal::adapters {
+
+tcp_server_adapter::tcp_server_adapter(std::string_view server_id)
+	: server_id_(server_id)
+	, server_(std::make_shared<core::messaging_server>(std::string(server_id)))
+{
+	setup_internal_callbacks();
+}
+
+tcp_server_adapter::~tcp_server_adapter()
+{
+	if (server_ && server_->is_running())
+	{
+		(void)server_->stop_server();
+	}
+}
+
+// =========================================================================
+// i_network_component interface implementation
+// =========================================================================
+
+auto tcp_server_adapter::is_running() const -> bool
+{
+	return server_ && server_->is_running();
+}
+
+auto tcp_server_adapter::wait_for_stop() -> void
+{
+	if (server_)
+	{
+		server_->wait_for_stop();
+	}
+}
+
+// =========================================================================
+// i_protocol_server interface implementation
+// =========================================================================
+
+auto tcp_server_adapter::start(uint16_t port) -> VoidResult
+{
+	if (!server_)
+	{
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"Server not initialized",
+			"tcp_server_adapter::start"
+		);
+	}
+	return server_->start_server(port);
+}
+
+auto tcp_server_adapter::stop() -> VoidResult
+{
+	if (!server_)
+	{
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"Server not initialized",
+			"tcp_server_adapter::stop"
+		);
+	}
+
+	auto result = server_->stop_server();
+
+	// Clear tracked sessions on stop
+	{
+		std::lock_guard<std::mutex> lock(sessions_mutex_);
+		sessions_.clear();
+	}
+
+	return result;
+}
+
+auto tcp_server_adapter::connection_count() const -> size_t
+{
+	std::lock_guard<std::mutex> lock(sessions_mutex_);
+	return sessions_.size();
+}
+
+auto tcp_server_adapter::set_connection_callback(connection_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	connection_callback_ = std::move(callback);
+}
+
+auto tcp_server_adapter::set_disconnection_callback(disconnection_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	disconnection_callback_ = std::move(callback);
+}
+
+auto tcp_server_adapter::set_receive_callback(receive_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	receive_callback_ = std::move(callback);
+}
+
+auto tcp_server_adapter::set_error_callback(error_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	error_callback_ = std::move(callback);
+}
+
+// =========================================================================
+// Internal methods
+// =========================================================================
+
+auto tcp_server_adapter::setup_internal_callbacks() -> void
+{
+	if (!server_)
+	{
+		return;
+	}
+
+	// Bridge legacy connection callback to i_protocol_server callback
+	server_->set_connection_callback(
+		[this](std::shared_ptr<session::messaging_session> session)
+		{
+			if (!session)
+			{
+				return;
+			}
+
+			// Track the session
+			auto i_session_ptr = track_session(session);
+
+			// Invoke the interface callback
+			connection_callback_t callback_copy;
+			{
+				std::lock_guard<std::mutex> lock(callbacks_mutex_);
+				callback_copy = connection_callback_;
+			}
+			if (callback_copy)
+			{
+				callback_copy(std::move(i_session_ptr));
+			}
+		});
+
+	// Bridge legacy disconnection callback
+	server_->set_disconnection_callback(
+		[this](const std::string& session_id)
+		{
+			// Remove from tracked sessions
+			{
+				std::lock_guard<std::mutex> lock(sessions_mutex_);
+				sessions_.erase(session_id);
+			}
+
+			// Invoke the interface callback
+			disconnection_callback_t callback_copy;
+			{
+				std::lock_guard<std::mutex> lock(callbacks_mutex_);
+				callback_copy = disconnection_callback_;
+			}
+			if (callback_copy)
+			{
+				callback_copy(session_id);
+			}
+		});
+
+	// Bridge legacy receive callback
+	server_->set_receive_callback(
+		[this](std::shared_ptr<session::messaging_session> session,
+		       const std::vector<uint8_t>& data)
+		{
+			if (!session)
+			{
+				return;
+			}
+
+			// Get session ID (messaging_session inherits from i_session)
+			std::string session_id(session->id());
+
+			// Invoke the interface callback
+			receive_callback_t callback_copy;
+			{
+				std::lock_guard<std::mutex> lock(callbacks_mutex_);
+				callback_copy = receive_callback_;
+			}
+			if (callback_copy)
+			{
+				callback_copy(session_id, data);
+			}
+		});
+
+	// Bridge legacy error callback
+	server_->set_error_callback(
+		[this](std::shared_ptr<session::messaging_session> session,
+		       std::error_code ec)
+		{
+			if (!session)
+			{
+				return;
+			}
+
+			// Get session ID
+			std::string session_id(session->id());
+
+			// Invoke the interface callback
+			error_callback_t callback_copy;
+			{
+				std::lock_guard<std::mutex> lock(callbacks_mutex_);
+				callback_copy = error_callback_;
+			}
+			if (callback_copy)
+			{
+				callback_copy(session_id, ec);
+			}
+		});
+}
+
+auto tcp_server_adapter::track_session(std::shared_ptr<session::messaging_session> session)
+	-> std::shared_ptr<interfaces::i_session>
+{
+	if (!session)
+	{
+		return nullptr;
+	}
+
+	std::string session_id(session->id());
+
+	{
+		std::lock_guard<std::mutex> lock(sessions_mutex_);
+		sessions_[session_id] = session;
+	}
+
+	// messaging_session inherits from i_session, so we can return it directly
+	return session;
+}
+
+} // namespace kcenon::network::internal::adapters

--- a/src/facade/tcp_facade.cpp
+++ b/src/facade/tcp_facade.cpp
@@ -38,9 +38,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdexcept>
 
 #include "internal/core/messaging_client.h"
-// SSL and server implementations will be added after they implement the protocol interfaces
+#include "internal/adapters/tcp_server_adapter.h"
+// SSL implementations will be added after they implement the protocol interfaces
 // #include "internal/core/secure_messaging_client.h"
-// #include "internal/core/messaging_server.h"
 // #include "internal/core/secure_messaging_server.h"
 
 namespace kcenon::network::facade
@@ -149,13 +149,24 @@ auto tcp_facade::create_server(const server_config& config) const
 	// Validate configuration
 	validate_server_config(config);
 
-	// TODO: Implement server creation after messaging_server implements IProtocolServer
-	// This is tracked in issue #597 (or create a follow-up issue for server support)
+	// Generate server ID if not provided
+	const std::string server_id = config.server_id.empty() ? generate_server_id() : config.server_id;
 
-	// For now, throw to indicate this is not yet implemented
-	throw std::runtime_error(
-		"tcp_facade::create_server not yet implemented - "
-		"requires messaging_server to implement IProtocolServer interface");
+	// Create appropriate server type based on SSL flag
+	std::shared_ptr<interfaces::i_protocol_server> server;
+
+	if (config.use_ssl)
+	{
+		// Note: SSL support will be added after secure_messaging_server implements IProtocolServer
+		throw std::runtime_error(
+			"tcp_facade: SSL/TLS support not yet implemented - "
+			"requires secure_messaging_server to implement IProtocolServer interface");
+	}
+
+	// Create adapter wrapping messaging_server
+	server = std::make_shared<internal::adapters::tcp_server_adapter>(server_id);
+
+	return server;
 }
 
 } // namespace kcenon::network::facade

--- a/src/internal/adapters/tcp_server_adapter.h
+++ b/src/internal/adapters/tcp_server_adapter.h
@@ -1,0 +1,149 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include "kcenon/network/interfaces/i_protocol_server.h"
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace kcenon::network::core {
+	class messaging_server;
+}
+
+namespace kcenon::network::session {
+	class messaging_session;
+}
+
+namespace kcenon::network::internal::adapters {
+
+/**
+ * @class tcp_server_adapter
+ * @brief Adapter that wraps messaging_server to implement i_protocol_server
+ *
+ * This adapter bridges the legacy messaging_server implementation with the
+ * unified i_protocol_server interface. It allows tcp_facade to return
+ * i_protocol_server without modifying the existing messaging_server class.
+ *
+ * ### Design Rationale
+ * The adapter pattern is used instead of direct inheritance because:
+ * 1. messaging_server has legacy callback signatures that differ from i_protocol_server
+ * 2. Avoiding breaking changes to existing code that uses messaging_server directly
+ * 3. Clean separation between legacy API and new unified API
+ *
+ * ### Thread Safety
+ * Thread-safe. All methods can be called from any thread.
+ *
+ * ### Usage Example
+ * @code
+ * // Used internally by tcp_facade
+ * auto adapter = std::make_shared<tcp_server_adapter>("my-server");
+ * auto result = adapter->start(8080);
+ * if (result) {
+ *     // Server is running
+ * }
+ * @endcode
+ *
+ * @see i_protocol_server
+ * @see messaging_server
+ */
+class tcp_server_adapter : public interfaces::i_protocol_server {
+public:
+	/**
+	 * @brief Constructs an adapter with a unique server ID
+	 * @param server_id Unique identifier for this server
+	 */
+	explicit tcp_server_adapter(std::string_view server_id);
+
+	/**
+	 * @brief Destructor ensures proper cleanup
+	 */
+	~tcp_server_adapter() override;
+
+	// Non-copyable, non-movable
+	tcp_server_adapter(const tcp_server_adapter&) = delete;
+	tcp_server_adapter& operator=(const tcp_server_adapter&) = delete;
+	tcp_server_adapter(tcp_server_adapter&&) = delete;
+	tcp_server_adapter& operator=(tcp_server_adapter&&) = delete;
+
+	// =========================================================================
+	// i_network_component interface implementation
+	// =========================================================================
+
+	[[nodiscard]] auto is_running() const -> bool override;
+	auto wait_for_stop() -> void override;
+
+	// =========================================================================
+	// i_protocol_server interface implementation
+	// =========================================================================
+
+	[[nodiscard]] auto start(uint16_t port) -> VoidResult override;
+	[[nodiscard]] auto stop() -> VoidResult override;
+	[[nodiscard]] auto connection_count() const -> size_t override;
+
+	auto set_connection_callback(connection_callback_t callback) -> void override;
+	auto set_disconnection_callback(disconnection_callback_t callback) -> void override;
+	auto set_receive_callback(receive_callback_t callback) -> void override;
+	auto set_error_callback(error_callback_t callback) -> void override;
+
+private:
+	/**
+	 * @brief Sets up internal callbacks to bridge legacy callbacks to i_protocol_server callbacks
+	 */
+	auto setup_internal_callbacks() -> void;
+
+	/**
+	 * @brief Tracks a session and returns it as i_session
+	 * @param session The messaging_session to track
+	 * @return Shared pointer to i_session
+	 */
+	auto track_session(std::shared_ptr<session::messaging_session> session)
+		-> std::shared_ptr<interfaces::i_session>;
+
+	std::string server_id_;
+	std::shared_ptr<core::messaging_server> server_;
+
+	mutable std::mutex callbacks_mutex_;
+	connection_callback_t connection_callback_;
+	disconnection_callback_t disconnection_callback_;
+	receive_callback_t receive_callback_;
+	error_callback_t error_callback_;
+
+	// Session tracking for lookup by ID
+	mutable std::mutex sessions_mutex_;
+	std::unordered_map<std::string, std::shared_ptr<session::messaging_session>> sessions_;
+};
+
+} // namespace kcenon::network::internal::adapters


### PR DESCRIPTION
## Summary

Implements `tcp_server_adapter` to bridge `messaging_server` with `i_protocol_server` interface, enabling `tcp_facade::create_server` to return a working `i_protocol_server` instance.

### Approach

The adapter pattern was chosen instead of direct inheritance because:
- Avoids breaking changes to legacy `messaging_server` API
- Keeps callback signature differences isolated (legacy uses `std::shared_ptr<messaging_session>`, interface uses `std::string_view session_id`)
- Enables clean separation between legacy and unified APIs

## Changes

- Add `tcp_server_adapter` class implementing `i_protocol_server`
- Update `tcp_facade::create_server` to use the adapter
- Register new source file in CMakeLists.txt

## Test Plan

- [x] Build passes
- [x] TcpFacadeTest passes
- [x] Client/server tests pass

Closes #640