### PR TITLE
refactor(facade): update quic_facade to return common protocol interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,6 +496,8 @@ add_library(NetworkSystem
     # Protocol adapters - bridge legacy implementations to unified interfaces
     src/adapters/http_client_adapter.cpp
     src/adapters/http_server_adapter.cpp
+    src/adapters/quic_client_adapter.cpp
+    src/adapters/quic_server_adapter.cpp
     src/adapters/tcp_server_adapter.cpp
     src/adapters/udp_client_adapter.cpp
     src/adapters/udp_server_adapter.cpp

--- a/include/kcenon/network/facade/quic_facade.h
+++ b/include/kcenon/network/facade/quic_facade.h
@@ -38,11 +38,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <vector>
 
-namespace kcenon::network::core
+namespace kcenon::network::interfaces
 {
-	class messaging_quic_client;
-	class messaging_quic_server;
-} // namespace kcenon::network::core
+	class i_protocol_client;
+	class i_protocol_server;
+} // namespace kcenon::network::interfaces
 
 namespace kcenon::network::facade
 {
@@ -166,41 +166,49 @@ public:
 	/*!
 	 * \brief Creates a QUIC client with the specified configuration.
 	 * \param config Client configuration.
-	 * \return Shared pointer to messaging_quic_client.
+	 * \return Shared pointer to i_protocol_client.
 	 * \throws std::invalid_argument if configuration is invalid.
 	 *
 	 * ### Behavior
-	 * - Creates a messaging_quic_client instance
+	 * - Creates a QUIC client adapter implementing i_protocol_client
 	 * - Client ID is auto-generated if not provided
 	 * - QUIC always uses TLS 1.3 encryption
-	 * - Client must be started manually using start_client() method
+	 * - Client must be started manually using start() method
 	 *
 	 * ### Error Conditions
 	 * - Throws if host is empty
 	 * - Throws if port is 0 or > 65535
+	 *
+	 * ### Note
+	 * For QUIC-specific features (multi-stream, 0-RTT, ALPN), use
+	 * messaging_quic_client directly instead of the facade.
 	 */
 	[[nodiscard]] auto create_client(const client_config& config) const
-		-> std::shared_ptr<core::messaging_quic_client>;
+		-> std::shared_ptr<interfaces::i_protocol_client>;
 
 	/*!
 	 * \brief Creates a QUIC server with the specified configuration.
 	 * \param config Server configuration.
-	 * \return Shared pointer to messaging_quic_server.
+	 * \return Shared pointer to i_protocol_server.
 	 * \throws std::invalid_argument if configuration is invalid.
 	 *
 	 * ### Behavior
-	 * - Creates a messaging_quic_server instance
+	 * - Creates a QUIC server adapter implementing i_protocol_server
 	 * - Server ID is auto-generated if not provided
 	 * - QUIC always uses TLS 1.3 encryption
-	 * - Server must be started manually using start_server() method
+	 * - Server must be started manually using start() method
 	 *
 	 * ### Error Conditions
 	 * - Throws if port is 0 or > 65535
 	 * - Throws if cert_path is empty
 	 * - Throws if key_path is empty
+	 *
+	 * ### Note
+	 * For QUIC-specific features (multi-stream, broadcast), use
+	 * messaging_quic_server directly instead of the facade.
 	 */
 	[[nodiscard]] auto create_server(const server_config& config) const
-		-> std::shared_ptr<core::messaging_quic_server>;
+		-> std::shared_ptr<interfaces::i_protocol_server>;
 
 private:
 	//! \brief Generates a unique client ID

--- a/src/adapters/quic_client_adapter.cpp
+++ b/src/adapters/quic_client_adapter.cpp
@@ -1,0 +1,307 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include "internal/adapters/quic_client_adapter.h"
+
+#include "kcenon/network/utils/result_types.h"
+
+// Enable experimental API for QUIC
+#ifndef NETWORK_USE_EXPERIMENTAL
+#define NETWORK_USE_EXPERIMENTAL
+#endif
+
+#include "internal/experimental/quic_client.h"
+
+using kcenon::network::ok;
+using kcenon::network::error_void;
+namespace error_codes = kcenon::network::error_codes;
+
+namespace kcenon::network::internal::adapters {
+
+quic_client_adapter::quic_client_adapter(std::string_view client_id)
+	: client_id_(client_id)
+	, client_(std::make_shared<core::messaging_quic_client>(client_id))
+{
+	setup_internal_callbacks();
+}
+
+quic_client_adapter::~quic_client_adapter()
+{
+	if (client_ && client_->is_running())
+	{
+		(void)client_->stop();
+	}
+}
+
+// =========================================================================
+// QUIC-specific Configuration
+// =========================================================================
+
+auto quic_client_adapter::set_alpn_protocols(const std::vector<std::string>& protocols) -> void
+{
+	alpn_protocols_ = protocols;
+	if (client_)
+	{
+		client_->set_alpn_protocols(protocols);
+	}
+}
+
+auto quic_client_adapter::set_ca_cert_path(std::string_view path) -> void
+{
+	ca_cert_path_ = std::string(path);
+}
+
+auto quic_client_adapter::set_client_cert(std::string_view cert_path, std::string_view key_path) -> void
+{
+	client_cert_path_ = std::string(cert_path);
+	client_key_path_ = std::string(key_path);
+}
+
+auto quic_client_adapter::set_verify_server(bool verify) -> void
+{
+	verify_server_ = verify;
+}
+
+auto quic_client_adapter::set_max_idle_timeout(uint64_t timeout_ms) -> void
+{
+	max_idle_timeout_ms_ = timeout_ms;
+}
+
+// =========================================================================
+// i_network_component interface implementation
+// =========================================================================
+
+auto quic_client_adapter::is_running() const -> bool
+{
+	return client_ && client_->is_running();
+}
+
+auto quic_client_adapter::wait_for_stop() -> void
+{
+	if (client_)
+	{
+		client_->wait_for_stop();
+	}
+}
+
+// =========================================================================
+// i_protocol_client interface implementation
+// =========================================================================
+
+auto quic_client_adapter::start(std::string_view host, uint16_t port) -> VoidResult
+{
+	if (!client_)
+	{
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"Client not initialized",
+			"quic_client_adapter::start"
+		);
+	}
+
+	// Build configuration
+	core::quic_client_config config;
+	config.ca_cert_file = ca_cert_path_;
+	config.client_cert_file = client_cert_path_;
+	config.client_key_file = client_key_path_;
+	config.verify_server = verify_server_;
+	config.alpn_protocols = alpn_protocols_;
+	config.max_idle_timeout_ms = max_idle_timeout_ms_;
+
+	return client_->start_client(host, port, config);
+}
+
+auto quic_client_adapter::stop() -> VoidResult
+{
+	if (!client_)
+	{
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"Client not initialized",
+			"quic_client_adapter::stop"
+		);
+	}
+
+	return client_->stop_client();
+}
+
+auto quic_client_adapter::send(std::vector<uint8_t>&& data) -> VoidResult
+{
+	if (!client_)
+	{
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"Client not initialized",
+			"quic_client_adapter::send"
+		);
+	}
+
+	if (!client_->is_connected())
+	{
+		return error_void(
+			error_codes::common_errors::invalid_argument,
+			"Client is not connected",
+			"quic_client_adapter::send"
+		);
+	}
+
+	return client_->send(std::move(data));
+}
+
+auto quic_client_adapter::is_connected() const -> bool
+{
+	return client_ && client_->is_connected();
+}
+
+auto quic_client_adapter::set_observer(std::shared_ptr<interfaces::connection_observer> observer) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	observer_ = std::move(observer);
+}
+
+auto quic_client_adapter::set_receive_callback(receive_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	receive_callback_ = std::move(callback);
+}
+
+auto quic_client_adapter::set_connected_callback(connected_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	connected_callback_ = std::move(callback);
+}
+
+auto quic_client_adapter::set_disconnected_callback(disconnected_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	disconnected_callback_ = std::move(callback);
+}
+
+auto quic_client_adapter::set_error_callback(error_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	error_callback_ = std::move(callback);
+}
+
+// =========================================================================
+// Internal methods
+// =========================================================================
+
+auto quic_client_adapter::setup_internal_callbacks() -> void
+{
+	if (!client_)
+	{
+		return;
+	}
+
+	// Bridge receive callback
+	client_->set_receive_callback([this](const std::vector<uint8_t>& data) {
+		std::shared_ptr<interfaces::connection_observer> observer_copy;
+		receive_callback_t callback_copy;
+		{
+			std::lock_guard<std::mutex> lock(callbacks_mutex_);
+			observer_copy = observer_;
+			callback_copy = receive_callback_;
+		}
+
+		if (observer_copy)
+		{
+			observer_copy->on_receive(data);
+		}
+		if (callback_copy)
+		{
+			callback_copy(data);
+		}
+	});
+
+	// Bridge connected callback
+	client_->set_connected_callback([this]() {
+		std::shared_ptr<interfaces::connection_observer> observer_copy;
+		connected_callback_t callback_copy;
+		{
+			std::lock_guard<std::mutex> lock(callbacks_mutex_);
+			observer_copy = observer_;
+			callback_copy = connected_callback_;
+		}
+
+		if (observer_copy)
+		{
+			observer_copy->on_connected();
+		}
+		if (callback_copy)
+		{
+			callback_copy();
+		}
+	});
+
+	// Bridge disconnected callback
+	client_->set_disconnected_callback([this]() {
+		std::shared_ptr<interfaces::connection_observer> observer_copy;
+		disconnected_callback_t callback_copy;
+		{
+			std::lock_guard<std::mutex> lock(callbacks_mutex_);
+			observer_copy = observer_;
+			callback_copy = disconnected_callback_;
+		}
+
+		if (observer_copy)
+		{
+			observer_copy->on_disconnected();
+		}
+		if (callback_copy)
+		{
+			callback_copy();
+		}
+	});
+
+	// Bridge error callback
+	client_->set_error_callback([this](std::error_code ec) {
+		std::shared_ptr<interfaces::connection_observer> observer_copy;
+		error_callback_t callback_copy;
+		{
+			std::lock_guard<std::mutex> lock(callbacks_mutex_);
+			observer_copy = observer_;
+			callback_copy = error_callback_;
+		}
+
+		if (observer_copy)
+		{
+			observer_copy->on_error(ec);
+		}
+		if (callback_copy)
+		{
+			callback_copy(ec);
+		}
+	});
+}
+
+} // namespace kcenon::network::internal::adapters

