### PR TITLE
refactor(facade): update udp_facade to return common protocol interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,6 +495,8 @@ add_library(NetworkSystem
 
     # Protocol adapters - bridge legacy implementations to unified interfaces
     src/adapters/tcp_server_adapter.cpp
+    src/adapters/udp_client_adapter.cpp
+    src/adapters/udp_server_adapter.cpp
 
     # Basic integration layer - container_integration and messaging_bridge
     # (Other integration sources are in network-integration-objects to avoid ODR violations)

--- a/include/kcenon/network/facade/udp_facade.h
+++ b/include/kcenon/network/facade/udp_facade.h
@@ -36,8 +36,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 #include <string>
 
-#include "kcenon/network/interfaces/i_udp_client.h"
-#include "kcenon/network/interfaces/i_udp_server.h"
+#include "kcenon/network/interfaces/i_protocol_client.h"
+#include "kcenon/network/interfaces/i_protocol_server.h"
 
 namespace kcenon::network::facade
 {
@@ -53,7 +53,7 @@ namespace kcenon::network::facade
  * ### Design Goals
  * - **Simplicity**: No template parameters or protocol tags
  * - **Consistency**: Same API pattern across all protocol facades
- * - **Type Safety**: Returns standard i_udp_client/i_udp_server interfaces
+ * - **Type Safety**: Returns standard IProtocolClient/IProtocolServer interfaces
  * - **Zero Cost**: No performance overhead compared to direct instantiation
  *
  * ### Thread Safety
@@ -78,8 +78,8 @@ namespace kcenon::network::facade
  * });
  * \endcode
  *
