### PR TITLE
refactor(facade): update http_facade to return common protocol interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,6 +494,8 @@ add_library(NetworkSystem
     src/facade/quic_facade.cpp
 
     # Protocol adapters - bridge legacy implementations to unified interfaces
+    src/adapters/http_client_adapter.cpp
+    src/adapters/http_server_adapter.cpp
     src/adapters/tcp_server_adapter.cpp
     src/adapters/udp_client_adapter.cpp
     src/adapters/udp_server_adapter.cpp

--- a/samples/simple_http_client.cpp
+++ b/samples/simple_http_client.cpp
@@ -5,7 +5,11 @@ Copyright (c) 2024, 🍀☀🌕🌥 🌊
 All rights reserved.
 *****************************************************************************/
 
-#include <kcenon/network/facade/http_facade.h>
+// Note: This sample uses http_client directly instead of http_facade
+// because it needs HTTP-specific features like GET, POST methods and
+// response handling. The http_facade returns i_protocol_client which
+// provides a unified interface but doesn't expose HTTP-specific methods.
+
 #include <internal/http/http_client.h>
 #include <iostream>
 #include <thread>
@@ -29,11 +33,8 @@ int main()
 {
     std::cout << "=== Simple HTTP Client Demo ===" << std::endl;
 
-    // Create HTTP client using facade
-    facade::http_facade http;
-    auto client = http.create_client({
-        .timeout = std::chrono::seconds(30)
-    });
+    // Create HTTP client directly for HTTP-specific features
+    auto client = std::make_shared<core::http_client>(std::chrono::seconds(30));
 
     // Wait a moment for server to be ready (if running locally)
     std::this_thread::sleep_for(std::chrono::milliseconds(500));

--- a/samples/simple_http_server.cpp
+++ b/samples/simple_http_server.cpp
@@ -5,7 +5,11 @@ Copyright (c) 2024, 🍀☀🌕🌥 🌊
 All rights reserved.
 *****************************************************************************/
 
-#include <kcenon/network/facade/http_facade.h>
+// Note: This sample uses http_server directly instead of http_facade
+// because it needs HTTP-specific features like routing and request handlers.
+// The http_facade returns i_protocol_server which provides a unified interface
+// but doesn't expose HTTP-specific methods.
+
 #include <internal/http/http_server.h>
 #include <iostream>
 #include <chrono>
@@ -17,11 +21,8 @@ int main()
 {
     std::cout << "=== Simple HTTP Server Demo ===" << std::endl;
 
-    // Create HTTP server using facade
-    facade::http_facade http;
-    auto server = http.create_server({
-        .server_id = "simple_http_server"
-    });
+    // Create HTTP server directly for HTTP-specific features
+    auto server = std::make_shared<core::http_server>("simple_http_server");
 
     // Register routes
     server->get("/", [](const core::http_request_context&)

--- a/src/adapters/http_client_adapter.cpp
+++ b/src/adapters/http_client_adapter.cpp
@@ -1,0 +1,300 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include "internal/adapters/http_client_adapter.h"
+
+#include "kcenon/network/utils/result_types.h"
+
+// Suppress deprecation warnings for internal usage
+#define NETWORK_SYSTEM_SUPPRESS_DEPRECATION_WARNINGS
+#include "internal/http/http_client.h"
+#undef NETWORK_SYSTEM_SUPPRESS_DEPRECATION_WARNINGS
+
+#include <sstream>
+
+using kcenon::network::ok;
+using kcenon::network::error_void;
+namespace error_codes = kcenon::network::error_codes;
+
+namespace kcenon::network::internal::adapters {
+
+http_client_adapter::http_client_adapter(
+	std::string_view client_id,
+	std::chrono::milliseconds timeout)
+	: client_id_(client_id)
+	, timeout_(timeout)
+	, client_(std::make_shared<core::http_client>(timeout))
+{
+}
+
+http_client_adapter::~http_client_adapter()
+{
+	is_running_.store(false, std::memory_order_release);
+}
+
+// =========================================================================
+// Path Configuration
+// =========================================================================
+
+auto http_client_adapter::set_path(std::string_view path) -> void
+{
+	path_ = std::string(path);
+}
+
+auto http_client_adapter::set_use_ssl(bool use_ssl) -> void
+{
+	use_ssl_ = use_ssl;
+}
+
+// =========================================================================
+// i_network_component interface implementation
+// =========================================================================
+
+auto http_client_adapter::is_running() const -> bool
+{
+	return is_running_.load(std::memory_order_acquire);
+}
+
+auto http_client_adapter::wait_for_stop() -> void
+{
+	// HTTP client is stateless, nothing to wait for
+}
+
+// =========================================================================
+// i_protocol_client interface implementation
+// =========================================================================
+
+auto http_client_adapter::start(std::string_view host, uint16_t port) -> VoidResult
+{
+	if (!client_)
+	{
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"Client not initialized",
+			"http_client_adapter::start"
+		);
+	}
+
+	// Store the connection details for building URLs
+	host_ = std::string(host);
+	port_ = port;
+	is_running_.store(true, std::memory_order_release);
+
+	// Notify connected callback (HTTP is "connected" when we have a target)
+	{
+		std::shared_ptr<interfaces::connection_observer> observer_copy;
+		connected_callback_t callback_copy;
+		{
+			std::lock_guard<std::mutex> lock(callbacks_mutex_);
+			observer_copy = observer_;
+			callback_copy = connected_callback_;
+		}
+
+		if (observer_copy)
+		{
+			observer_copy->on_connected();
+		}
+		if (callback_copy)
+		{
+			callback_copy();
+		}
+	}
+
+	return ok();
+}
+
+auto http_client_adapter::stop() -> VoidResult
+{
+	if (!is_running_.load(std::memory_order_acquire))
+	{
+		return error_void(
+			error_codes::common_errors::invalid_argument,
+			"Client is not running",
+			"http_client_adapter::stop"
+		);
+	}
+
+	is_running_.store(false, std::memory_order_release);
+
+	// Notify disconnected callback
+	{
+		std::shared_ptr<interfaces::connection_observer> observer_copy;
+		disconnected_callback_t callback_copy;
+		{
+			std::lock_guard<std::mutex> lock(callbacks_mutex_);
+			observer_copy = observer_;
+			callback_copy = disconnected_callback_;
+		}
+
+		if (observer_copy)
+		{
+			observer_copy->on_disconnected();
+		}
+		if (callback_copy)
+		{
+			callback_copy();
+		}
+	}
+
+	return ok();
+}
+
+auto http_client_adapter::send(std::vector<uint8_t>&& data) -> VoidResult
+{
+	if (!client_)
+	{
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"Client not initialized",
+			"http_client_adapter::send"
+		);
+	}
+
+	if (!is_running_.load(std::memory_order_acquire))
+	{
+		return error_void(
+			error_codes::common_errors::invalid_argument,
+			"Client is not running - call start() first",
+			"http_client_adapter::send"
+		);
+	}
+
+	// Build the full URL
+	const std::string url = build_url();
+
+	// Perform HTTP POST request with the binary data
+	auto result = client_->post(url, data);
+	if (result.is_err())
+	{
+		notify_error(std::make_error_code(std::errc::io_error));
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"HTTP POST request failed: " + result.error().message,
+			"http_client_adapter::send"
+		);
+	}
+
+	// Notify receive callback with response body
+	const auto& response = result.value();
+	notify_receive(response.body);
+
+	return ok();
+}
+
+auto http_client_adapter::is_connected() const -> bool
+{
+	return is_running_.load(std::memory_order_acquire) && !host_.empty();
+}
+
+auto http_client_adapter::set_observer(std::shared_ptr<interfaces::connection_observer> observer) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	observer_ = std::move(observer);
+}
+
+auto http_client_adapter::set_receive_callback(receive_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	receive_callback_ = std::move(callback);
+}
+
+auto http_client_adapter::set_connected_callback(connected_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	connected_callback_ = std::move(callback);
+}
+
+auto http_client_adapter::set_disconnected_callback(disconnected_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	disconnected_callback_ = std::move(callback);
+}
+
+auto http_client_adapter::set_error_callback(error_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	error_callback_ = std::move(callback);
+}
+
+// =========================================================================
+// Internal methods
+// =========================================================================
+
+auto http_client_adapter::build_url() const -> std::string
+{
+	std::ostringstream oss;
+	oss << (use_ssl_ ? "https://" : "http://")
+		<< host_ << ":" << port_ << path_;
+	return oss.str();
+}
+
+auto http_client_adapter::notify_receive(const std::vector<uint8_t>& data) -> void
+{
+	std::shared_ptr<interfaces::connection_observer> observer_copy;
+	receive_callback_t callback_copy;
+	{
+		std::lock_guard<std::mutex> lock(callbacks_mutex_);
+		observer_copy = observer_;
+		callback_copy = receive_callback_;
+	}
+
+	if (observer_copy)
+	{
+		observer_copy->on_receive(data);
+	}
+	if (callback_copy)
+	{
+		callback_copy(data);
+	}
+}
+
+auto http_client_adapter::notify_error(std::error_code ec) -> void
+{
+	std::shared_ptr<interfaces::connection_observer> observer_copy;
+	error_callback_t callback_copy;
+	{
+		std::lock_guard<std::mutex> lock(callbacks_mutex_);
+		observer_copy = observer_;
+		callback_copy = error_callback_;
+	}
+
+	if (observer_copy)
+	{
+		observer_copy->on_error(ec);
+	}
+	if (callback_copy)
+	{
+		callback_copy(ec);
+	}
+}
+
+} // namespace kcenon::network::internal::adapters

