### PR TITLE
refactor(headers): update source code to use internal header paths

### DIFF
--- a/core/messaging_client.cpp
+++ b/core/messaging_client.cpp
@@ -30,7 +30,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
-#include "kcenon/network/core/messaging_client.h"
+#include "internal/core/messaging_client.h"
 #include "kcenon/network/internal/send_coroutine.h"
 #include "kcenon/network/integration/logger_integration.h"
 #include "kcenon/network/integration/io_context_thread_manager.h"

--- a/core/messaging_server.cpp
+++ b/core/messaging_server.cpp
@@ -30,7 +30,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
-#include "kcenon/network/core/messaging_server.h"
+#include "internal/core/messaging_server.h"
 #include "kcenon/network/session/messaging_session.h"
 #include "kcenon/network/integration/logger_integration.h"
 #include "kcenon/network/integration/io_context_thread_manager.h"

--- a/libs/network-tcp/include/network_tcp/unified/adapters/tcp_connection_adapter.h
+++ b/libs/network-tcp/include/network_tcp/unified/adapters/tcp_connection_adapter.h
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include "kcenon/network/unified/i_connection.h"
-#include "kcenon/network/core/unified_messaging_client.h"
+#include "internal/core/unified_messaging_client.h"
 
 #include <atomic>
 #include <memory>

--- a/libs/network-tcp/include/network_tcp/unified/adapters/tcp_listener_adapter.h
+++ b/libs/network-tcp/include/network_tcp/unified/adapters/tcp_listener_adapter.h
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include "kcenon/network/unified/i_listener.h"
-#include "kcenon/network/core/unified_messaging_server.h"
+#include "internal/core/unified_messaging_server.h"
 
 #include <atomic>
 #include <memory>

--- a/libs/network-udp/experimental/src/reliable_udp_client.cpp
+++ b/libs/network-udp/experimental/src/reliable_udp_client.cpp
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define NETWORK_USE_EXPERIMENTAL
 #include "network_udp/reliable_udp_client.h"
 #include "network_udp/core/messaging_udp_client.h"
-#include "kcenon/network/core/network_context.h"
+#include "internal/core/network_context.h"
 #include "internal/integration/logger_integration.h"
 
 #include <algorithm>

--- a/libs/network-udp/include/network_udp/core/messaging_udp_client.h
+++ b/libs/network-udp/include/network_udp/core/messaging_udp_client.h
@@ -63,7 +63,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <asio.hpp>
 
-#include "kcenon/network/core/callback_indices.h"
+#include "internal/core/callback_indices.h"
 #include "network_udp/interfaces/i_udp_client.h"
 #include "kcenon/network/utils/result_types.h"
 #include "kcenon/network/utils/lifecycle_manager.h"

--- a/libs/network-udp/include/network_udp/core/messaging_udp_server.h
+++ b/libs/network-udp/include/network_udp/core/messaging_udp_server.h
@@ -62,7 +62,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <asio.hpp>
 
-#include "kcenon/network/core/callback_indices.h"
+#include "internal/core/callback_indices.h"
 #include "network_udp/interfaces/i_udp_server.h"
 #include "kcenon/network/utils/result_types.h"
 #include "kcenon/network/utils/lifecycle_manager.h"

--- a/libs/network-udp/include/network_udp/core/secure_messaging_udp_client.h
+++ b/libs/network-udp/include/network_udp/core/secure_messaging_udp_client.h
@@ -65,7 +65,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <asio.hpp>
 #include <openssl/ssl.h>
 
-#include "kcenon/network/core/callback_indices.h"
+#include "internal/core/callback_indices.h"
 #include "kcenon/network/integration/thread_integration.h"
 #include "kcenon/network/utils/lifecycle_manager.h"
 #include "kcenon/network/utils/callback_manager.h"

--- a/libs/network-udp/include/network_udp/core/unified_udp_messaging_client.h
+++ b/libs/network-udp/include/network_udp/core/unified_udp_messaging_client.h
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <asio.hpp>
 
-#include "kcenon/network/core/callback_indices.h"
+#include "internal/core/callback_indices.h"
 #include "network_udp/interfaces/i_udp_client.h"
 #include "kcenon/network/integration/thread_integration.h"
 #include "kcenon/network/policy/tls_policy.h"

--- a/libs/network-udp/include/network_udp/core/unified_udp_messaging_client.inl
+++ b/libs/network-udp/include/network_udp/core/unified_udp_messaging_client.inl
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "kcenon/network/core/network_context.h"
+#include "internal/core/network_context.h"
 #include "network_udp/internal/udp_socket.h"
 #include "internal/integration/logger_integration.h"
 

--- a/libs/network-udp/include/network_udp/core/unified_udp_messaging_server.h
+++ b/libs/network-udp/include/network_udp/core/unified_udp_messaging_server.h
@@ -48,7 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <asio.hpp>
 
-#include "kcenon/network/core/callback_indices.h"
+#include "internal/core/callback_indices.h"
 #include "network_udp/interfaces/i_udp_server.h"
 #include "kcenon/network/integration/thread_integration.h"
 #include "kcenon/network/policy/tls_policy.h"

