### PR TITLE
refactor(tests): update tests to use internal/experimental header paths

### DIFF
--- a/tests/failure/boundary_test.cpp
+++ b/tests/failure/boundary_test.cpp
@@ -7,9 +7,9 @@ All rights reserved.
 
 #include <gtest/gtest.h>
 
-#include "kcenon/network/core/http_server.h"
-#include "kcenon/network/core/messaging_client.h"
-#include "kcenon/network/core/messaging_server.h"
+#include "internal/http/http_server.h"
+#include "internal/core/messaging_client.h"
+#include "internal/core/messaging_server.h"
 #include "internal/http/http_error.h"
 
 #include <chrono>

--- a/tests/failure/network_failure_test.cpp
+++ b/tests/failure/network_failure_test.cpp
@@ -7,8 +7,8 @@ All rights reserved.
 
 #include <gtest/gtest.h>
 
-#include "kcenon/network/core/messaging_client.h"
-#include "kcenon/network/core/messaging_server.h"
+#include "internal/core/messaging_client.h"
+#include "internal/core/messaging_server.h"
 
 #include <atomic>
 #include <chrono>

--- a/tests/integration/session_manager_integration_test.cpp
+++ b/tests/integration/session_manager_integration_test.cpp
@@ -5,8 +5,8 @@ Copyright (c) 2025, kcenon
 All rights reserved.
 *****************************************************************************/
 
-#include "kcenon/network/core/session_manager.h"
-#include "kcenon/network/core/session_manager_base.h"
+#include "internal/core/session_manager.h"
+#include "internal/core/session_manager_base.h"
 
 #include <gtest/gtest.h>
 

--- a/tests/integration/test_quic_e2e.cpp
+++ b/tests/integration/test_quic_e2e.cpp
@@ -56,8 +56,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <gtest/gtest.h>
 
-#include "kcenon/network/core/messaging_quic_client.h"
-#include "kcenon/network/core/messaging_quic_server.h"
+#define NETWORK_USE_EXPERIMENTAL
+#include "kcenon/network/experimental/quic_client.h"
+#include "kcenon/network/experimental/quic_server.h"
 #include "kcenon/network/session/quic_session.h"
 
 using namespace kcenon::network::core;

--- a/tests/test_messaging_quic_client.cpp
+++ b/tests/test_messaging_quic_client.cpp
@@ -36,7 +36,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <thread>
 #include <future>
 
-#include "kcenon/network/core/messaging_quic_client.h"
+#define NETWORK_USE_EXPERIMENTAL
+#include "kcenon/network/experimental/quic_client.h"
 #include "kcenon/network/utils/result_types.h"
 
 namespace kcenon::network::core::test

--- a/tests/test_messaging_quic_server.cpp
+++ b/tests/test_messaging_quic_server.cpp
@@ -36,7 +36,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <thread>
 #include <future>
 
-#include "kcenon/network/core/messaging_quic_server.h"
+#define NETWORK_USE_EXPERIMENTAL
+#include "kcenon/network/experimental/quic_server.h"
 #include "kcenon/network/utils/result_types.h"
 #include "kcenon/network/session/quic_session.h"
 #include "kcenon/network/utils/result_types.h"

--- a/tests/test_messaging_ws_client.cpp
+++ b/tests/test_messaging_ws_client.cpp
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <gtest/gtest.h>
 
-#include "kcenon/network/core/messaging_ws_client.h"
+#include "kcenon/network/http/websocket_client.h"
 #include "kcenon/network/utils/result_types.h"
 
 namespace kcenon::network::core::test

--- a/tests/test_messaging_ws_server.cpp
+++ b/tests/test_messaging_ws_server.cpp
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <gtest/gtest.h>
 
-#include "kcenon/network/core/messaging_ws_server.h"
+#include "kcenon/network/http/websocket_server.h"
 #include "kcenon/network/utils/result_types.h"
 
 namespace kcenon::network::core::test

--- a/tests/thread_safety_tests.cpp
+++ b/tests/thread_safety_tests.cpp
@@ -5,8 +5,8 @@ Copyright (c) 2025, 🍀☀🌕🌥 🌊
 All rights reserved.
 *****************************************************************************/
 
-#include "kcenon/network/core/messaging_client.h"
-#include "kcenon/network/core/messaging_server.h"
+#include "internal/core/messaging_client.h"
+#include "internal/core/messaging_server.h"
 #include "kcenon/network/session/messaging_session.h"
 #include <gtest/gtest.h>
 

--- a/tests/udp_basic_test.cpp
+++ b/tests/udp_basic_test.cpp
@@ -41,8 +41,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * - Error conditions
  */
 
-#include "kcenon/network/core/messaging_udp_server.h"
-#include "kcenon/network/core/messaging_udp_client.h"
+#include "internal/core/messaging_udp_server.h"
+#include "internal/core/messaging_udp_client.h"
 
 #include <iostream>
 #include <thread>

--- a/tests/unit/session_manager_base_test.cpp
+++ b/tests/unit/session_manager_base_test.cpp
@@ -5,7 +5,7 @@ Copyright (c) 2025, kcenon
 All rights reserved.
 *****************************************************************************/
 