--- a/src/adapters/quic_server_adapter.cpp
+++ b/src/adapters/quic_server_adapter.cpp
@@ -1,0 +1,374 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include "internal/adapters/quic_server_adapter.h"
+
+#include "kcenon/network/utils/result_types.h"
+#include "kcenon/network/session/quic_session.h"
+
+// Enable experimental API for QUIC
+#ifndef NETWORK_USE_EXPERIMENTAL
+#define NETWORK_USE_EXPERIMENTAL
+#endif
+
+#include "internal/experimental/quic_server.h"
+
+using kcenon::network::ok;
+using kcenon::network::error_void;
+namespace error_codes = kcenon::network::error_codes;
+
+namespace kcenon::network::internal::adapters {
+
+// =========================================================================
+// quic_session_wrapper implementation
+// =========================================================================
+
+quic_session_wrapper::quic_session_wrapper(
+	std::string_view session_id,
+	std::shared_ptr<session::quic_session> session)
+	: session_id_(session_id)
+	, session_(std::move(session))
+{
+}
+
+auto quic_session_wrapper::id() const -> std::string_view
+{
+	return session_id_;
+}
+
+auto quic_session_wrapper::is_connected() const -> bool
+{
+	return is_connected_.load(std::memory_order_acquire) &&
+	       session_ && session_->is_active();
+}
+
+auto quic_session_wrapper::send(std::vector<uint8_t>&& data) -> VoidResult
+{
+	if (!is_connected_.load(std::memory_order_acquire))
+	{
+		return error_void(
+			error_codes::common_errors::invalid_argument,
+			"Session is not connected",
+			"quic_session_wrapper::send"
+		);
+	}
+
+	if (!session_)
+	{
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"Session not initialized",
+			"quic_session_wrapper::send"
+		);
+	}
+
+	// Send using the interface send method
+	return session_->send(std::move(data));
+}
+
+auto quic_session_wrapper::close() -> void
+{
+	is_connected_.store(false, std::memory_order_release);
+	if (session_)
+	{
+		(void)session_->close(0); // 0 = no error
+	}
+}
+
+// =========================================================================
+// quic_server_adapter implementation
+// =========================================================================
+
+quic_server_adapter::quic_server_adapter(std::string_view server_id)
+	: server_id_(server_id)
+	, server_(std::make_shared<core::messaging_quic_server>(server_id))
+{
+	setup_internal_callbacks();
+}
+
+quic_server_adapter::~quic_server_adapter()
+{
+	if (server_ && is_running_.load(std::memory_order_acquire))
+	{
+		(void)server_->stop();
+	}
+}
+
+// =========================================================================
+// QUIC-specific Configuration
+// =========================================================================
+
+auto quic_server_adapter::set_cert_path(std::string_view path) -> void
+{
+	cert_path_ = std::string(path);
+}
+
+auto quic_server_adapter::set_key_path(std::string_view path) -> void
+{
+	key_path_ = std::string(path);
+}
+
+auto quic_server_adapter::set_alpn_protocols(const std::vector<std::string>& protocols) -> void
+{
+	alpn_protocols_ = protocols;
+}
+
+auto quic_server_adapter::set_ca_cert_path(std::string_view path) -> void
+{
+	ca_cert_path_ = std::string(path);
+}
+
+auto quic_server_adapter::set_require_client_cert(bool require) -> void
+{
+	require_client_cert_ = require;
+}
+
+auto quic_server_adapter::set_max_idle_timeout(uint64_t timeout_ms) -> void
+{
+	max_idle_timeout_ms_ = timeout_ms;
+}
+
+auto quic_server_adapter::set_max_connections(size_t max) -> void
+{
+	max_connections_ = max;
+}
+
+// =========================================================================
+// i_network_component interface implementation
+// =========================================================================
+
+auto quic_server_adapter::is_running() const -> bool
+{
+	return is_running_.load(std::memory_order_acquire);
+}
+
+auto quic_server_adapter::wait_for_stop() -> void
+{
+	if (server_)
+	{
+		server_->wait_for_stop();
+	}
+}
+
+// =========================================================================
+// i_protocol_server interface implementation
+// =========================================================================
+
+auto quic_server_adapter::start(uint16_t port) -> VoidResult
+{
+	if (!server_)
+	{
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"Server not initialized",
+			"quic_server_adapter::start"
+		);
+	}
+
+	// Build configuration
+	core::quic_server_config config;
+	config.cert_file = cert_path_;
+	config.key_file = key_path_;
+	config.ca_cert_file = ca_cert_path_;
+	config.require_client_cert = require_client_cert_;
+	config.alpn_protocols = alpn_protocols_;
+	config.max_idle_timeout_ms = max_idle_timeout_ms_;
+	config.max_connections = max_connections_;
+
+	auto result = server_->start_server(port, config);
+	if (result.is_ok())
+	{
+		is_running_.store(true, std::memory_order_release);
+	}
+	return result;
+}
+
+auto quic_server_adapter::stop() -> VoidResult
+{
+	if (!server_)
+	{
+		return error_void(
+			error_codes::common_errors::internal_error,
+			"Server not initialized",
+			"quic_server_adapter::stop"
+		);
+	}
+
+	auto result = server_->stop_server();
+	is_running_.store(false, std::memory_order_release);
+
+	// Clear tracked sessions on stop
+	{
+		std::lock_guard<std::mutex> lock(sessions_mutex_);
+		sessions_.clear();
+	}
+
+	return result;
+}
+
+auto quic_server_adapter::connection_count() const -> size_t
+{
+	std::lock_guard<std::mutex> lock(sessions_mutex_);
+	return sessions_.size();
+}
+
+auto quic_server_adapter::set_connection_callback(connection_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	connection_callback_ = std::move(callback);
+}
+
+auto quic_server_adapter::set_disconnection_callback(disconnection_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	disconnection_callback_ = std::move(callback);
+}
+
+auto quic_server_adapter::set_receive_callback(receive_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	receive_callback_ = std::move(callback);
+}
+
+auto quic_server_adapter::set_error_callback(error_callback_t callback) -> void
+{
+	std::lock_guard<std::mutex> lock(callbacks_mutex_);
+	error_callback_ = std::move(callback);
+}
+
+// =========================================================================
+// Internal methods
+// =========================================================================
+
+auto quic_server_adapter::setup_internal_callbacks() -> void
+{
+	if (!server_)
+	{
+		return;
+	}
+
+	// Bridge connection callback using the legacy callback type (takes quic_session directly)
+	core::messaging_quic_server::connection_callback_t conn_cb =
+		[this](std::shared_ptr<session::quic_session> quic_sess) {
+			if (!quic_sess)
+			{
+				return;
+			}
+
+			auto wrapper = get_or_create_wrapper(quic_sess);
+
+			connection_callback_t callback_copy;
+			{
+				std::lock_guard<std::mutex> lock(callbacks_mutex_);
+				callback_copy = connection_callback_;
+			}
+
+			if (callback_copy)
+			{
+				callback_copy(wrapper);
+			}
+		};
+	server_->set_connection_callback(conn_cb);
+
+	// Bridge disconnection callback
+	server_->set_disconnection_callback(
+		[this](std::string_view session_id) {
+			disconnection_callback_t callback_copy;
+			{
+				std::lock_guard<std::mutex> lock(callbacks_mutex_);
+				callback_copy = disconnection_callback_;
+			}
+
+			if (callback_copy)
+			{
+				callback_copy(session_id);
+			}
+
+			remove_wrapper(std::string(session_id));
+		});
+
+	// Bridge receive callback
+	server_->set_receive_callback(
+		[this](std::string_view session_id, const std::vector<uint8_t>& data) {
+			receive_callback_t callback_copy;
+			{
+				std::lock_guard<std::mutex> lock(callbacks_mutex_);
+				callback_copy = receive_callback_;
+			}
+
+			if (callback_copy)
+			{
+				callback_copy(session_id, data);
+			}
+		});
+
+	// Bridge error callback
+	server_->set_error_callback(
+		[this](std::string_view session_id, std::error_code ec) {
+			error_callback_t callback_copy;
+			{
+				std::lock_guard<std::mutex> lock(callbacks_mutex_);
+				callback_copy = error_callback_;
+			}
+
+			if (callback_copy)
+			{
+				callback_copy(session_id, ec);
+			}
+		});
+}
+
+auto quic_server_adapter::get_or_create_wrapper(std::shared_ptr<session::quic_session> session)
+	-> std::shared_ptr<quic_session_wrapper>
+{
+	const std::string session_id = session->session_id();
+
+	std::lock_guard<std::mutex> lock(sessions_mutex_);
+
+	auto it = sessions_.find(session_id);
+	if (it != sessions_.end())
+	{
+		return it->second;
+	}
+
+	auto wrapper = std::make_shared<quic_session_wrapper>(session_id, session);
+	sessions_[session_id] = wrapper;
+	return wrapper;
+}
+
+auto quic_server_adapter::remove_wrapper(const std::string& session_id) -> void
+{
+	std::lock_guard<std::mutex> lock(sessions_mutex_);
+	sessions_.erase(session_id);
+}
+
+} // namespace kcenon::network::internal::adapters

