### PR TITLE
docs(readme): clarify monitoring_system dependency status

### DIFF
--- a/README.kr.md
+++ b/README.kr.md
@@ -47,6 +47,8 @@ network_system
     └── common_system
 ```
 
+> **참고**: database_system과 달리 network_system은 monitoring_system에 대한 컴파일 타임 의존성이 **없습니다**. observability를 위해 network_system은 common_system의 EventBus 기반 메트릭 publishing을 사용합니다. 외부 모니터링 소비자(monitoring_system 포함)는 메트릭 수집을 위해 `network_metric_event`를 구독할 수 있습니다. 자세한 내용은 [모니터링 통합 가이드](docs/integration/with-monitoring.md)를 참조하세요.
+
 ### 의존성과 함께 빌드
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ network_system
     └── common_system
 ```
 
+> **Note**: Unlike database_system, network_system does **not** have a compile-time dependency on monitoring_system. For observability, network_system uses EventBus-based metric publishing via common_system. External monitoring consumers (including monitoring_system) can subscribe to `network_metric_event` for metrics collection. See [Monitoring Integration Guide](docs/integration/with-monitoring.md) for details.
+
 ### Building with Dependencies
 
 ```bash


### PR DESCRIPTION
Closes #682

## Summary
- Added a note to the Dependency Flow section in both English and Korean README files
- Clarifies that network_system does **not** have a compile-time dependency on monitoring_system
- Explains the EventBus-based metric publishing pattern used for observability
- Links to the existing monitoring integration guide for detailed information

## Changes Made
- `README.md`: Added note explaining monitoring_system is not a dependency
- `README.kr.md`: Added corresponding Korean translation

## Key Points Documented
1. Unlike database_system, network_system has no monitoring_system compile-time dependency
2. Observability uses EventBus-based metric publishing via common_system
3. External consumers (including monitoring_system) can subscribe to `network_metric_event`
4. Reference to `docs/integration/with-monitoring.md` for implementation details

## Test Plan
- [x] Verified both README files render correctly with the new note
- [x] Confirmed links to monitoring integration guide are valid