-#include "kcenon/network/core/session_manager_base.h"
+#include "internal/core/session_manager_base.h"
 
 #include <gtest/gtest.h>
 

--- a/tests/unit/session_manager_test.cpp
+++ b/tests/unit/session_manager_test.cpp
@@ -5,7 +5,7 @@ Copyright (c) 2025, 🍀☀🌕🌥 🌊
 All rights reserved.
 *****************************************************************************/
 
-#include "kcenon/network/core/session_manager.h"
+#include "internal/core/session_manager.h"
 #include <gtest/gtest.h>
 
 #include <chrono>

--- a/tests/unit/session_type_erasure_test.cpp
+++ b/tests/unit/session_type_erasure_test.cpp
@@ -5,10 +5,10 @@ Copyright (c) 2025, kcenon
 All rights reserved.
 *****************************************************************************/
 
-#include "kcenon/network/core/session_concept.h"
-#include "kcenon/network/core/session_handle.h"
-#include "kcenon/network/core/session_model.h"
-#include "kcenon/network/core/session_traits.h"
+#include "internal/core/session_concept.h"
+#include "internal/core/session_handle.h"
+#include "internal/core/session_model.h"
+#include "internal/core/session_traits.h"
 
 #include <gtest/gtest.h>
 

--- a/tests/unit/test_udp_composition.cpp
+++ b/tests/unit/test_udp_composition.cpp
@@ -51,8 +51,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <thread>
 #include <vector>
 
-#include "kcenon/network/core/messaging_udp_client.h"
-#include "kcenon/network/core/messaging_udp_server.h"
+#include "internal/core/messaging_udp_client.h"
+#include "internal/core/messaging_udp_server.h"
 #include "kcenon/network/interfaces/i_udp_client.h"
 #include "kcenon/network/interfaces/i_udp_server.h"
 

--- a/tests/unit/test_unified_messaging_client.cpp
+++ b/tests/unit/test_unified_messaging_client.cpp
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 #include <type_traits>
 
-#include "kcenon/network/core/unified_messaging_client.h"
+#include "internal/core/unified_messaging_client.h"
 #include "kcenon/network/policy/tls_policy.h"
 #include "kcenon/network/protocol/protocol_tags.h"
 

--- a/tests/unit/test_unified_messaging_server.cpp
+++ b/tests/unit/test_unified_messaging_server.cpp
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 #include <type_traits>
 
-#include "kcenon/network/core/unified_messaging_server.h"
+#include "internal/core/unified_messaging_server.h"
 #include "kcenon/network/policy/tls_policy.h"
 #include "kcenon/network/protocol/protocol_tags.h"
 

--- a/tests/unit/unified_session_manager_test.cpp
+++ b/tests/unit/unified_session_manager_test.cpp
@@ -5,8 +5,8 @@ Copyright (c) 2025, kcenon
 All rights reserved.
 *****************************************************************************/
 
-#include "kcenon/network/core/session_traits.h"
-#include "kcenon/network/core/unified_session_manager.h"
+#include "internal/core/session_traits.h"
+#include "internal/core/unified_session_manager.h"
 
 #include <gtest/gtest.h>
 

--- a/tests/unit/ws_session_manager_test.cpp
+++ b/tests/unit/ws_session_manager_test.cpp
@@ -5,7 +5,7 @@ Copyright (c) 2025, kcenon
 All rights reserved.
 *****************************************************************************/
 
-#include "kcenon/network/core/ws_session_manager.h"
+#include "internal/core/ws_session_manager.h"
 
 #include <gtest/gtest.h>
 

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -44,8 +44,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <thread>
 #include <vector>
 
-#include "kcenon/network/core/messaging_server.h"
-#include "kcenon/network/core/messaging_client.h"
+#include "internal/core/messaging_server.h"
+#include "internal/core/messaging_client.h"
 #include "internal/integration/container_integration.h"
 #include "kcenon/network/utils/result_types.h"
 


### PR DESCRIPTION
Closes #646

## Summary

Update all test files to use new header locations instead of deprecated `kcenon/network/core/*` paths. This change is part of EPIC #577 (Facade pattern implementation) and prepares for deprecated wrapper header removal.

### Header Path Mappings

| Old Path | New Path |
|----------|----------|
| `kcenon/network/core/messaging_*.h` | `internal/core/messaging_*.h` |
| `kcenon/network/core/session_*.h` | `internal/core/session_*.h` |
| `kcenon/network/core/messaging_quic_*.h` | `kcenon/network/experimental/quic_*.h` |
| `kcenon/network/core/messaging_ws_*.h` | `kcenon/network/http/websocket_*.h` |

### Files Modified

- 19 test files updated
- TCP/UDP internal tests now use `internal/core/*` paths
- QUIC tests now use `experimental/quic_*` with `NETWORK_USE_EXPERIMENTAL`
- WebSocket tests now use `http/websocket_*` paths

## Test Plan

- [x] All session manager tests pass (88/88 - 100%)
- [x] Build passes without errors
- [x] Overall test suite passes at 99% (same rate as before)
- [x] No new test failures introduced by this change