--- a/src/internal/adapters/quic_client_adapter.h
+++ b/src/internal/adapters/quic_client_adapter.h
@@ -1,0 +1,190 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include "kcenon/network/interfaces/i_protocol_client.h"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace kcenon::network::core {
+	class messaging_quic_client;
+}
+
+namespace kcenon::network::internal::adapters {
+
+/**
+ * @class quic_client_adapter
+ * @brief Adapter that wraps messaging_quic_client to implement i_protocol_client
+ *
+ * This adapter bridges the QUIC client implementation with the unified
+ * i_protocol_client interface. It allows quic_facade to return i_protocol_client
+ * without modifying the existing messaging_quic_client class.
+ *
+ * ### Design Rationale
+ * The adapter pattern is used because:
+ * 1. QUIC's i_quic_client has additional methods (multi-stream, 0-RTT, ALPN)
+ * 2. QUIC always uses TLS 1.3, so SSL/TLS configuration is implicit
+ * 3. For QUIC-specific features, users should use messaging_quic_client directly
+ *
+ * ### ALPN Configuration
+ * ALPN protocols can be configured via set_alpn_protocols() before start().
+ * Common values: "h3" (HTTP/3), "hq-29" (HTTP/QUIC draft-29)
+ *
+ * ### Message Handling
+ * - send() sends data on the default stream (stream 0)
+ * - For multi-stream operations, use messaging_quic_client directly
+ *
+ * ### Thread Safety
+ * Thread-safe. All methods can be called from any thread.
+ *
+ * @see i_protocol_client
+ * @see messaging_quic_client
+ */
+class quic_client_adapter : public interfaces::i_protocol_client {
+public:
+	/**
+	 * @brief Constructs an adapter with a unique client ID
+	 * @param client_id Unique identifier for this client
+	 */
+	explicit quic_client_adapter(std::string_view client_id);
+
+	/**
+	 * @brief Destructor ensures proper cleanup
+	 */
+	~quic_client_adapter() override;
+
+	// Non-copyable, non-movable
+	quic_client_adapter(const quic_client_adapter&) = delete;
+	quic_client_adapter& operator=(const quic_client_adapter&) = delete;
+	quic_client_adapter(quic_client_adapter&&) = delete;
+	quic_client_adapter& operator=(quic_client_adapter&&) = delete;
+
+	// =========================================================================
+	// QUIC-specific Configuration
+	// =========================================================================
+
+	/**
+	 * @brief Sets the ALPN protocols for negotiation
+	 * @param protocols List of protocol identifiers (e.g., {"h3", "hq-29"})
+	 *
+	 * Must be called before start() to take effect.
+	 */
+	auto set_alpn_protocols(const std::vector<std::string>& protocols) -> void;
+
+	/**
+	 * @brief Sets CA certificate path for server verification
+	 * @param path Path to CA certificate file (PEM format)
+	 */
+	auto set_ca_cert_path(std::string_view path) -> void;
+
+	/**
+	 * @brief Sets client certificate path for mutual TLS
+	 * @param cert_path Path to client certificate file (PEM format)
+	 * @param key_path Path to client private key file (PEM format)
+	 */
+	auto set_client_cert(std::string_view cert_path, std::string_view key_path) -> void;
+
+	/**
+	 * @brief Sets whether to verify server certificate
+	 * @param verify True to verify (default), false to skip verification
+	 */
+	auto set_verify_server(bool verify) -> void;
+
+	/**
+	 * @brief Sets max idle timeout in milliseconds
+	 * @param timeout_ms Maximum idle timeout (default: 30000)
+	 */
+	auto set_max_idle_timeout(uint64_t timeout_ms) -> void;
+
+	// =========================================================================
+	// i_network_component interface implementation
+	// =========================================================================
+
+	[[nodiscard]] auto is_running() const -> bool override;
+	auto wait_for_stop() -> void override;
+
+	// =========================================================================
+	// i_protocol_client interface implementation
+	// =========================================================================
+
+	[[nodiscard]] auto start(std::string_view host, uint16_t port) -> VoidResult override;
+	[[nodiscard]] auto stop() -> VoidResult override;
+	[[nodiscard]] auto send(std::vector<uint8_t>&& data) -> VoidResult override;
+	[[nodiscard]] auto is_connected() const -> bool override;
+
+	auto set_observer(std::shared_ptr<interfaces::connection_observer> observer) -> void override;
+
+	[[deprecated("Use set_observer() with connection_observer instead")]]
+	auto set_receive_callback(receive_callback_t callback) -> void override;
+
+	[[deprecated("Use set_observer() with connection_observer instead")]]
+	auto set_connected_callback(connected_callback_t callback) -> void override;
+
+	[[deprecated("Use set_observer() with connection_observer instead")]]
+	auto set_disconnected_callback(disconnected_callback_t callback) -> void override;
+
+	[[deprecated("Use set_observer() with connection_observer instead")]]
+	auto set_error_callback(error_callback_t callback) -> void override;
+
+private:
+	/**
+	 * @brief Sets up internal callbacks to bridge QUIC callbacks to i_protocol_client callbacks
+	 */
+	auto setup_internal_callbacks() -> void;
+
+	std::string client_id_;
+	std::shared_ptr<core::messaging_quic_client> client_;
+
+	// QUIC-specific configuration
+	std::vector<std::string> alpn_protocols_;
+	std::optional<std::string> ca_cert_path_;
+	std::optional<std::string> client_cert_path_;
+	std::optional<std::string> client_key_path_;
+	bool verify_server_{true};
+	uint64_t max_idle_timeout_ms_{30000};
+
+	mutable std::mutex callbacks_mutex_;
+	std::shared_ptr<interfaces::connection_observer> observer_;
+	receive_callback_t receive_callback_;
+	connected_callback_t connected_callback_;
+	disconnected_callback_t disconnected_callback_;
+	error_callback_t error_callback_;
+};
+
+} // namespace kcenon::network::internal::adapters