--- a/src/adapters/http_server_adapter.cpp
+++ b/src/adapters/http_server_adapter.cpp
@@ -1,0 +1,390 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include "internal/adapters/http_server_adapter.h"
+
+#include "kcenon/network/utils/result_types.h"
+
+// Suppress deprecation warnings for internal usage
+#define NETWORK_SYSTEM_SUPPRESS_DEPRECATION_WARNINGS
+#include "internal/http/http_server.h"
+#undef NETWORK_SYSTEM_SUPPRESS_DEPRECATION_WARNINGS
+
+#include <sstream>
+
+using kcenon::network::ok;
+using kcenon::network::error_void;
+namespace error_codes = kcenon::network::error_codes;
+
+namespace kcenon::network::internal::adapters {
+
+// =========================================================================
+// http_request_session implementation
+// =========================================================================
+
+http_request_session::http_request_session(
+	std::string_view session_id,
+	std::string_view client_address,
+	uint16_t client_port,
+	std::weak_ptr<core::http_server> server)
+	: session_id_(session_id)
+	, client_address_(client_address)
+	, client_port_(client_port)
+	, server_(std::move(server))
+{
+}
+
+auto http_request_session::id() const -> std::string_view
+{
+	return session_id_;
+}
+
+auto http_request_session::is_connected() const -> bool
+{
+	return is_connected_.load(std::memory_order_acquire);
+}
+
+auto http_request_session::send(std::vector<uint8_t>&& data) -> VoidResult
+{
+	if (!is_connected_.load(std::memory_order_acquire))
+	{
+		return error_void(
+			error_codes::common_errors::invalid_argument,
+			"Session is not connected",
+			"http_request_session::send"
+		);
+	}
+
+	std::lock_guard<std::mutex> lock(data_mutex_);
+	response_data_ = std::move(data);
+
+	return ok();
+}
+
+auto http_request_session::close() -> void
+{
+	is_connected_.store(false, std::memory_order_release);
+}
+
+auto http_request_session::set_response_data(std::vector<uint8_t> data) -> void
+{
+	std::lock_guard<std::mutex> lock(data_mutex_);
+	response_data_ = std::move(data);
+}
+
+auto http_request_session::get_response_data() const -> const std::vector<uint8_t>&
+{
+	std::lock_guard<std::mutex> lock(data_mutex_);
+	return response_data_;
+}
+
+// =========================================================================
+// http_server_adapter implementation
+// =========================================================================
+
+http_server_adapter::http_server_adapter(std::string_view server_id)
+	: server_id_(server_id)
+	, server_(std::make_shared<core::http_server>(std::string(server_id)))
+{
+	setup_internal_routes();
+}
+
+http_server_adapter::~http_server_adapter()
+{
+	if (server_ && is_running_.load(std::memory_order_acquire))
+	{
+		(void)server_->stop();
+	}
+}
+
+// =========================================================================
+// i_network_component interface implementation
+// =========================================================================
+
+auto http_server_adapter::is_running() const -> bool
+{
+	return is_running_.load(std::memory_order_acquire);
+}
+
+auto http_server_adapter::wait_for_stop() -> void
+{
+	if (server_)
+	{
+		server_->wait_for_stop();
+	}
+}
+
+// =========================================================================
+// i_protocol_server interface implementation
+// =========================================================================
+
+auto http_server_adapter::start(uint16_t port) -> VoidResult
+{
+	if (!server_)
+	{
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"Server not initialized",
+			"http_server_adapter::start"
+		);
+	}
+
+	auto result = server_->start(port);
+	if (result.is_ok())
+	{
+		is_running_.store(true, std::memory_order_release);
+	}
+	return result;
+}
+
+auto http_server_adapter::stop() -> VoidResult
+{
+	if (!server_)
+	{
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"Server not initialized",
+			"http_server_adapter::stop"
+		);
+	}
+
+	auto result = server_->stop();
+	is_running_.store(false, std::memory_order_release);
+
+	// Clear tracked sessions on stop
+	{
+		std::lock_guard<std::mutex> lock(sessions_mutex_);
+		sessions_.clear();
+	}
+
+	return result;
+}
+
+auto http_server_adapter::connection_count() const -> size_t
+{
+	std::lock_guard<std::mutex> lock(sessions_mutex_);
+	return sessions_.size();
+}
+
+auto http_server_adapter::set_connection_callback(connection_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	connection_callback_ = std::move(callback);
+}
+
+auto http_server_adapter::set_disconnection_callback(disconnection_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	disconnection_callback_ = std::move(callback);
+}
+
+auto http_server_adapter::set_receive_callback(receive_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	receive_callback_ = std::move(callback);
+}
+
+auto http_server_adapter::set_error_callback(error_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	error_callback_ = std::move(callback);
+}
+
+// =========================================================================
+// Internal methods
+// =========================================================================
+
+auto http_server_adapter::setup_internal_routes() -> void
+{
+	if (!server_)
+	{
+		return;
+	}
+
+	// Register a catch-all POST handler for unified protocol interface
+	// The i_protocol_client.send() performs HTTP POST, so we handle POST requests
+	server_->post("/:path", [this](const core::http_request_context& ctx) {
+		// Create a session for this request
+		const auto request_id = request_counter_.fetch_add(1, std::memory_order_relaxed);
+		const auto session_id = make_session_id("client", 0, request_id);
+		auto session = std::make_shared<http_request_session>(
+			session_id, "client", 0, server_);
+
+		// Track the session
+		{
+			std::lock_guard<std::mutex> lock(sessions_mutex_);
+			sessions_[session_id] = session;
+		}
+
+		// Notify connection callback
+		{
+			connection_callback_t callback_copy;
+			{
+				std::lock_guard<std::mutex> lock(callbacks_mutex_);
+				callback_copy = connection_callback_;
+			}
+			if (callback_copy)
+			{
+				callback_copy(session);
+			}
+		}
+
+		// Notify receive callback with request body
+		{
+			receive_callback_t callback_copy;
+			{
+				std::lock_guard<std::mutex> lock(callbacks_mutex_);
+				callback_copy = receive_callback_;
+			}
+			if (callback_copy)
+			{
+				callback_copy(session_id, ctx.request.body);
+			}
+		}
+
+		// Build response from session data
+		network::internal::http_response response;
+		response.status_code = 200;
+		response.body = session->get_response_data();
+		response.set_header("Content-Type", "application/octet-stream");
+
+		// Notify disconnection callback
+		{
+			disconnection_callback_t callback_copy;
+			{
+				std::lock_guard<std::mutex> lock(callbacks_mutex_);
+				callback_copy = disconnection_callback_;
+			}
+			if (callback_copy)
+			{
+				callback_copy(session_id);
+			}
+		}
+
+		// Remove session
+		remove_session(session_id);
+
+		return response;
+	});
+
+	// Also register root POST handler
+	server_->post("/", [this](const core::http_request_context& ctx) {
+		const auto request_id = request_counter_.fetch_add(1, std::memory_order_relaxed);
+		const auto session_id = make_session_id("client", 0, request_id);
+		auto session = std::make_shared<http_request_session>(
+			session_id, "client", 0, server_);
+
+		{
+			std::lock_guard<std::mutex> lock(sessions_mutex_);
+			sessions_[session_id] = session;
+		}
+
+		{
+			connection_callback_t callback_copy;
+			{
+				std::lock_guard<std::mutex> lock(callbacks_mutex_);
+				callback_copy = connection_callback_;
+			}
+			if (callback_copy)
+			{
+				callback_copy(session);
+			}
+		}
+
+		{
+			receive_callback_t callback_copy;
+			{
+				std::lock_guard<std::mutex> lock(callbacks_mutex_);
+				callback_copy = receive_callback_;
+			}
+			if (callback_copy)
+			{
+				callback_copy(session_id, ctx.request.body);
+			}
+		}
+
+		network::internal::http_response response;
+		response.status_code = 200;
+		response.body = session->get_response_data();
+		response.set_header("Content-Type", "application/octet-stream");
+
+		{
+			disconnection_callback_t callback_copy;
+			{
+				std::lock_guard<std::mutex> lock(callbacks_mutex_);
+				callback_copy = disconnection_callback_;
+			}
+			if (callback_copy)
+			{
+				callback_copy(session_id);
+			}
+		}
+
+		remove_session(session_id);
+
+		return response;
+	});
+}
+
+auto http_server_adapter::make_session_id(
+	const std::string& address,
+	uint16_t port,
+	uint64_t request_id) -> std::string
+{
+	std::ostringstream oss;
+	oss << address << ":" << port << "#" << request_id;
+	return oss.str();
+}
+
+auto http_server_adapter::get_or_create_session(
+	const std::string& address,
+	uint16_t port) -> std::shared_ptr<http_request_session>
+{
+	const auto request_id = request_counter_.fetch_add(1, std::memory_order_relaxed);
+	const auto session_id = make_session_id(address, port, request_id);
+
+	std::lock_guard<std::mutex> lock(sessions_mutex_);
+
+	auto session = std::make_shared<http_request_session>(
+		session_id, address, port, server_);
+	sessions_[session_id] = session;
+
+	return session;
+}
+
+auto http_server_adapter::remove_session(const std::string& session_id) -> void
+{
+	std::lock_guard<std::mutex> lock(sessions_mutex_);
+	sessions_.erase(session_id);
+}
+
+} // namespace kcenon::network::internal::adapters

