### PR TITLE
refactor(internal): update WebSocket adapter includes to internal paths

### DIFF
--- a/src/internal/unified/adapters/ws_connection_adapter.h
+++ b/src/internal/unified/adapters/ws_connection_adapter.h
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include "kcenon/network/unified/i_connection.h"
-#include "kcenon/network/http/websocket_client.h"
+#include "internal/http/websocket_client.h"
 
 #include <atomic>
 #include <memory>

--- a/src/internal/unified/adapters/ws_listener_adapter.h
+++ b/src/internal/unified/adapters/ws_listener_adapter.h
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include "kcenon/network/unified/i_listener.h"
-#include "kcenon/network/http/websocket_server.h"
+#include "internal/http/websocket_server.h"
 
 #include <atomic>
 #include <memory>


### PR DESCRIPTION
## Summary

Updates internal WebSocket adapter headers to use internal include paths instead of deprecated public paths.

Closes #649

## Changes

- `src/internal/unified/adapters/ws_connection_adapter.h`:
  - Changed `#include "kcenon/network/http/websocket_client.h"` to `#include "internal/http/websocket_client.h"`

- `src/internal/unified/adapters/ws_listener_adapter.h`:
  - Changed `#include "kcenon/network/http/websocket_server.h"` to `#include "internal/http/websocket_server.h"`

## Context

Part of EPIC #577 (Apply Facade pattern to reduce protocol header complexity).

This is a prerequisite for removing deprecated wrapper headers (#648). The internal files were including deprecated public header paths which created a circular dependency preventing wrapper removal.

## Test Plan

- [x] Build passes
- [x] Tests pass (99% - 3 flaky integration/load tests unrelated to this change)