--- a/src/internal/adapters/quic_server_adapter.h
+++ b/src/internal/adapters/quic_server_adapter.h
@@ -1,0 +1,246 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+#include "kcenon/network/interfaces/i_protocol_server.h"
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace kcenon::network::core {
+	class messaging_quic_server;
+}
+
+namespace kcenon::network::session {
+	class quic_session;
+}
+
+namespace kcenon::network::internal::adapters {
+
+/**
+ * @class quic_session_wrapper
+ * @brief Wrapper for QUIC session to implement i_session interface
+ *
+ * This wrapper provides the i_session interface for QUIC sessions,
+ * enabling unified session management through i_protocol_server.
+ */
+class quic_session_wrapper : public interfaces::i_session {
+public:
+	/**
+	 * @brief Constructs a session wrapper
+	 * @param session_id Unique session identifier
+	 * @param session The underlying QUIC session
+	 */
+	quic_session_wrapper(
+		std::string_view session_id,
+		std::shared_ptr<session::quic_session> session);
+
+	// i_session interface
+	[[nodiscard]] auto id() const -> std::string_view override;
+	[[nodiscard]] auto is_connected() const -> bool override;
+	[[nodiscard]] auto send(std::vector<uint8_t>&& data) -> VoidResult override;
+	auto close() -> void override;
+
+private:
+	std::string session_id_;
+	std::shared_ptr<session::quic_session> session_;
+	std::atomic<bool> is_connected_{true};
+};
+
+/**
+ * @class quic_server_adapter
+ * @brief Adapter that wraps messaging_quic_server to implement i_protocol_server
+ *
+ * This adapter bridges the QUIC server implementation with the unified
+ * i_protocol_server interface. It allows quic_facade to return i_protocol_server
+ * without modifying the existing messaging_quic_server class.
+ *
+ * ### Design Rationale
+ * The adapter pattern is used because:
+ * 1. QUIC's i_quic_server has additional methods (multi-stream, broadcast)
+ * 2. QUIC always uses TLS 1.3, requiring certificate configuration
+ * 3. For QUIC-specific features, users should use messaging_quic_server directly
+ *
+ * ### TLS Configuration
+ * QUIC requires TLS certificates. Configure via:
+ * - set_cert_path() for server certificate
+ * - set_key_path() for private key
+ * These MUST be called before start().
+ *
+ * ### Message Handling
+ * - Receives data from clients on default stream
+ * - For multi-stream operations, use messaging_quic_server directly
+ *
+ * ### Thread Safety
+ * Thread-safe. All methods can be called from any thread.
+ *
+ * @see i_protocol_server
+ * @see messaging_quic_server
+ */
+class quic_server_adapter : public interfaces::i_protocol_server {
+public:
+	/**
+	 * @brief Constructs an adapter with a unique server ID
+	 * @param server_id Unique identifier for this server
+	 */
+	explicit quic_server_adapter(std::string_view server_id);
+
+	/**
+	 * @brief Destructor ensures proper cleanup
+	 */
+	~quic_server_adapter() override;
+
+	// Non-copyable, non-movable
+	quic_server_adapter(const quic_server_adapter&) = delete;
+	quic_server_adapter& operator=(const quic_server_adapter&) = delete;
+	quic_server_adapter(quic_server_adapter&&) = delete;
+	quic_server_adapter& operator=(quic_server_adapter&&) = delete;
+
+	// =========================================================================
+	// QUIC-specific Configuration (REQUIRED before start)
+	// =========================================================================
+
+	/**
+	 * @brief Sets the server certificate path
+	 * @param path Path to server certificate file (PEM format)
+	 *
+	 * REQUIRED: Must be called before start().
+	 */
+	auto set_cert_path(std::string_view path) -> void;
+
+	/**
+	 * @brief Sets the server private key path
+	 * @param path Path to private key file (PEM format)
+	 *
+	 * REQUIRED: Must be called before start().
+	 */
+	auto set_key_path(std::string_view path) -> void;
+
+	/**
+	 * @brief Sets the ALPN protocols for negotiation
+	 * @param protocols List of protocol identifiers (e.g., {"h3", "hq-29"})
+	 */
+	auto set_alpn_protocols(const std::vector<std::string>& protocols) -> void;
+
+	/**
+	 * @brief Sets CA certificate path for client verification
+	 * @param path Path to CA certificate file (PEM format)
+	 */
+	auto set_ca_cert_path(std::string_view path) -> void;
+
+	/**
+	 * @brief Sets whether to require client certificate (mutual TLS)
+	 * @param require True to require client cert, false otherwise
+	 */
+	auto set_require_client_cert(bool require) -> void;
+
+	/**
+	 * @brief Sets max idle timeout in milliseconds
+	 * @param timeout_ms Maximum idle timeout (default: 30000)
+	 */
+	auto set_max_idle_timeout(uint64_t timeout_ms) -> void;
+
+	/**
+	 * @brief Sets maximum number of concurrent connections
+	 * @param max Maximum connections (default: 10000)
+	 */
+	auto set_max_connections(size_t max) -> void;
+
+	// =========================================================================
+	// i_network_component interface implementation
+	// =========================================================================
+
+	[[nodiscard]] auto is_running() const -> bool override;
+	auto wait_for_stop() -> void override;
+
+	// =========================================================================
+	// i_protocol_server interface implementation
+	// =========================================================================
+
+	[[nodiscard]] auto start(uint16_t port) -> VoidResult override;
+	[[nodiscard]] auto stop() -> VoidResult override;
+	[[nodiscard]] auto connection_count() const -> size_t override;
+
+	auto set_connection_callback(connection_callback_t callback) -> void override;
+	auto set_disconnection_callback(disconnection_callback_t callback) -> void override;
+	auto set_receive_callback(receive_callback_t callback) -> void override;
+	auto set_error_callback(error_callback_t callback) -> void override;
+
+private:
+	/**
+	 * @brief Sets up internal callbacks to bridge QUIC callbacks to i_protocol_server callbacks
+	 */
+	auto setup_internal_callbacks() -> void;
+
+	/**
+	 * @brief Creates or retrieves a session wrapper for a QUIC session
+	 */
+	auto get_or_create_wrapper(std::shared_ptr<session::quic_session> session)
+		-> std::shared_ptr<quic_session_wrapper>;
+
+	/**
+	 * @brief Removes a session wrapper
+	 */
+	auto remove_wrapper(const std::string& session_id) -> void;
+
+	std::string server_id_;
+	std::shared_ptr<core::messaging_quic_server> server_;
+	std::atomic<bool> is_running_{false};
+
+	// QUIC-specific configuration
+	std::string cert_path_;
+	std::string key_path_;
+	std::vector<std::string> alpn_protocols_;
+	std::optional<std::string> ca_cert_path_;
+	bool require_client_cert_{false};
+	uint64_t max_idle_timeout_ms_{30000};
+	size_t max_connections_{10000};
+
+	// Session management
+	mutable std::mutex sessions_mutex_;
+	std::unordered_map<std::string, std::shared_ptr<quic_session_wrapper>> sessions_;
+
+	// Callbacks
+	mutable std::mutex callbacks_mutex_;
+	connection_callback_t connection_callback_;
+	disconnection_callback_t disconnection_callback_;
+	receive_callback_t receive_callback_;
+	error_callback_t error_callback_;
+};
+
+} // namespace kcenon::network::internal::adapters


### PR DESCRIPTION
## Summary

- Create `quic_client_adapter` implementing `i_protocol_client` interface
- Create `quic_server_adapter` implementing `i_protocol_server` interface
- Update `quic_facade` to return interface types instead of concrete types
- Update samples to use `messaging_quic_client`/`messaging_quic_server` directly for QUIC-specific features

## Motivation

This change completes the unified interface migration for all facades (TCP, UDP, HTTP, WebSocket, QUIC), providing a consistent protocol-agnostic API through `i_protocol_client` and `i_protocol_server` interfaces.

## Design Decision

QUIC has protocol-specific features (multi-stream, 0-RTT, ALPN) that don't fit well into the generic interface. The adapters map the unified interface to QUIC semantics:
- `start(host, port)` - Initiates QUIC connection with TLS 1.3
- `send(data)` - Sends on the default stream (stream 0)

For QUIC-specific features, users should use `messaging_quic_client`/`messaging_quic_server` directly.

## Test Plan

- [x] Build succeeds without errors
- [x] Existing QUIC tests pass
- [x] Sample files compile and work correctly

Closes #661
Part of Epic #577