### PR TITLE
refactor(internal): move experimental headers to src/internal

### DIFF
--- a/include/kcenon/network/core/README.md
+++ b/include/kcenon/network/core/README.md
@@ -25,9 +25,9 @@ deprecation warnings. Please migrate to the new locations:
 | `http_server.h` | `kcenon/network/http/http_server.h` |
 | `messaging_ws_client.h` | `kcenon/network/http/websocket_client.h` |
 | `messaging_ws_server.h` | `kcenon/network/http/websocket_server.h` |
-| `messaging_quic_client.h` | `kcenon/network/experimental/quic_client.h` |
-| `messaging_quic_server.h` | `kcenon/network/experimental/quic_server.h` |
-| `reliable_udp_client.h` | `kcenon/network/experimental/reliable_udp_client.h` |
+| `messaging_quic_client.h` | `internal/experimental/quic_client.h` |
+| `messaging_quic_server.h` | `internal/experimental/quic_server.h` |
+| `reliable_udp_client.h` | `internal/experimental/reliable_udp_client.h` |
 
 ## Stability
 

--- a/include/kcenon/network/experimental/README.md
+++ b/include/kcenon/network/experimental/README.md
@@ -1,96 +1,55 @@
-# Experimental Module
+# Experimental Module (Migrated)
 
-This module contains experimental protocol implementations that are still under development.
+## Status: Moved to Internal
 
