### PR TITLE
docs(unified): add comprehensive Unified API interface guide

### DIFF
--- a/docs/UNIFIED_API_GUIDE.md
+++ b/docs/UNIFIED_API_GUIDE.md
@@ -97,7 +97,9 @@ struct endpoint_info {
 
     endpoint_info() = default;
     endpoint_info(const std::string& h, uint16_t p);      // Host/port
+    endpoint_info(const char* h, uint16_t p);              // Host/port (C-string)
     explicit endpoint_info(const std::string& url);         // URL-only
+    explicit endpoint_info(const char* url);                // URL-only (C-string)
 
     [[nodiscard]] auto is_valid() const noexcept -> bool;   // Non-empty host
     [[nodiscard]] auto to_string() const -> std::string;    // "host:port" or URL


### PR DESCRIPTION
Closes #685

## Summary
- Add `docs/UNIFIED_API_GUIDE.md` documenting the Unified API interface layer
- Document all 3 core interfaces: `i_transport` (base), `i_connection` (lifecycle), `i_listener` (server-side)
- Document all 4 foundation types: `endpoint_info`, `connection_callbacks`, `listener_callbacks`, `connection_options`
- Include interface hierarchy diagram and connection state machine with state transition table
- Provide protocol support matrix (TCP, UDP, WebSocket, QUIC, HTTP, TLS)
- Add 8 protocol-agnostic code examples (send function, connection handler, echo server, broadcast server, etc.)
- Include custom protocol extension guide with implementation contracts

## Test Plan
- [x] Verify all code examples reference correct types and method signatures from headers
- [x] Review API reference tables against actual struct/interface declarations
- [x] Confirm documentation links and cross-references are correct

## Verification Results

| Test Item | Status | Details |
|-----------|--------|---------|
| Code examples vs headers | PASS | All examples verified (includes, namespaces, signatures, designated initializers) |
| API reference tables | PASS | All methods, fields, types, defaults, noexcept qualifiers match |
| Documentation links | PASS | 8 internal anchors, 4 header paths, all class names correct |

One MEDIUM issue found and fixed in second commit: missing `endpoint_info` C-string constructor overloads.