- * \see interfaces::i_udp_client
- * \see interfaces::i_udp_server
+ * \see interfaces::i_protocol_client
+ * \see interfaces::i_protocol_server
  */
 class udp_facade
 {
@@ -116,11 +116,11 @@ public:
 	/*!
 	 * \brief Creates a UDP client with the specified configuration.
 	 * \param config Client configuration.
-	 * \return Shared pointer to i_udp_client interface.
+	 * \return Shared pointer to IProtocolClient interface.
 	 * \throws std::invalid_argument if configuration is invalid.
 	 *
 	 * ### Behavior
-	 * - Creates a messaging_udp_client instance
+	 * - Creates a UDP client adapter wrapping messaging_udp_client
 	 * - Client ID is auto-generated if not provided
 	 * - Automatically connects to the specified target endpoint
 	 *
@@ -129,16 +129,16 @@ public:
 	 * - Throws if port is 0 or > 65535
 	 */
 	[[nodiscard]] auto create_client(const client_config& config) const
-		-> std::shared_ptr<interfaces::i_udp_client>;
+		-> std::shared_ptr<interfaces::i_protocol_client>;
 
 	/*!
 	 * \brief Creates a UDP server with the specified configuration.
 	 * \param config Server configuration.
-	 * \return Shared pointer to i_udp_server interface.
+	 * \return Shared pointer to IProtocolServer interface.
 	 * \throws std::invalid_argument if configuration is invalid.
 	 *
 	 * ### Behavior
-	 * - Creates a messaging_udp_server instance
+	 * - Creates a UDP server adapter wrapping messaging_udp_server
 	 * - Server ID is auto-generated if not provided
 	 * - Automatically starts listening on the specified port
 	 *
@@ -146,7 +146,7 @@ public:
 	 * - Throws if port is 0 or > 65535
 	 */
 	[[nodiscard]] auto create_server(const server_config& config) const
-		-> std::shared_ptr<interfaces::i_udp_server>;
+		-> std::shared_ptr<interfaces::i_protocol_server>;
 
 private:
 	//! \brief Generates a unique client ID

--- a/src/adapters/udp_client_adapter.cpp
+++ b/src/adapters/udp_client_adapter.cpp
@@ -1,0 +1,267 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include "internal/adapters/udp_client_adapter.h"
+
+#include "internal/core/messaging_udp_client.h"
+
+namespace kcenon::network::internal::adapters {
+
+udp_client_adapter::udp_client_adapter(std::string_view client_id)
+	: client_id_(client_id)
+	, client_(std::make_shared<core::messaging_udp_client>(std::string(client_id)))
+{
+	setup_internal_callbacks();
+}
+
+udp_client_adapter::~udp_client_adapter()
+{
+	if (client_ && client_->is_running())
+	{
+		(void)client_->stop();
+	}
+}
+
+// =========================================================================
+// i_network_component interface implementation
+// =========================================================================
+
+auto udp_client_adapter::is_running() const -> bool
+{
+	return client_ && client_->is_running();
+}
+
+auto udp_client_adapter::wait_for_stop() -> void
+{
+	if (client_)
+	{
+		client_->wait_for_stop();
+	}
+}
+
+// =========================================================================
+// i_protocol_client interface implementation
+// =========================================================================
+
+auto udp_client_adapter::start(std::string_view host, uint16_t port) -> VoidResult
+{
+	if (!client_)
+	{
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"Client not initialized",
+			"udp_client_adapter::start"
+		);
+	}
+
+	auto result = client_->start(host, port);
+	if (result.is_ok())
+	{
+		is_connected_.store(true, std::memory_order_release);
+
+		// Invoke connected callback/observer since we've "connected" to the target
+		std::shared_ptr<interfaces::connection_observer> observer_copy;
+		connected_callback_t callback_copy;
+		{
+			std::lock_guard<std::mutex> lock(callbacks_mutex_);
+			observer_copy = observer_;
+			callback_copy = connected_callback_;
+		}
+
+		if (observer_copy)
+		{
+			observer_copy->on_connected();
+		}
+		if (callback_copy)
+		{
+			callback_copy();
+		}
+	}
+
+	return result;
+}
+
+auto udp_client_adapter::stop() -> VoidResult
+{
+	if (!client_)
+	{
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"Client not initialized",
+			"udp_client_adapter::stop"
+		);
+	}
+
+	bool was_connected = is_connected_.exchange(false, std::memory_order_acq_rel);
+	auto result = client_->stop();
+
+	// Invoke disconnected callback/observer if we were connected
+	if (was_connected)
+	{
+		std::shared_ptr<interfaces::connection_observer> observer_copy;
+		disconnected_callback_t callback_copy;
+		{
+			std::lock_guard<std::mutex> lock(callbacks_mutex_);
+			observer_copy = observer_;
+			callback_copy = disconnected_callback_;
+		}
+
+		if (observer_copy)
+		{
+			observer_copy->on_disconnected();
+		}
+		if (callback_copy)
+		{
+			callback_copy();
+		}
+	}
+
+	return result;
+}
+
+auto udp_client_adapter::send(std::vector<uint8_t>&& data) -> VoidResult
+{
+	if (!client_)
+	{
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"Client not initialized",
+			"udp_client_adapter::send"
+		);
+	}
+
+	if (!is_connected_.load(std::memory_order_acquire))
+	{
+		return error_void(
+			error_codes::common_errors::invalid_argument,
+			"Client is not connected - call start() first",
+			"udp_client_adapter::send"
+		);
+	}
+
+	return client_->send(std::move(data));
+}
+
+auto udp_client_adapter::is_connected() const -> bool
+{
+	return is_connected_.load(std::memory_order_acquire);
+}
+
+auto udp_client_adapter::set_observer(std::shared_ptr<interfaces::connection_observer> observer) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	observer_ = std::move(observer);
+}
+
+auto udp_client_adapter::set_receive_callback(receive_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	receive_callback_ = std::move(callback);
+}
+
+auto udp_client_adapter::set_connected_callback(connected_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	connected_callback_ = std::move(callback);
+}
+
+auto udp_client_adapter::set_disconnected_callback(disconnected_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	disconnected_callback_ = std::move(callback);
+}
+
+auto udp_client_adapter::set_error_callback(error_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	error_callback_ = std::move(callback);
+}
+
+// =========================================================================
+// Internal methods
+// =========================================================================
+
+auto udp_client_adapter::setup_internal_callbacks() -> void
+{
+	if (!client_)
+	{
+		return;
+	}
+
+	// Bridge UDP receive callback to i_protocol_client callback
+	// Note: UDP receive includes endpoint info which we discard for the unified interface
+	client_->set_receive_callback(
+		[this](const std::vector<uint8_t>& data,
+		       const interfaces::i_udp_client::endpoint_info& /* endpoint */)
+		{
+			std::shared_ptr<interfaces::connection_observer> observer_copy;
+			receive_callback_t callback_copy;
+			{
+				std::lock_guard<std::mutex> lock(callbacks_mutex_);
+				observer_copy = observer_;
+				callback_copy = receive_callback_;
+			}
+
+			if (observer_copy)
+			{
+				observer_copy->on_receive(data);
+			}
+			if (callback_copy)
+			{
+				callback_copy(data);
+			}
+		});
+
+	// Bridge UDP error callback
+	client_->set_error_callback(
+		[this](std::error_code ec)
+		{
+			std::shared_ptr<interfaces::connection_observer> observer_copy;
+			error_callback_t callback_copy;
+			{
+				std::lock_guard<std::mutex> lock(callbacks_mutex_);
+				observer_copy = observer_;
+				callback_copy = error_callback_;
+			}
+
+			if (observer_copy)
+			{
+				observer_copy->on_error(ec);
+			}
+			if (callback_copy)
+			{
+				callback_copy(ec);
+			}
+		});
+}
+
+} // namespace kcenon::network::internal::adapters