--- a/src/facade/http_facade.cpp
+++ b/src/facade/http_facade.cpp
@@ -37,20 +37,28 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sstream>
 #include <stdexcept>
 
-// Suppress deprecation warnings for internal usage
-#define NETWORK_SYSTEM_SUPPRESS_DEPRECATION_WARNINGS
-#include "internal/http/http_client.h"
-#include "internal/http/http_server.h"
-#undef NETWORK_SYSTEM_SUPPRESS_DEPRECATION_WARNINGS
+#include "internal/adapters/http_client_adapter.h"
+#include "internal/adapters/http_server_adapter.h"
 
 namespace kcenon::network::facade
 {
 
 namespace
 {
+	//! \brief Atomic counter for generating unique client IDs
+	std::atomic<uint64_t> g_client_id_counter{0};
+
 	//! \brief Atomic counter for generating unique server IDs
 	std::atomic<uint64_t> g_server_id_counter{0};
 } // namespace
+
+auto http_facade::generate_client_id() -> std::string
+{
+	const auto id = g_client_id_counter.fetch_add(1, std::memory_order_relaxed);
+	std::ostringstream oss;
+	oss << "http_client_" << std::setfill('0') << std::setw(8) << id;
+	return oss.str();
+}
 
 auto http_facade::generate_server_id() -> std::string
 {
@@ -77,21 +85,32 @@ auto http_facade::validate_server_config(const server_config& config) -> void
 }
 
 auto http_facade::create_client(const client_config& config) const
-	-> std::shared_ptr<core::http_client>
+	-> std::shared_ptr<interfaces::i_protocol_client>
 {
 	validate_client_config(config);
 
-	return std::make_shared<core::http_client>(config.timeout);
+	const auto client_id = config.client_id.empty() ? generate_client_id() : config.client_id;
+
+	// Create adapter with timeout from config
+	auto adapter = std::make_shared<internal::adapters::http_client_adapter>(
+		client_id, config.timeout);
+
+	// Configure path and SSL
+	adapter->set_path(config.path);
+	adapter->set_use_ssl(config.use_ssl);
+
+	return adapter;
 }
 
 auto http_facade::create_server(const server_config& config) const
-	-> std::shared_ptr<core::http_server>
+	-> std::shared_ptr<interfaces::i_protocol_server>
 {
 	validate_server_config(config);
 
 	const auto server_id = config.server_id.empty() ? generate_server_id() : config.server_id;
 
-	return std::make_shared<core::http_server>(server_id);
+	// Create adapter
+	return std::make_shared<internal::adapters::http_server_adapter>(server_id);
 }
 
 } // namespace kcenon::network::facade

