### PR TITLE
refactor(headers): add umbrella headers for config, session, tracing, metrics

### DIFF
--- a/include/kcenon/network/config/config.h
+++ b/include/kcenon/network/config/config.h
@@ -1,0 +1,76 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024-2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+/**
+ * @file config.h
+ * @brief Unified configuration header for network_system
+ *
+ * This is the main entry point for network_system configuration.
+ * It includes all configuration-related headers:
+ * - Feature flags for compile-time feature detection
+ * - Standalone configuration for internal resource management
+ * - Integration configuration for external dependency injection
+ *
+ * Usage:
+ * @code
+ * #include <kcenon/network/config/config.h>
+ *
+ * using namespace kcenon::network::config;
+ *
+ * // Standalone initialization
+ * auto result = kcenon::network::initialize(network_config::production());
+ *
+ * // Integration with existing infrastructure
+ * network_system_config cfg;
+ * cfg.executor = my_shared_executor;
+ * cfg.logger = my_shared_logger;
+ * auto result = kcenon::network::initialize(cfg);
+ * @endcode
+ *
+ * @note For backward compatibility, individual headers can still be included
+ * directly, but using this unified header is recommended.
+ *
+ * @see feature_flags.h For compile-time feature detection
+ * @see network_config.h For standalone configuration
+ * @see network_system_config.h For integration configuration
+ */
+
+// Feature flags must come first (defines KCENON_WITH_* macros)
+#include "feature_flags.h"
+
+// Standalone configuration (creates internal resources)
+#include "network_config.h"
+
+// Integration configuration (accepts external dependencies)
+#include "network_system_config.h"

--- a/include/kcenon/network/metrics/metrics.h
+++ b/include/kcenon/network/metrics/metrics.h
@@ -1,0 +1,77 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024-2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+/**
+ * @file metrics.h
+ * @brief Unified metrics header for network_system
+ *
+ * This is the main entry point for network metrics in network_system.
+ * It includes all metrics-related headers:
+ * - network_metrics: Core metrics definitions and reporting
+ * - histogram: Histogram implementation for latency tracking
+ * - sliding_histogram: Time-windowed histogram for recent data
+ *
+ * Usage:
+ * @code
+ * #include <kcenon/network/metrics/metrics.h>
+ *
+ * using namespace kcenon::network::metrics;
+ *
+ * // Create a histogram for latency tracking
+ * histogram latency_hist;
+ * latency_hist.record(50); // 50ms latency
+ *
+ * // Get histogram statistics
+ * auto snapshot = latency_hist.get_snapshot();
+ * std::cout << "p99 latency: " << snapshot.percentile(0.99) << "ms\n";
+ *
+ * // Use sliding histogram for time-windowed metrics
+ * sliding_histogram recent_latency(std::chrono::minutes(5));
+ * recent_latency.record(30);
+ * @endcode
+ *
+ * @note For backward compatibility, individual headers can still be included
+ * directly, but using this unified header is recommended.
+ *
+ * @see network_metrics.h For core metrics definitions
+ * @see histogram.h For histogram implementation
+ * @see sliding_histogram.h For time-windowed histogram
+ */
+
+// Core metrics types
+#include "network_metrics.h"
+
+// Histogram implementations
+#include "histogram.h"
+#include "sliding_histogram.h"

--- a/include/kcenon/network/session/session.h
+++ b/include/kcenon/network/session/session.h
@@ -1,0 +1,72 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024-2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+/**
+ * @file session.h
+ * @brief Unified session header for network_system
+ *
+ * This is the main entry point for network session management.
+ * It includes all session-related headers:
+ * - messaging_session: TCP-based messaging sessions
+ * - secure_session: TLS/SSL encrypted sessions
+ * - quic_session: QUIC protocol sessions
+ *
+ * Usage:
+ * @code
+ * #include <kcenon/network/session/session.h>
+ *
+ * using namespace kcenon::network::session;
+ *
+ * // Create a messaging session for TCP communication
+ * auto session = std::make_shared<messaging_session>(socket, io_context);
+ *
+ * // Create a secure session for encrypted communication
+ * auto secure = std::make_shared<secure_session>(socket, ssl_context);
+ *
+ * // Create a QUIC session for modern transport
+ * auto quic = std::make_shared<quic_session>(connection);
+ * @endcode
+ *
+ * @note For backward compatibility, individual headers can still be included
+ * directly, but using this unified header is recommended.
+ *
+ * @see messaging_session.h For TCP messaging sessions
+ * @see secure_session.h For TLS/SSL sessions
+ * @see quic_session.h For QUIC protocol sessions
+ */
+
+// Session implementations
+#include "messaging_session.h"
+#include "secure_session.h"
+#include "quic_session.h"