--- a/src/adapters/udp_server_adapter.cpp
+++ b/src/adapters/udp_server_adapter.cpp
@@ -1,0 +1,289 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include "internal/adapters/udp_server_adapter.h"
+
+#include "internal/core/messaging_udp_server.h"
+
+#include <sstream>
+
+namespace kcenon::network::internal::adapters {
+
+// =========================================================================
+// udp_endpoint_session implementation
+// =========================================================================
+
+udp_endpoint_session::udp_endpoint_session(
+	std::string_view session_id,
+	std::string_view address,
+	uint16_t port,
+	std::weak_ptr<core::messaging_udp_server> server)
+	: session_id_(session_id)
+	, address_(address)
+	, port_(port)
+	, server_(std::move(server))
+{
+}
+
+auto udp_endpoint_session::id() const -> std::string_view
+{
+	return session_id_;
+}
+
+auto udp_endpoint_session::is_connected() const -> bool
+{
+	// UDP is connectionless, so we consider the session "connected"
+	// as long as the server is still running
+	auto server = server_.lock();
+	return server && server->is_running();
+}
+
+auto udp_endpoint_session::send(std::vector<uint8_t>&& data) -> VoidResult
+{
+	auto server = server_.lock();
+	if (!server)
+	{
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"Server no longer available",
+			"udp_endpoint_session::send"
+		);
+	}
+
+	interfaces::i_udp_server::endpoint_info endpoint{address_, port_};
+	return server->send_to(endpoint, std::move(data));
+}
+
+auto udp_endpoint_session::close() -> void
+{
+	// UDP is connectionless, so close is a no-op
+	// The session will be removed from tracking when server stops
+}
+
+// =========================================================================
+// udp_server_adapter implementation
+// =========================================================================
+
+udp_server_adapter::udp_server_adapter(std::string_view server_id)
+	: server_id_(server_id)
+	, server_(std::make_shared<core::messaging_udp_server>(std::string(server_id)))
+{
+	setup_internal_callbacks();
+}
+
+udp_server_adapter::~udp_server_adapter()
+{
+	if (server_ && server_->is_running())
+	{
+		(void)server_->stop();
+	}
+}
+
+// =========================================================================
+// i_network_component interface implementation
+// =========================================================================
+
+auto udp_server_adapter::is_running() const -> bool
+{
+	return server_ && server_->is_running();
+}
+
+auto udp_server_adapter::wait_for_stop() -> void
+{
+	if (server_)
+	{
+		server_->wait_for_stop();
+	}
+}
+
+// =========================================================================
+// i_protocol_server interface implementation
+// =========================================================================
+
+auto udp_server_adapter::start(uint16_t port) -> VoidResult
+{
+	if (!server_)
+	{
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"Server not initialized",
+			"udp_server_adapter::start"
+		);
+	}
+	return server_->start(port);
+}
+
+auto udp_server_adapter::stop() -> VoidResult
+{
+	if (!server_)
+	{
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"Server not initialized",
+			"udp_server_adapter::stop"
+		);
+	}
+
+	auto result = server_->stop();
+
+	// Clear tracked sessions on stop
+	{
+		std::lock_guard<std::mutex> lock(sessions_mutex_);
+		sessions_.clear();
+	}
+
+	return result;
+}
+
+auto udp_server_adapter::connection_count() const -> size_t
+{
+	std::lock_guard<std::mutex> lock(sessions_mutex_);
+	return sessions_.size();
+}
+
+auto udp_server_adapter::set_connection_callback(connection_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	connection_callback_ = std::move(callback);
+}
+
+auto udp_server_adapter::set_disconnection_callback(disconnection_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	disconnection_callback_ = std::move(callback);
+}
+
+auto udp_server_adapter::set_receive_callback(receive_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	receive_callback_ = std::move(callback);
+}
+
+auto udp_server_adapter::set_error_callback(error_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	error_callback_ = std::move(callback);
+}
+
+// =========================================================================
+// Internal methods
+// =========================================================================
+
+auto udp_server_adapter::setup_internal_callbacks() -> void
+{
+	if (!server_)
+	{
+		return;
+	}
+
+	// Bridge UDP receive callback to i_protocol_server callback
+	// Create virtual sessions for each unique endpoint
+	server_->set_receive_callback(
+		[this](const std::vector<uint8_t>& data,
+		       const interfaces::i_udp_server::endpoint_info& endpoint)
+		{
+			// Get or create session for this endpoint
+			auto session = get_or_create_session(endpoint.address, endpoint.port);
+			std::string session_id(session->id());
+
+			// Invoke the receive callback
+			receive_callback_t callback_copy;
+			{
+				std::lock_guard<std::mutex> lock(callbacks_mutex_);
+				callback_copy = receive_callback_;
+			}
+			if (callback_copy)
+			{
+				callback_copy(session_id, data);
+			}
+		});
+
+	// Bridge UDP error callback
+	server_->set_error_callback(
+		[this](std::error_code ec)
+		{
+			// Server-level error, use empty session_id
+			error_callback_t callback_copy;
+			{
+				std::lock_guard<std::mutex> lock(callbacks_mutex_);
+				callback_copy = error_callback_;
+			}
+			if (callback_copy)
+			{
+				callback_copy("", ec);
+			}
+		});
+}
+
+auto udp_server_adapter::make_session_id(const std::string& address, uint16_t port) -> std::string
+{
+	std::ostringstream oss;
+	oss << address << ":" << port;
+	return oss.str();
+}
+
+auto udp_server_adapter::get_or_create_session(const std::string& address, uint16_t port)
+	-> std::shared_ptr<interfaces::i_session>
+{
+	std::string session_id = make_session_id(address, port);
+
+	{
+		std::lock_guard<std::mutex> lock(sessions_mutex_);
+
+		auto it = sessions_.find(session_id);
+		if (it != sessions_.end())
+		{
+			return it->second;
+		}
+
+		// Create new session
+		auto session = std::make_shared<udp_endpoint_session>(
+			session_id, address, port, server_);
+		sessions_[session_id] = session;
+
+		// Invoke connection callback for new session (outside of lock)
+		connection_callback_t callback_copy;
+		{
+			std::lock_guard<std::mutex> cb_lock(callbacks_mutex_);
+			callback_copy = connection_callback_;
+		}
+
+		if (callback_copy)
+		{
+			callback_copy(session);
+		}
+
+		return session;
+	}
+}
+
+} // namespace kcenon::network::internal::adapters