--- a/src/internal/adapters/http_client_adapter.h
+++ b/src/internal/adapters/http_client_adapter.h
@@ -1,0 +1,191 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include "kcenon/network/interfaces/i_protocol_client.h"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace kcenon::network::core {
+	class http_client;
+}
+
+namespace kcenon::network::internal::adapters {
+
+/**
+ * @class http_client_adapter
+ * @brief Adapter that wraps http_client to implement i_protocol_client
+ *
+ * This adapter bridges the HTTP client implementation with the unified
+ * i_protocol_client interface. It allows http_facade to return i_protocol_client
+ * without modifying the existing http_client class.
+ *
+ * ### Design Rationale
+ * The adapter pattern is used because:
+ * 1. HTTP uses request/response paradigm vs streaming i_protocol_client interface
+ * 2. HTTP is stateless while i_protocol_client assumes connection state
+ * 3. HTTP operations (GET, POST, etc.) don't map directly to send()
+ *
+ * ### Connection Semantics
+ * Since HTTP is stateless:
+ * - start(host, port) stores the base URL for subsequent requests
+ * - is_connected() returns true when base URL is configured
+ * - send() performs an HTTP POST request with binary data
+ * - Received response body is delivered via receive callback
+ *
+ * ### Path Handling
+ * - The path is configured via set_path() before sending
+ * - Default path is "/" if not configured
+ * - Each send() uses the configured path
+ *
+ * ### Thread Safety
+ * Thread-safe. All methods can be called from any thread.
+ *
+ * @see i_protocol_client
+ * @see http_client
+ */
+class http_client_adapter : public interfaces::i_protocol_client {
+public:
+	/**
+	 * @brief Constructs an adapter with timeout configuration
+	 * @param client_id Unique identifier for this client
+	 * @param timeout Request timeout (default: 30 seconds)
+	 */
+	explicit http_client_adapter(
+		std::string_view client_id,
+		std::chrono::milliseconds timeout = std::chrono::seconds(30));
+
+	/**
+	 * @brief Destructor ensures proper cleanup
+	 */
+	~http_client_adapter() override;
+
+	// Non-copyable, non-movable
+	http_client_adapter(const http_client_adapter&) = delete;
+	http_client_adapter& operator=(const http_client_adapter&) = delete;
+	http_client_adapter(http_client_adapter&&) = delete;
+	http_client_adapter& operator=(http_client_adapter&&) = delete;
+
+	// =========================================================================
+	// Path Configuration
+	// =========================================================================
+
+	/**
+	 * @brief Sets the HTTP path for requests
+	 * @param path The HTTP path (e.g., "/api/data", "/submit")
+	 *
+	 * Can be changed between send() calls to target different endpoints.
+	 * Default path is "/" if not set.
+	 */
+	auto set_path(std::string_view path) -> void;
+
+	/**
+	 * @brief Sets whether to use HTTPS
+	 * @param use_ssl true for HTTPS, false for HTTP
+	 *
+	 * Must be called before start() or between connections.
+	 * Default is false (HTTP).
+	 */
+	auto set_use_ssl(bool use_ssl) -> void;
+
+	// =========================================================================
+	// i_network_component interface implementation
+	// =========================================================================
+
+	[[nodiscard]] auto is_running() const -> bool override;
+	auto wait_for_stop() -> void override;
+
+	// =========================================================================
+	// i_protocol_client interface implementation
+	// =========================================================================
+
+	[[nodiscard]] auto start(std::string_view host, uint16_t port) -> VoidResult override;
+	[[nodiscard]] auto stop() -> VoidResult override;
+	[[nodiscard]] auto send(std::vector<uint8_t>&& data) -> VoidResult override;
+	[[nodiscard]] auto is_connected() const -> bool override;
+
+	auto set_observer(std::shared_ptr<interfaces::connection_observer> observer) -> void override;
+
+	[[deprecated("Use set_observer() with connection_observer instead")]]
+	auto set_receive_callback(receive_callback_t callback) -> void override;
+
+	[[deprecated("Use set_observer() with connection_observer instead")]]
+	auto set_connected_callback(connected_callback_t callback) -> void override;
+
+	[[deprecated("Use set_observer() with connection_observer instead")]]
+	auto set_disconnected_callback(disconnected_callback_t callback) -> void override;
+
+	[[deprecated("Use set_observer() with connection_observer instead")]]
+	auto set_error_callback(error_callback_t callback) -> void override;
+
+private:
+	/**
+	 * @brief Builds the full URL from stored components
+	 */
+	[[nodiscard]] auto build_url() const -> std::string;
+
+	/**
+	 * @brief Notifies observers/callbacks of received data
+	 */
+	auto notify_receive(const std::vector<uint8_t>& data) -> void;
+
+	/**
+	 * @brief Notifies observers/callbacks of errors
+	 */
+	auto notify_error(std::error_code ec) -> void;
+
+	std::string client_id_;
+	std::chrono::milliseconds timeout_;
+	std::shared_ptr<core::http_client> client_;
+
+	// URL components
+	std::string host_;
+	uint16_t port_{0};
+	std::string path_{"/"};
+	bool use_ssl_{false};
+
+	std::atomic<bool> is_running_{false};
+
+	mutable std::mutex callbacks_mutex_;
+	std::shared_ptr<interfaces::connection_observer> observer_;
+	receive_callback_t receive_callback_;
+	connected_callback_t connected_callback_;
+	disconnected_callback_t disconnected_callback_;
+	error_callback_t error_callback_;
+};
+
+} // namespace kcenon::network::internal::adapters