-## Warning
+The experimental headers have been moved to `src/internal/experimental/` as part of the header simplification effort (Issue #577).
 
-**APIs in this module may change between minor versions without notice.**
+## Migration Guide
 
-These implementations are provided for early adopters and feedback collection.
-Do not use in production without understanding the risks.
+If you were using experimental APIs directly, update your includes:
 
-## Contents
+| Old Path | New Path |
+|----------|----------|
+| `kcenon/network/experimental/quic_client.h` | `internal/experimental/quic_client.h` |
+| `kcenon/network/experimental/quic_server.h` | `internal/experimental/quic_server.h` |
+| `kcenon/network/experimental/reliable_udp_client.h` | `internal/experimental/reliable_udp_client.h` |
+| `kcenon/network/experimental/experimental_api.h` | `internal/experimental/experimental_api.h` |
 
-| Header | Description |
-|--------|-------------|
-| `experimental_api.h` | Macros for experimental API opt-in |
-| `quic_client.h` | QUIC protocol client implementation |
-| `quic_server.h` | QUIC protocol server implementation |
-| `reliable_udp_client.h` | Reliable UDP transport layer |
+## Recommended Approach
 
-## Enabling Experimental APIs
-
-To use experimental APIs, you must explicitly opt-in:
+Instead of using internal headers directly, prefer the facade APIs:
 
 ```cpp
-// Method 1: Define before including
-#define NETWORK_USE_EXPERIMENTAL
-#include <kcenon/network/experimental/quic_client.h>
+#include <kcenon/network/facade/quic_facade.h>
 
-// Method 2: Compiler define
-// g++ -DNETWORK_USE_EXPERIMENTAL ...
-```
+using namespace kcenon::network::facade;
 
-Without opt-in, you'll get a compile-time error explaining that the API is experimental.
-
-## Usage
-
-```cpp
-#define NETWORK_USE_EXPERIMENTAL
-#include <kcenon/network/experimental/quic_client.h>
-#include <kcenon/network/experimental/quic_server.h>
-
-using namespace kcenon::network::experimental;
-
-// QUIC Client
-auto client = messaging_quic_client::create(quic_client_config{
-    .server_address = "localhost",
-    .port = 4433
+// Create QUIC client via facade
+quic_facade facade;
+auto client = facade.create_client({
+    .host = "localhost",
+    .port = 4433,
+    .client_id = "my-client"
 });
 
-// QUIC Server (requires TLS certificates)
-auto server = messaging_quic_server::create(quic_server_config{
+// Create QUIC server via facade
+auto server = facade.create_server({
     .port = 4433,
     .cert_path = "server.crt",
     .key_path = "server.key"
 });
 ```
 
-## Migration from core/
+## Why This Change?
 
-If you were previously using includes from `kcenon/network/core/`:
+This change is part of EPIC #577 to:
+1. Reduce public header count (goal: < 40 files)
+2. Hide internal implementation details
+3. Promote facade-based API usage
+4. Improve compilation times
 
-| Old Path | New Path |
-|----------|----------|
-| `core/messaging_quic_client.h` | `experimental/quic_client.h` |
-| `core/messaging_quic_server.h` | `experimental/quic_server.h` |
-| `core/reliable_udp_client.h` | `experimental/reliable_udp_client.h` |
+## See Also
 
-The old paths still work but will emit deprecation warnings and automatically
-enable the experimental flag for backward compatibility.
-
-## Namespace
-
-All types are in `kcenon::network::experimental` namespace:
-
-```cpp
-namespace kcenon::network::experimental {
-    class messaging_quic_client;
-    class messaging_quic_server;
-    class reliable_udp_client;
-    // ... etc
-}
-```
-
-## Feedback
-
-We welcome feedback on experimental APIs! Please open an issue on GitHub
-with your use case, suggestions, or bug reports.
-
-## Promotion Path
-
-Experimental APIs may be promoted to stable status when:
-1. The API has stabilized and no breaking changes are expected
-2. Sufficient testing and real-world usage has occurred
-3. Documentation is complete
-4. Performance characteristics are well understood
+- `kcenon/network/facade/quic_facade.h` - Recommended facade API
+- `kcenon/network/interfaces/i_quic_client.h` - Public interface
+- `kcenon/network/interfaces/i_quic_server.h` - Public interface

--- a/include/kcenon/network/session/quic_session.h
+++ b/include/kcenon/network/session/quic_session.h
@@ -46,7 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef NETWORK_USE_EXPERIMENTAL
 #define NETWORK_USE_EXPERIMENTAL
 #endif
-#include "kcenon/network/experimental/quic_client.h"
+#include "internal/experimental/quic_client.h"
 #include "kcenon/network/interfaces/i_quic_server.h"
 #include "kcenon/network/protocols/quic/connection_id.h"
 #include "kcenon/network/utils/result_types.h"

--- a/libs/network-udp/experimental/include/network_udp/reliable_udp_client.h
+++ b/libs/network-udp/experimental/include/network_udp/reliable_udp_client.h
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 // Experimental API marker - users must opt-in to use this header
-#include "kcenon/network/experimental/experimental_api.h"
+#include "internal/experimental/experimental_api.h"
 NETWORK_REQUIRE_EXPERIMENTAL
 
 #include <cstdint>

--- a/samples/quic_client_example.cpp
+++ b/samples/quic_client_example.cpp
@@ -27,7 +27,7 @@
 
 #define NETWORK_USE_EXPERIMENTAL
 #include <kcenon/network/facade/quic_facade.h>
-#include <kcenon/network/experimental/quic_client.h>
+#include "internal/experimental/quic_client.h"
 
 using namespace kcenon::network;
 

--- a/samples/quic_server_example.cpp
+++ b/samples/quic_server_example.cpp
@@ -23,7 +23,7 @@
 #endif
 
 #include <kcenon/network/facade/quic_facade.h>
-#include <kcenon/network/experimental/quic_server.h>
+#include "internal/experimental/quic_server.h"
 #include <kcenon/network/session/quic_session.h>
 
 #include <iostream>

--- a/src/experimental/quic_client.cpp
+++ b/src/experimental/quic_client.cpp
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
 #define NETWORK_USE_EXPERIMENTAL
-#include "kcenon/network/experimental/quic_client.h"
+#include "internal/experimental/quic_client.h"
 #include "internal/integration/logger_integration.h"
 #include "kcenon/network/tracing/span.h"
 #include "kcenon/network/tracing/trace_context.h"

--- a/src/experimental/quic_server.cpp
+++ b/src/experimental/quic_server.cpp
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <kcenon/network/config/feature_flags.h>
 
 #define NETWORK_USE_EXPERIMENTAL
-#include "kcenon/network/experimental/quic_server.h"
+#include "internal/experimental/quic_server.h"
 
 #include "internal/integration/logger_integration.h"
 #include "kcenon/network/metrics/network_metrics.h"

--- a/src/experimental/reliable_udp_client.cpp
+++ b/src/experimental/reliable_udp_client.cpp
@@ -31,7 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
 #define NETWORK_USE_EXPERIMENTAL
-#include "kcenon/network/experimental/reliable_udp_client.h"
+#include "internal/experimental/reliable_udp_client.h"
 #include "internal/core/messaging_udp_client.h"
 #include "internal/core/network_context.h"
 #include "internal/integration/logger_integration.h"

--- a/src/facade/quic_facade.cpp
+++ b/src/facade/quic_facade.cpp
@@ -42,8 +42,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define NETWORK_USE_EXPERIMENTAL
 #endif
 
-#include "kcenon/network/experimental/quic_client.h"
-#include "kcenon/network/experimental/quic_server.h"
+#include "internal/experimental/quic_client.h"
+#include "internal/experimental/quic_server.h"
 
 namespace kcenon::network::facade
 {

--- a/src/internal/experimental/experimental_api.h
+++ b/src/internal/experimental/experimental_api.h
@@ -48,7 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * To use experimental APIs, define NETWORK_USE_EXPERIMENTAL:
  * \code
  * #define NETWORK_USE_EXPERIMENTAL
- * #include <kcenon/network/experimental/quic_client.h>
+ * #include "internal/experimental/quic_client.h"
  * \endcode
  *
  * Without the define, a clear compiler error will guide users.

--- a/src/internal/experimental/quic_client.h
+++ b/src/internal/experimental/quic_client.h
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 // Experimental API marker - users must opt-in to use this header
-#include "kcenon/network/experimental/experimental_api.h"
+#include "internal/experimental/experimental_api.h"
 NETWORK_REQUIRE_EXPERIMENTAL
 
 #include <atomic>

--- a/src/internal/experimental/quic_server.h
+++ b/src/internal/experimental/quic_server.h
@@ -33,13 +33,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 // Experimental API marker - users must opt-in to use this header
-#include "kcenon/network/experimental/experimental_api.h"
+#include "internal/experimental/experimental_api.h"
 NETWORK_REQUIRE_EXPERIMENTAL
 
 #include <kcenon/network/config/feature_flags.h>
 
 #include "internal/core/callback_indices.h"
-#include "kcenon/network/experimental/quic_client.h"
+#include "internal/experimental/quic_client.h"
 #include "internal/core/network_context.h"
 #include "kcenon/network/interfaces/i_quic_server.h"
 #include "kcenon/network/integration/thread_integration.h"

--- a/src/internal/experimental/reliable_udp_client.h
+++ b/src/internal/experimental/reliable_udp_client.h
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 // Experimental API marker - users must opt-in to use this header
-#include "kcenon/network/experimental/experimental_api.h"
+#include "internal/experimental/experimental_api.h"
 NETWORK_REQUIRE_EXPERIMENTAL
 
 #include <cstdint>

--- a/tests/integration/test_quic_e2e.cpp
+++ b/tests/integration/test_quic_e2e.cpp
@@ -57,8 +57,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <gtest/gtest.h>
 
 #define NETWORK_USE_EXPERIMENTAL
-#include "kcenon/network/experimental/quic_client.h"
-#include "kcenon/network/experimental/quic_server.h"
+#include "internal/experimental/quic_client.h"
+#include "internal/experimental/quic_server.h"
 #include "kcenon/network/session/quic_session.h"
 
 using namespace kcenon::network::core;

--- a/tests/test_messaging_quic_client.cpp
+++ b/tests/test_messaging_quic_client.cpp
@@ -37,7 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <future>
 
 #define NETWORK_USE_EXPERIMENTAL
-#include "kcenon/network/experimental/quic_client.h"
+#include "internal/experimental/quic_client.h"
 #include "kcenon/network/utils/result_types.h"
 
 namespace kcenon::network::core::test

--- a/tests/test_messaging_quic_server.cpp
+++ b/tests/test_messaging_quic_server.cpp
@@ -37,7 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <future>
 
 #define NETWORK_USE_EXPERIMENTAL
-#include "kcenon/network/experimental/quic_server.h"
+#include "internal/experimental/quic_server.h"
 #include "kcenon/network/utils/result_types.h"
 #include "kcenon/network/session/quic_session.h"
 #include "kcenon/network/utils/result_types.h"


### PR DESCRIPTION
Closes #652

## Summary

Move all experimental headers from `include/kcenon/network/experimental/` to `src/internal/experimental/` as part of the header simplification effort (EPIC #577).

### Changes

- Move 4 experimental headers to internal:
  - `quic_client.h`
  - `quic_server.h`
  - `reliable_udp_client.h`
  - `experimental_api.h`
- Update 14 dependent files to use new `internal/experimental/` paths
- Update documentation with migration guide

### Impact

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Public header count | 76 | 72 | -4 |

### Related

Part of EPIC #577: Apply Facade pattern to reduce protocol header complexity

## Test Plan

- [x] Build succeeds (Release configuration)
- [x] All 1468/1470 tests pass (2 flaky tests fail in parallel but pass individually)
- [x] QUIC samples compile and link correctly
- [x] No regression in functionality

## Migration Guide

Users should update their includes:

```diff
- #include <kcenon/network/experimental/quic_client.h>
+ #include "internal/experimental/quic_client.h"
```

Or preferably, use the facade API:

```cpp
#include <kcenon/network/facade/quic_facade.h>

quic_facade facade;
auto client = facade.create_client({...});
```