--- a/src/facade/udp_facade.cpp
+++ b/src/facade/udp_facade.cpp
@@ -37,8 +37,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sstream>
 #include <stdexcept>
 
-#include "internal/core/messaging_udp_client.h"
-#include "internal/core/messaging_udp_server.h"
+#include "internal/adapters/udp_client_adapter.h"
+#include "internal/adapters/udp_server_adapter.h"
 
 namespace kcenon::network::facade
 {
@@ -90,7 +90,7 @@ auto udp_facade::validate_server_config(const server_config& config) -> void
 }
 
 auto udp_facade::create_client(const client_config& config) const
-	-> std::shared_ptr<interfaces::i_udp_client>
+	-> std::shared_ptr<interfaces::i_protocol_client>
 {
 	// Validate configuration
 	validate_client_config(config);
@@ -98,8 +98,8 @@ auto udp_facade::create_client(const client_config& config) const
 	// Generate client ID if not provided
 	const std::string client_id = config.client_id.empty() ? generate_client_id() : config.client_id;
 
-	// Create UDP client
-	auto client = std::make_shared<core::messaging_udp_client>(client_id);
+	// Create UDP client adapter that wraps messaging_udp_client
+	auto client = std::make_shared<internal::adapters::udp_client_adapter>(client_id);
 
 	// Start the client and connect to target
 	auto result = client->start(config.host, config.port);
@@ -112,7 +112,7 @@ auto udp_facade::create_client(const client_config& config) const
 }
 
 auto udp_facade::create_server(const server_config& config) const