--- a/src/internal/adapters/http_server_adapter.h
+++ b/src/internal/adapters/http_server_adapter.h
@@ -1,0 +1,202 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include "kcenon/network/interfaces/i_protocol_server.h"
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace kcenon::network::core {
+	class http_server;
+}
+
+namespace kcenon::network::internal::adapters {
+
+/**
+ * @class http_request_session
+ * @brief Session wrapper for HTTP request connections implementing i_session
+ *
+ * Since HTTP is stateless, each request is treated as a virtual session.
+ * This class wraps request metadata to provide a stable i_session interface.
+ *
+ * Note: In HTTP, a "session" typically represents a single request/response
+ * cycle. The session ID is derived from the client's endpoint information.
+ */
+class http_request_session : public interfaces::i_session {
+public:
+	http_request_session(
+		std::string_view session_id,
+		std::string_view client_address,
+		uint16_t client_port,
+		std::weak_ptr<core::http_server> server);
+
+	[[nodiscard]] auto id() const -> std::string_view override;
+	[[nodiscard]] auto is_connected() const -> bool override;
+	[[nodiscard]] auto send(std::vector<uint8_t>&& data) -> VoidResult override;
+	auto close() -> void override;
+
+	/**
+	 * @brief Stores the response data to be sent back to client
+	 * @param data Response body data
+	 */
+	auto set_response_data(std::vector<uint8_t> data) -> void;
+
+	/**
+	 * @brief Gets the stored response data
+	 * @return Response body data
+	 */
+	[[nodiscard]] auto get_response_data() const -> const std::vector<uint8_t>&;
+
+private:
+	std::string session_id_;
+	std::string client_address_;
+	uint16_t client_port_;
+	std::weak_ptr<core::http_server> server_;
+	std::vector<uint8_t> response_data_;
+	std::atomic<bool> is_connected_{true};
+	mutable std::mutex data_mutex_;
+};
+
+/**
+ * @class http_server_adapter
+ * @brief Adapter that wraps http_server to implement i_protocol_server
+ *
+ * This adapter bridges the HTTP server implementation with the unified
+ * i_protocol_server interface. It allows http_facade to return i_protocol_server
+ * without modifying the existing http_server class.
+ *
+ * ### Design Rationale
+ * The adapter pattern is used because:
+ * 1. HTTP server uses routing (GET, POST handlers) vs callback-only i_protocol_server
+ * 2. HTTP responses must be sent within the request handler context
+ * 3. HTTP has request/response semantics, not streaming
+ *
+ * ### Request Handling
+ * The adapter registers a catch-all route that:
+ * 1. Invokes connection_callback when a request arrives
+ * 2. Invokes receive_callback with the request body
+ * 3. Waits for send() on the session to get response data
+ * 4. Returns the response to the HTTP client
+ *
+ * ### Session Management
+ * - Each HTTP request is treated as a temporary session
+ * - Session ID is derived from client endpoint + request timestamp
+ * - Sessions are removed after response is sent
+ *
+ * ### Thread Safety
+ * Thread-safe. All methods can be called from any thread.
+ *
+ * @see i_protocol_server
+ * @see http_server
+ */
+class http_server_adapter : public interfaces::i_protocol_server {
+public:
+	/**
+	 * @brief Constructs an adapter with a unique server ID
+	 * @param server_id Unique identifier for this server
+	 */
+	explicit http_server_adapter(std::string_view server_id);
+
+	/**
+	 * @brief Destructor ensures proper cleanup
+	 */
+	~http_server_adapter() override;
+
+	// Non-copyable, non-movable
+	http_server_adapter(const http_server_adapter&) = delete;
+	http_server_adapter& operator=(const http_server_adapter&) = delete;
+	http_server_adapter(http_server_adapter&&) = delete;
+	http_server_adapter& operator=(http_server_adapter&&) = delete;
+
+	// =========================================================================
+	// i_network_component interface implementation
+	// =========================================================================
+
+	[[nodiscard]] auto is_running() const -> bool override;
+	auto wait_for_stop() -> void override;
+
+	// =========================================================================
+	// i_protocol_server interface implementation
+	// =========================================================================
+
+	[[nodiscard]] auto start(uint16_t port) -> VoidResult override;
+	[[nodiscard]] auto stop() -> VoidResult override;
+	[[nodiscard]] auto connection_count() const -> size_t override;
+
+	auto set_connection_callback(connection_callback_t callback) -> void override;
+	auto set_disconnection_callback(disconnection_callback_t callback) -> void override;
+	auto set_receive_callback(receive_callback_t callback) -> void override;
+	auto set_error_callback(error_callback_t callback) -> void override;
+
+private:
+	/**
+	 * @brief Sets up internal HTTP routes to bridge to i_protocol_server callbacks
+	 */
+	auto setup_internal_routes() -> void;
+
+	/**
+	 * @brief Creates a unique session ID from request info
+	 */
+	static auto make_session_id(const std::string& address, uint16_t port, uint64_t request_id) -> std::string;
+
+	/**
+	 * @brief Gets or creates a session for the given request
+	 */
+	auto get_or_create_session(const std::string& address, uint16_t port)
+		-> std::shared_ptr<http_request_session>;
+
+	/**
+	 * @brief Removes a session after request processing
+	 */
+	auto remove_session(const std::string& session_id) -> void;
+
+	std::string server_id_;
+	std::shared_ptr<core::http_server> server_;
+
+	mutable std::mutex callbacks_mutex_;
+	connection_callback_t connection_callback_;
+	disconnection_callback_t disconnection_callback_;
+	receive_callback_t receive_callback_;
+	error_callback_t error_callback_;
+
+	mutable std::mutex sessions_mutex_;
+	std::unordered_map<std::string, std::shared_ptr<http_request_session>> sessions_;
+	std::atomic<uint64_t> request_counter_{0};
+	std::atomic<bool> is_running_{false};
+};
+
+} // namespace kcenon::network::internal::adapters


### PR DESCRIPTION
## Summary

- Create `http_client_adapter` implementing `i_protocol_client` interface
- Create `http_server_adapter` implementing `i_protocol_server` interface
- Update `http_facade` to return interface types instead of concrete types
- Update tests to use interface types
- Update samples to use `core::http_client`/`core::http_server` directly for HTTP-specific features

## Motivation

This change aligns `http_facade` with the adapter pattern used by other facades (TCP, UDP, WebSocket), providing a unified protocol-agnostic API through `i_protocol_client` and `i_protocol_server` interfaces.

## Design Decision

HTTP's request/response paradigm differs from stream-based protocols. The adapters map the unified interface to HTTP semantics:
- `start(host, port)` - Stores base URL for subsequent requests
- `send(data)` - Performs HTTP POST and returns response via callback

For HTTP-specific features (routing, GET/POST methods), users should use `core::http_client`/`core::http_server` directly.

## Test Plan

- [x] All 14 HttpFacadeTest tests pass
- [x] Build succeeds without errors
- [x] Sample files compile and work correctly

Closes #659
Part of Epic #577