--- a/include/kcenon/network/tracing/tracing.h
+++ b/include/kcenon/network/tracing/tracing.h
@@ -1,0 +1,78 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024-2025, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#pragma once
+
+/**
+ * @file tracing.h
+ * @brief Unified tracing header for network_system
+ *
+ * This is the main entry point for distributed tracing in network_system.
+ * It includes all tracing-related headers:
+ * - trace_context: Context propagation for distributed traces
+ * - span: RAII span implementation for timing operations
+ * - tracing_config: Configuration for tracing behavior
+ *
+ * Usage:
+ * @code
+ * #include <kcenon/network/tracing/tracing.h>
+ *
+ * using namespace kcenon::network::tracing;
+ *
+ * // Create a trace context for a new request
+ * auto ctx = trace_context::create("request-processing");
+ *
+ * // Create a span for timing an operation
+ * {
+ *     span operation_span(ctx, "database-query");
+ *     // ... perform operation ...
+ * } // span automatically ends and reports duration
+ *
+ * // Configure tracing behavior
+ * tracing_config config;
+ * config.sampling_rate = 0.1; // Sample 10% of traces
+ * @endcode
+ *
+ * @note For backward compatibility, individual headers can still be included
+ * directly, but using this unified header is recommended.
+ *
+ * @see trace_context.h For context propagation
+ * @see span.h For RAII span implementation
+ * @see tracing_config.h For tracing configuration
+ */
+
+// Core tracing types (order matters: trace_context first, span depends on it)
+#include "trace_context.h"
+#include "span.h"
+
+// Configuration
+#include "tracing_config.h"


### PR DESCRIPTION
Closes #677

## Summary
- Add unified umbrella headers for easier API consumption:
  - `config/config.h`: includes feature_flags, network_config, network_system_config
  - `session/session.h`: includes messaging_session, secure_session, quic_session
  - `tracing/tracing.h`: includes trace_context, span, tracing_config
  - `metrics/metrics.h`: includes network_metrics, histogram, sliding_histogram

## Background
This is Phase 1 preparation for EPIC #577 (reduce public header count from 67 to <40).

### Current State
- Public headers: **71** (67 original + 4 new umbrella headers)
- Target: **< 40 files**

### What This PR Does
Creates umbrella header pattern consistent with existing headers (`interfaces/interfaces.h`, `protocol/protocol.h`, `protocols/grpc/grpc.h`, `concepts/concepts.h`, `unified/unified.h`, `utils.h`).

### Remaining Work (Needs Discussion)
To achieve the <40 target, individual headers need to be moved to internal directories. This requires discussion on:

1. **Backward Compatibility Strategy**
   - Option A: Move headers to internal, leave forwarding headers with deprecation warnings
   - Option B: Move headers to internal, update all internal usages, remove public paths
   - Option C: Inline small headers into umbrella headers where appropriate

2. **Priority of Header Migration**
   - interfaces/ (14 files → 2 files potential savings: -12)
   - protocols/grpc/ (7 files → 1 file: -6)
   - protocol/ (6 files → 1 file: -5)
   - concepts/ (3 files → 1 file: -2)
   - Others: config, session, tracing, metrics, unified

3. **Breaking Change Policy**
   - Should this be a major version bump (v2.0)?
   - Timeline for deprecation warnings before removal?

## Test Plan
- [x] CMake configuration succeeds
- [x] Build completes without errors
- [x] 99% tests pass (1470/1472)
  - 2 failing tests are pre-existing issues unrelated to this change

## Related
Part of #577