-	-> std::shared_ptr<interfaces::i_udp_server>
+	-> std::shared_ptr<interfaces::i_protocol_server>
 {
 	// Validate configuration
 	validate_server_config(config);
@@ -120,8 +120,8 @@ auto udp_facade::create_server(const server_config& config) const
 	// Generate server ID if not provided
 	const std::string server_id = config.server_id.empty() ? generate_server_id() : config.server_id;
 
-	// Create UDP server
-	auto server = std::make_shared<core::messaging_udp_server>(server_id);
+	// Create UDP server adapter that wraps messaging_udp_server
+	auto server = std::make_shared<internal::adapters::udp_server_adapter>(server_id);
 
 	// Start the server
 	auto result = server->start(config.port);

--- a/src/internal/adapters/udp_client_adapter.h
+++ b/src/internal/adapters/udp_client_adapter.h
@@ -1,0 +1,141 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include "kcenon/network/interfaces/i_protocol_client.h"
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace kcenon::network::core {
+	class messaging_udp_client;
+}
+
+namespace kcenon::network::internal::adapters {
+
+/**
+ * @class udp_client_adapter
+ * @brief Adapter that wraps messaging_udp_client to implement i_protocol_client
+ *
+ * This adapter bridges the UDP client implementation with the unified
+ * i_protocol_client interface. It allows udp_facade to return i_protocol_client
+ * without modifying the existing messaging_udp_client class.
+ *
+ * ### Design Rationale
+ * The adapter pattern is used because:
+ * 1. UDP's i_udp_client has different method signatures than i_protocol_client
+ * 2. UDP is connectionless but i_protocol_client assumes connection semantics
+ * 3. UDP receive callbacks include endpoint info, which i_protocol_client lacks
+ *
+ * ### Connection Semantics
+ * Since UDP is connectionless:
+ * - is_connected() returns true when target endpoint is set
+ * - connect/disconnect callbacks are invoked on start/stop
+ * - The "connection" represents the ability to send to the target
+ *
+ * ### Thread Safety
+ * Thread-safe. All methods can be called from any thread.
+ *
+ * @see i_protocol_client
+ * @see messaging_udp_client
+ */
+class udp_client_adapter : public interfaces::i_protocol_client {
+public:
+	/**
+	 * @brief Constructs an adapter with a unique client ID
+	 * @param client_id Unique identifier for this client
+	 */
+	explicit udp_client_adapter(std::string_view client_id);
+
+	/**
+	 * @brief Destructor ensures proper cleanup
+	 */
+	~udp_client_adapter() override;
+
+	// Non-copyable, non-movable
+	udp_client_adapter(const udp_client_adapter&) = delete;
+	udp_client_adapter& operator=(const udp_client_adapter&) = delete;
+	udp_client_adapter(udp_client_adapter&&) = delete;
+	udp_client_adapter& operator=(udp_client_adapter&&) = delete;
+
+	// =========================================================================
+	// i_network_component interface implementation
+	// =========================================================================
+
+	[[nodiscard]] auto is_running() const -> bool override;
+	auto wait_for_stop() -> void override;
+
+	// =========================================================================
+	// i_protocol_client interface implementation
+	// =========================================================================
+
+	[[nodiscard]] auto start(std::string_view host, uint16_t port) -> VoidResult override;
+	[[nodiscard]] auto stop() -> VoidResult override;
+	[[nodiscard]] auto send(std::vector<uint8_t>&& data) -> VoidResult override;
+	[[nodiscard]] auto is_connected() const -> bool override;
+
+	auto set_observer(std::shared_ptr<interfaces::connection_observer> observer) -> void override;
+
+	[[deprecated("Use set_observer() with connection_observer instead")]]
+	auto set_receive_callback(receive_callback_t callback) -> void override;
+
+	[[deprecated("Use set_observer() with connection_observer instead")]]
+	auto set_connected_callback(connected_callback_t callback) -> void override;
+
+	[[deprecated("Use set_observer() with connection_observer instead")]]
+	auto set_disconnected_callback(disconnected_callback_t callback) -> void override;
+
+	[[deprecated("Use set_observer() with connection_observer instead")]]
+	auto set_error_callback(error_callback_t callback) -> void override;
+
+private:
+	/**
+	 * @brief Sets up internal callbacks to bridge UDP callbacks to i_protocol_client callbacks
+	 */
+	auto setup_internal_callbacks() -> void;
+
+	std::string client_id_;
+	std::shared_ptr<core::messaging_udp_client> client_;
+	std::atomic<bool> is_connected_{false};
+
+	mutable std::mutex callbacks_mutex_;
+	std::shared_ptr<interfaces::connection_observer> observer_;
+	receive_callback_t receive_callback_;
+	connected_callback_t connected_callback_;
+	disconnected_callback_t disconnected_callback_;
+	error_callback_t error_callback_;
+};
+
+} // namespace kcenon::network::internal::adapters

--- a/src/internal/adapters/udp_server_adapter.h
+++ b/src/internal/adapters/udp_server_adapter.h
@@ -1,0 +1,165 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include "kcenon/network/interfaces/i_protocol_server.h"
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace kcenon::network::core {
+	class messaging_udp_server;
+}
+
+namespace kcenon::network::internal::adapters {
+
+/**
+ * @class udp_endpoint_session
+ * @brief Session wrapper for UDP endpoint connections
+ *
+ * Since UDP is connectionless, this class provides a session abstraction
+ * for each unique remote endpoint that communicates with the server.
+ */
+class udp_endpoint_session : public interfaces::i_session {
+public:
+	udp_endpoint_session(
+		std::string_view session_id,
+		std::string_view address,
+		uint16_t port,
+		std::weak_ptr<core::messaging_udp_server> server);
+
+	[[nodiscard]] auto id() const -> std::string_view override;
+	[[nodiscard]] auto is_connected() const -> bool override;
+	[[nodiscard]] auto send(std::vector<uint8_t>&& data) -> VoidResult override;
+	auto close() -> void override;
+
+private:
+	std::string session_id_;
+	std::string address_;
+	uint16_t port_;
+	std::weak_ptr<core::messaging_udp_server> server_;
+};
+
+/**
+ * @class udp_server_adapter
+ * @brief Adapter that wraps messaging_udp_server to implement i_protocol_server
+ *
+ * This adapter bridges the UDP server implementation with the unified
+ * i_protocol_server interface. It tracks unique endpoints as virtual
+ * "connections" to provide session semantics for connectionless UDP.
+ *
+ * ### Connection Semantics
+ * Since UDP is connectionless:
+ * - Each unique remote endpoint is treated as a virtual "session"
+ * - Sessions are created on first datagram from a new endpoint
+ * - Sessions are removed after inactivity timeout (optional)
+ * - connection_count() returns count of known endpoints
+ *
+ * ### Thread Safety
+ * Thread-safe. All methods can be called from any thread.
+ *
+ * @see i_protocol_server
+ * @see messaging_udp_server
+ */
+class udp_server_adapter : public interfaces::i_protocol_server {
+public:
+	/**
+	 * @brief Constructs an adapter with a unique server ID
+	 * @param server_id Unique identifier for this server
+	 */
+	explicit udp_server_adapter(std::string_view server_id);
+
+	/**
+	 * @brief Destructor ensures proper cleanup
+	 */
+	~udp_server_adapter() override;
+
+	// Non-copyable, non-movable
+	udp_server_adapter(const udp_server_adapter&) = delete;
+	udp_server_adapter& operator=(const udp_server_adapter&) = delete;
+	udp_server_adapter(udp_server_adapter&&) = delete;
+	udp_server_adapter& operator=(udp_server_adapter&&) = delete;
+
+	// =========================================================================
+	// i_network_component interface implementation
+	// =========================================================================
+
+	[[nodiscard]] auto is_running() const -> bool override;
+	auto wait_for_stop() -> void override;
+
+	// =========================================================================
+	// i_protocol_server interface implementation
+	// =========================================================================
+
+	[[nodiscard]] auto start(uint16_t port) -> VoidResult override;
+	[[nodiscard]] auto stop() -> VoidResult override;
+	[[nodiscard]] auto connection_count() const -> size_t override;
+
+	auto set_connection_callback(connection_callback_t callback) -> void override;
+	auto set_disconnection_callback(disconnection_callback_t callback) -> void override;
+	auto set_receive_callback(receive_callback_t callback) -> void override;
+	auto set_error_callback(error_callback_t callback) -> void override;
+
+private:
+	/**
+	 * @brief Sets up internal callbacks to bridge UDP callbacks to i_protocol_server callbacks
+	 */
+	auto setup_internal_callbacks() -> void;
+
+	/**
+	 * @brief Creates a unique session ID from endpoint info
+	 */
+	static auto make_session_id(const std::string& address, uint16_t port) -> std::string;
+
+	/**
+	 * @brief Gets or creates a session for the given endpoint
+	 */
+	auto get_or_create_session(const std::string& address, uint16_t port)
+		-> std::shared_ptr<interfaces::i_session>;
+
+	std::string server_id_;
+	std::shared_ptr<core::messaging_udp_server> server_;
+
+	mutable std::mutex callbacks_mutex_;
+	connection_callback_t connection_callback_;
+	disconnection_callback_t disconnection_callback_;
+	receive_callback_t receive_callback_;
+	error_callback_t error_callback_;
+
+	mutable std::mutex sessions_mutex_;
+	std::unordered_map<std::string, std::shared_ptr<udp_endpoint_session>> sessions_;
+};
+
+} // namespace kcenon::network::internal::adapters


### PR DESCRIPTION
## Summary
- Add `udp_client_adapter` wrapping `messaging_udp_client` to implement `i_protocol_client`
- Add `udp_server_adapter` with `udp_endpoint_session` for session abstraction to implement `i_protocol_server`
- Update `udp_facade.h` to return `i_protocol_client`/`i_protocol_server` instead of UDP-specific interfaces
- Update tests and samples for new callback signatures

This brings UDP facade in line with the unified interface pattern used by `tcp_facade`.

## Test Plan
- [x] UDP facade tests pass (9/9)
- [x] Build succeeds with no errors
- [x] Sample code compiles and demonstrates new interface usage

Closes #655