--- a/libs/network-udp/include/network_udp/core/unified_udp_messaging_server.inl
+++ b/libs/network-udp/include/network_udp/core/unified_udp_messaging_server.inl
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "kcenon/network/core/network_context.h"
+#include "internal/core/network_context.h"
 #include "network_udp/internal/udp_socket.h"
 #include "internal/integration/logger_integration.h"
 

--- a/libs/network-udp/src/messaging_udp_client.cpp
+++ b/libs/network-udp/src/messaging_udp_client.cpp
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
 #include "network_udp/core/messaging_udp_client.h"
-#include "kcenon/network/core/network_context.h"
+#include "internal/core/network_context.h"
 #include "network_udp/internal/udp_socket.h"
 #include "internal/integration/logger_integration.h"
 

--- a/libs/network-udp/src/messaging_udp_server.cpp
+++ b/libs/network-udp/src/messaging_udp_server.cpp
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
 #include "network_udp/core/messaging_udp_server.h"
-#include "kcenon/network/core/network_context.h"
+#include "internal/core/network_context.h"
 #include "network_udp/internal/udp_socket.h"
 #include "internal/integration/logger_integration.h"
 

--- a/libs/network-udp/src/secure_messaging_udp_client.cpp
+++ b/libs/network-udp/src/secure_messaging_udp_client.cpp
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
 #include "network_udp/core/secure_messaging_udp_client.h"
-#include "kcenon/network/core/network_context.h"
+#include "internal/core/network_context.h"
 #include "internal/tcp/dtls_socket.h"
 
 #include <chrono>

--- a/libs/network-udp/src/secure_messaging_udp_server.cpp
+++ b/libs/network-udp/src/secure_messaging_udp_server.cpp
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
 #include "network_udp/core/secure_messaging_udp_server.h"
-#include "kcenon/network/core/network_context.h"
+#include "internal/core/network_context.h"
 #include "internal/tcp/dtls_socket.h"
 
 #include <string_view>

--- a/src/internal/http/http_client.h
+++ b/src/internal/http/http_client.h
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "kcenon/network/core/messaging_client.h"
+#include "internal/core/messaging_client.h"
 #include "internal/http/http_types.h"
 #include "internal/http/http_parser.h"
 #include "kcenon/network/utils/result_types.h"

--- a/src/internal/http/http_server.h
+++ b/src/internal/http/http_server.h
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "kcenon/network/core/messaging_server.h"
+#include "internal/core/messaging_server.h"
 #include "internal/http/http_types.h"
 #include "internal/http/http_parser.h"
 #include "internal/http/http_error.h"

--- a/src/internal/http/websocket_client.h
+++ b/src/internal/http/websocket_client.h
@@ -47,7 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <asio.hpp>
 
 #include "kcenon/network/interfaces/i_websocket_client.h"
-#include "kcenon/network/core/callback_indices.h"
+#include "internal/core/callback_indices.h"
 #include "internal/websocket/websocket_protocol.h"
 #include "kcenon/network/utils/result_types.h"
 #include "kcenon/network/utils/lifecycle_manager.h"

--- a/src/internal/http/websocket_server.h
+++ b/src/internal/http/websocket_server.h
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
-#include "kcenon/network/core/callback_indices.h"
+#include "internal/core/callback_indices.h"
 #include "kcenon/network/interfaces/i_websocket_server.h"
 #include "internal/websocket/websocket_protocol.h"
 #include "kcenon/network/utils/result_types.h"

--- a/src/internal/integration/messaging_bridge.h
+++ b/src/internal/integration/messaging_bridge.h
@@ -46,8 +46,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <kcenon/network/config/feature_flags.h>
 #include "internal/integration/bridge_interface.h"
-#include "kcenon/network/core/messaging_client.h"
-#include "kcenon/network/core/messaging_server.h"
+#include "internal/core/messaging_client.h"
+#include "internal/core/messaging_server.h"
 
 #if KCENON_WITH_CONTAINER_SYSTEM
 #include "container.h"


### PR DESCRIPTION
## Summary
- Update source files to include internal headers directly instead of deprecated public header shims
- Prepares codebase for future removal of deprecated header shims
- Eliminates unnecessary deprecation warnings in internal implementation files

## Related Issues
- Closes #642
- Part of #577 (EPIC: Apply Facade pattern to reduce protocol header complexity)

## Files Changed

### Core
- `core/messaging_client.cpp` - Use `internal/core/messaging_client.h`
- `core/messaging_server.cpp` - Use `internal/core/messaging_server.h`

### network-udp Library
- Source files: Use `internal/core/network_context.h` instead of deprecated shim
- Header files: Use `internal/core/callback_indices.h` instead of deprecated shim

### network-tcp Library
- `tcp_connection_adapter.h` - Use `internal/core/unified_messaging_client.h`
- `tcp_listener_adapter.h` - Use `internal/core/unified_messaging_server.h`

### Internal Headers
- `http_client.h`, `http_server.h` - Use internal core headers
- `websocket_client.h`, `websocket_server.h` - Use internal callback indices
- `messaging_bridge.h` - Use internal messaging headers

## Test Plan
- [x] Build passes (`cmake --build build/`)
- [x] All tests pass (1468/1470, remaining 2 are flaky timing tests)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No breaking changes to public API