### PR TITLE
test(utils/http2): add unit tests for socket_metrics, callback_indices, and http2_request (#725)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2807,6 +2807,105 @@ network_gtest_discover_tests(network_config_http_error_test
 message(STATUS "Network config and HTTP error utility tests enabled")
 
 ##################################################
+# Socket Metrics and Data Mode Tests (Issue #725)
+##################################################
+
+add_executable(network_socket_metrics_test
+    unit/socket_metrics_test.cpp
+)
+
+target_link_libraries(network_socket_metrics_test PRIVATE
+    NetworkSystem
+    GTest::gtest
+    GTest::gtest_main
+    Threads::Threads
+)
+
+setup_asio_integration(network_socket_metrics_test)
+
+if(COMMON_SYSTEM_INCLUDE_DIR)
+    target_include_directories(network_socket_metrics_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+    target_compile_definitions(network_socket_metrics_test PRIVATE WITH_COMMON_SYSTEM)
+endif()
+
+set_target_properties(network_socket_metrics_test PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+network_gtest_discover_tests(network_socket_metrics_test
+    DISCOVERY_TIMEOUT 60
+)
+message(STATUS "Socket metrics and data mode tests enabled")
+
+##################################################
+# Callback Indices Tests (Issue #725)
+##################################################
+
+add_executable(network_callback_indices_test
+    unit/callback_indices_test.cpp
+)
+
+target_link_libraries(network_callback_indices_test PRIVATE
+    NetworkSystem
+    GTest::gtest
+    GTest::gtest_main
+    Threads::Threads
+)
+
+setup_asio_integration(network_callback_indices_test)
+
+if(COMMON_SYSTEM_INCLUDE_DIR)
+    target_include_directories(network_callback_indices_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+    target_compile_definitions(network_callback_indices_test PRIVATE WITH_COMMON_SYSTEM)
+endif()
+
+set_target_properties(network_callback_indices_test PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+network_gtest_discover_tests(network_callback_indices_test
+    DISCOVERY_TIMEOUT 60
+)
+message(STATUS "Callback indices tests enabled")
+
+##################################################
+# HTTP/2 Request Tests (Issue #725)
+##################################################
+
+add_executable(network_http2_request_test
+    unit/http2_request_test.cpp
+)
+
+target_link_libraries(network_http2_request_test PRIVATE
+    NetworkSystem
+    GTest::gtest
+    GTest::gtest_main
+    Threads::Threads
+)
+
+setup_asio_integration(network_http2_request_test)
+
+if(COMMON_SYSTEM_INCLUDE_DIR)
+    target_include_directories(network_http2_request_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+    target_compile_definitions(network_http2_request_test PRIVATE WITH_COMMON_SYSTEM)
+endif()
+
+set_target_properties(network_http2_request_test PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+network_gtest_discover_tests(network_http2_request_test
+    DISCOVERY_TIMEOUT 60
+)
+message(STATUS "HTTP/2 request tests enabled")
+
+##################################################
 # Integration Tests
 ##################################################
 

--- a/tests/unit/callback_indices_test.cpp
+++ b/tests/unit/callback_indices_test.cpp
@@ -1,0 +1,263 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+*****************************************************************************/
+
+#include "internal/core/callback_indices.h"
+#include <gtest/gtest.h>
+
+using namespace kcenon::network;
+
+/**
+ * @file callback_indices_test.cpp
+ * @brief Unit tests for callback_indices enums and to_index() helper
+ *
+ * Tests validate:
+ * - tcp_client_callback enum values and count
+ * - tcp_server_callback enum values and count
+ * - udp_client_callback enum values and count
+ * - secure_udp_client_callback enum values and count
+ * - udp_server_callback enum values and count
+ * - unified_udp_client_callback enum values and count
+ * - unified_udp_server_callback enum values and count
+ * - ws_client_callback enum values and count
+ * - ws_server_callback enum values and count
+ * - quic_client_callback enum values and count
+ * - quic_server_callback enum values and count
+ * - to_index() template helper for all enum types
+ */
+
+// ============================================================================
+// TCP Client Callback Tests
+// ============================================================================
+
+class TcpClientCallbackTest : public ::testing::Test
+{
+};
+
+TEST_F(TcpClientCallbackTest, EnumValuesAreSequential)
+{
+	EXPECT_EQ(to_index(tcp_client_callback::receive), 0);
+	EXPECT_EQ(to_index(tcp_client_callback::connected), 1);
+	EXPECT_EQ(to_index(tcp_client_callback::disconnected), 2);
+	EXPECT_EQ(to_index(tcp_client_callback::error), 3);
+}
+
+TEST_F(TcpClientCallbackTest, EnumValuesAreDistinct)
+{
+	EXPECT_NE(tcp_client_callback::receive, tcp_client_callback::connected);
+	EXPECT_NE(tcp_client_callback::connected, tcp_client_callback::disconnected);
+	EXPECT_NE(tcp_client_callback::disconnected, tcp_client_callback::error);
+}
+
+// ============================================================================
+// TCP Server Callback Tests
+// ============================================================================
+
+class TcpServerCallbackTest : public ::testing::Test
+{
+};
+
+TEST_F(TcpServerCallbackTest, EnumValuesAreSequential)
+{
+	EXPECT_EQ(to_index(tcp_server_callback::connection), 0);
+	EXPECT_EQ(to_index(tcp_server_callback::disconnection), 1);
+	EXPECT_EQ(to_index(tcp_server_callback::receive), 2);
+	EXPECT_EQ(to_index(tcp_server_callback::error), 3);
+}
+
+// ============================================================================
+// UDP Client Callback Tests
+// ============================================================================
+
+class UdpClientCallbackTest : public ::testing::Test
+{
+};
+
+TEST_F(UdpClientCallbackTest, EnumValuesAreSequential)
+{
+	EXPECT_EQ(to_index(udp_client_callback::receive), 0);
+	EXPECT_EQ(to_index(udp_client_callback::error), 1);
+}
+
+// ============================================================================
+// Secure UDP Client Callback Tests
+// ============================================================================
+
+class SecureUdpClientCallbackTest : public ::testing::Test
+{
+};
+
+TEST_F(SecureUdpClientCallbackTest, EnumValuesAreSequential)
+{
+	EXPECT_EQ(to_index(secure_udp_client_callback::receive), 0);
+	EXPECT_EQ(to_index(secure_udp_client_callback::connected), 1);
+	EXPECT_EQ(to_index(secure_udp_client_callback::disconnected), 2);
+	EXPECT_EQ(to_index(secure_udp_client_callback::error), 3);
+}
+
+// ============================================================================
+// UDP Server Callback Tests
+// ============================================================================
+
+class UdpServerCallbackTest : public ::testing::Test
+{
+};
+
+TEST_F(UdpServerCallbackTest, EnumValuesAreSequential)
+{
+	EXPECT_EQ(to_index(udp_server_callback::receive), 0);
+	EXPECT_EQ(to_index(udp_server_callback::error), 1);
+}
+
+// ============================================================================
+// Unified UDP Client Callback Tests
+// ============================================================================
+
+class UnifiedUdpClientCallbackTest : public ::testing::Test
+{
+};
+
+TEST_F(UnifiedUdpClientCallbackTest, EnumValuesAreSequential)
+{
+	EXPECT_EQ(to_index(unified_udp_client_callback::receive), 0);
+	EXPECT_EQ(to_index(unified_udp_client_callback::connected), 1);
+	EXPECT_EQ(to_index(unified_udp_client_callback::disconnected), 2);
+	EXPECT_EQ(to_index(unified_udp_client_callback::error), 3);
+}
+
+// ============================================================================
+// Unified UDP Server Callback Tests
+// ============================================================================
+
+class UnifiedUdpServerCallbackTest : public ::testing::Test
+{
+};
+
+TEST_F(UnifiedUdpServerCallbackTest, EnumValuesAreSequential)
+{
+	EXPECT_EQ(to_index(unified_udp_server_callback::receive), 0);
+	EXPECT_EQ(to_index(unified_udp_server_callback::client_connected), 1);
+	EXPECT_EQ(to_index(unified_udp_server_callback::client_disconnected), 2);
+	EXPECT_EQ(to_index(unified_udp_server_callback::error), 3);
+}
+
+// ============================================================================
+// WebSocket Client Callback Tests
+// ============================================================================
+
+class WsClientCallbackTest : public ::testing::Test
+{
+};
+
+TEST_F(WsClientCallbackTest, EnumValuesAreSequential)
+{
+	EXPECT_EQ(to_index(ws_client_callback::message), 0);
+	EXPECT_EQ(to_index(ws_client_callback::text_message), 1);
+	EXPECT_EQ(to_index(ws_client_callback::binary_message), 2);
+	EXPECT_EQ(to_index(ws_client_callback::connected), 3);
+	EXPECT_EQ(to_index(ws_client_callback::disconnected), 4);
+	EXPECT_EQ(to_index(ws_client_callback::error), 5);
+}
+
+// ============================================================================
+// WebSocket Server Callback Tests
+// ============================================================================
+
+class WsServerCallbackTest : public ::testing::Test
+{
+};
+
+TEST_F(WsServerCallbackTest, EnumValuesAreSequential)
+{
+	EXPECT_EQ(to_index(ws_server_callback::connection), 0);
+	EXPECT_EQ(to_index(ws_server_callback::disconnection), 1);
+	EXPECT_EQ(to_index(ws_server_callback::message), 2);
+	EXPECT_EQ(to_index(ws_server_callback::text_message), 3);
+	EXPECT_EQ(to_index(ws_server_callback::binary_message), 4);
+	EXPECT_EQ(to_index(ws_server_callback::error), 5);
+}
+
+// ============================================================================
+// QUIC Client Callback Tests
+// ============================================================================
+
+class QuicClientCallbackTest : public ::testing::Test
+{
+};
+
+TEST_F(QuicClientCallbackTest, EnumValuesAreSequential)
+{
+	EXPECT_EQ(to_index(quic_client_callback::receive), 0);
+	EXPECT_EQ(to_index(quic_client_callback::stream_receive), 1);
+	EXPECT_EQ(to_index(quic_client_callback::connected), 2);
+	EXPECT_EQ(to_index(quic_client_callback::disconnected), 3);
+	EXPECT_EQ(to_index(quic_client_callback::error), 4);
+}
+
+// ============================================================================
+// QUIC Server Callback Tests
+// ============================================================================
+
+class QuicServerCallbackTest : public ::testing::Test
+{
+};
+
+TEST_F(QuicServerCallbackTest, EnumValuesAreSequential)
+{
+	EXPECT_EQ(to_index(quic_server_callback::connection), 0);
+	EXPECT_EQ(to_index(quic_server_callback::disconnection), 1);
+	EXPECT_EQ(to_index(quic_server_callback::receive), 2);
+	EXPECT_EQ(to_index(quic_server_callback::stream_receive), 3);
+	EXPECT_EQ(to_index(quic_server_callback::error), 4);
+}
+
+// ============================================================================
+// to_index() Template Helper Tests
+// ============================================================================
+
+class ToIndexHelperTest : public ::testing::Test
+{
+};
+
+TEST_F(ToIndexHelperTest, ReturnsCorrectSizeT)
+{
+	std::size_t index = to_index(tcp_client_callback::error);
+
+	EXPECT_EQ(index, 3);
+	static_assert(std::is_same_v<decltype(to_index(tcp_client_callback::error)), std::size_t>,
+				  "to_index must return std::size_t");
+}
+
+TEST_F(ToIndexHelperTest, IsConstexpr)
+{
+	constexpr auto index = to_index(ws_client_callback::connected);
+
+	static_assert(index == 3, "to_index should be usable in constexpr context");
+	EXPECT_EQ(index, 3);
+}
+
+TEST_F(ToIndexHelperTest, WorksWithAllEnumTypes)
+{
+	// Verify to_index compiles and returns correct values for every enum type
+	EXPECT_EQ(to_index(tcp_client_callback::receive), 0);
+	EXPECT_EQ(to_index(tcp_server_callback::connection), 0);
+	EXPECT_EQ(to_index(udp_client_callback::receive), 0);
+	EXPECT_EQ(to_index(secure_udp_client_callback::receive), 0);
+	EXPECT_EQ(to_index(udp_server_callback::receive), 0);
+	EXPECT_EQ(to_index(unified_udp_client_callback::receive), 0);
+	EXPECT_EQ(to_index(unified_udp_server_callback::receive), 0);
+	EXPECT_EQ(to_index(ws_client_callback::message), 0);
+	EXPECT_EQ(to_index(ws_server_callback::connection), 0);
+	EXPECT_EQ(to_index(quic_client_callback::receive), 0);
+	EXPECT_EQ(to_index(quic_server_callback::connection), 0);
+}
+
+TEST_F(ToIndexHelperTest, IsNoexcept)
+{
+	static_assert(noexcept(to_index(tcp_client_callback::receive)),
+				  "to_index should be noexcept");
+	SUCCEED();
+}

--- a/tests/unit/http2_request_test.cpp
+++ b/tests/unit/http2_request_test.cpp
@@ -1,0 +1,401 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+*****************************************************************************/
+
+#include "internal/protocols/http2/http2_request.h"
+#include <gtest/gtest.h>
+
+using namespace kcenon::network::protocols::http2;
+
+/**
+ * @file http2_request_test.cpp
+ * @brief Unit tests for http2_request struct
+ *
+ * Tests validate:
+ * - is_valid() for normal requests and CONNECT method
+ * - get_header() case-insensitive lookup
+ * - content_type() typed accessor
+ * - content_length() parsing and error handling
+ * - get_body_string() conversion
+ * - from_headers() static factory method
+ */
+
+// ============================================================================
+// is_valid() Tests
+// ============================================================================
+
+class Http2RequestValidationTest : public ::testing::Test
+{
+};
+
+TEST_F(Http2RequestValidationTest, EmptyMethodIsInvalid)
+{
+	http2_request req;
+
+	EXPECT_FALSE(req.is_valid());
+}
+
+TEST_F(Http2RequestValidationTest, GetWithSchemeAndPathIsValid)
+{
+	http2_request req;
+	req.method = "GET";
+	req.scheme = "https";
+	req.path = "/index.html";
+
+	EXPECT_TRUE(req.is_valid());
+}
+
+TEST_F(Http2RequestValidationTest, PostWithSchemeAndPathIsValid)
+{
+	http2_request req;
+	req.method = "POST";
+	req.scheme = "https";
+	req.path = "/api/data";
+
+	EXPECT_TRUE(req.is_valid());
+}
+
+TEST_F(Http2RequestValidationTest, GetWithoutSchemeIsInvalid)
+{
+	http2_request req;
+	req.method = "GET";
+	req.path = "/index.html";
+
+	EXPECT_FALSE(req.is_valid());
+}
+
+TEST_F(Http2RequestValidationTest, GetWithoutPathIsInvalid)
+{
+	http2_request req;
+	req.method = "GET";
+	req.scheme = "https";
+
+	EXPECT_FALSE(req.is_valid());
+}
+
+TEST_F(Http2RequestValidationTest, ConnectWithAuthorityIsValid)
+{
+	http2_request req;
+	req.method = "CONNECT";
+	req.authority = "proxy.example.com:443";
+
+	EXPECT_TRUE(req.is_valid());
+}
+
+TEST_F(Http2RequestValidationTest, ConnectWithoutAuthorityIsInvalid)
+{
+	http2_request req;
+	req.method = "CONNECT";
+
+	EXPECT_FALSE(req.is_valid());
+}
+
+TEST_F(Http2RequestValidationTest, ConnectDoesNotRequireSchemeOrPath)
+{
+	http2_request req;
+	req.method = "CONNECT";
+	req.authority = "example.com:80";
+	// No scheme or path needed for CONNECT
+
+	EXPECT_TRUE(req.is_valid());
+}
+
+// ============================================================================
+// get_header() Tests
+// ============================================================================
+
+class Http2RequestHeaderTest : public ::testing::Test
+{
+protected:
+	http2_request req_;
+
+	void SetUp() override
+	{
+		req_.method = "GET";
+		req_.scheme = "https";
+		req_.path = "/";
+		req_.headers = {
+			{"content-type", "application/json"},
+			{"Authorization", "Bearer token123"},
+			{"X-Custom-Header", "custom-value"},
+		};
+	}
+};
+
+TEST_F(Http2RequestHeaderTest, FindsExactMatchHeader)
+{
+	auto result = req_.get_header("content-type");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result.value(), "application/json");
+}
+
+TEST_F(Http2RequestHeaderTest, FindsCaseInsensitiveHeader)
+{
+	auto result = req_.get_header("CONTENT-TYPE");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result.value(), "application/json");
+}
+
+TEST_F(Http2RequestHeaderTest, FindsMixedCaseHeader)
+{
+	auto result = req_.get_header("authorization");
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result.value(), "Bearer token123");
+}
+
+TEST_F(Http2RequestHeaderTest, ReturnsNulloptForMissingHeader)
+{
+	auto result = req_.get_header("X-Missing-Header");
+
+	EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(Http2RequestHeaderTest, ReturnsNulloptForEmptyHeaders)
+{
+	http2_request empty_req;
+	auto result = empty_req.get_header("content-type");
+
+	EXPECT_FALSE(result.has_value());
+}
+
+// ============================================================================
+// content_type() Tests
+// ============================================================================
+
+class Http2RequestContentTypeTest : public ::testing::Test
+{
+};
+
+TEST_F(Http2RequestContentTypeTest, ReturnsContentTypeWhenPresent)
+{
+	http2_request req;
+	req.headers = {{"content-type", "text/html"}};
+
+	auto result = req.content_type();
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result.value(), "text/html");
+}
+
+TEST_F(Http2RequestContentTypeTest, ReturnsNulloptWhenMissing)
+{
+	http2_request req;
+	req.headers = {{"accept", "text/html"}};
+
+	auto result = req.content_type();
+
+	EXPECT_FALSE(result.has_value());
+}
+
+// ============================================================================
+// content_length() Tests
+// ============================================================================
+
+class Http2RequestContentLengthTest : public ::testing::Test
+{
+};
+
+TEST_F(Http2RequestContentLengthTest, ParsesValidContentLength)
+{
+	http2_request req;
+	req.headers = {{"content-length", "1024"}};
+
+	auto result = req.content_length();
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result.value(), 1024);
+}
+
+TEST_F(Http2RequestContentLengthTest, ParsesZeroContentLength)
+{
+	http2_request req;
+	req.headers = {{"content-length", "0"}};
+
+	auto result = req.content_length();
+
+	ASSERT_TRUE(result.has_value());
+	EXPECT_EQ(result.value(), 0);
+}
+
+TEST_F(Http2RequestContentLengthTest, ReturnsNulloptForMissingHeader)
+{
+	http2_request req;
+
+	auto result = req.content_length();
+
+	EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(Http2RequestContentLengthTest, ReturnsNulloptForInvalidValue)
+{
+	http2_request req;
+	req.headers = {{"content-length", "not-a-number"}};
+
+	auto result = req.content_length();
+
+	EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(Http2RequestContentLengthTest, ReturnsNulloptForEmptyValue)
+{
+	http2_request req;
+	req.headers = {{"content-length", ""}};
+
+	auto result = req.content_length();
+
+	EXPECT_FALSE(result.has_value());
+}
+
+// ============================================================================
+// get_body_string() Tests
+// ============================================================================
+
+class Http2RequestBodyTest : public ::testing::Test
+{
+};
+
+TEST_F(Http2RequestBodyTest, ConvertsBodyToString)
+{
+	http2_request req;
+	std::string text = "Hello, World!";
+	req.body.assign(text.begin(), text.end());
+
+	EXPECT_EQ(req.get_body_string(), "Hello, World!");
+}
+
+TEST_F(Http2RequestBodyTest, EmptyBodyReturnsEmptyString)
+{
+	http2_request req;
+
+	EXPECT_EQ(req.get_body_string(), "");
+}
+
+TEST_F(Http2RequestBodyTest, ConvertsJsonBody)
+{
+	http2_request req;
+	std::string json = R"({"key":"value"})";
+	req.body.assign(json.begin(), json.end());
+
+	EXPECT_EQ(req.get_body_string(), json);
+}
+
+// ============================================================================
+// from_headers() Static Factory Tests
+// ============================================================================
+
+class Http2RequestFromHeadersTest : public ::testing::Test
+{
+};
+
+TEST_F(Http2RequestFromHeadersTest, SeparatesPseudoHeaders)
+{
+	std::vector<http_header> headers = {
+		{":method", "GET"},
+		{":path", "/api/users"},
+		{":scheme", "https"},
+		{":authority", "example.com"},
+		{"accept", "application/json"},
+		{"user-agent", "TestClient/1.0"},
+	};
+
+	auto req = http2_request::from_headers(headers);
+
+	EXPECT_EQ(req.method, "GET");
+	EXPECT_EQ(req.path, "/api/users");
+	EXPECT_EQ(req.scheme, "https");
+	EXPECT_EQ(req.authority, "example.com");
+	ASSERT_EQ(req.headers.size(), 2);
+	EXPECT_EQ(req.headers[0].name, "accept");
+	EXPECT_EQ(req.headers[1].name, "user-agent");
+}
+
+TEST_F(Http2RequestFromHeadersTest, HandlesEmptyHeaderList)
+{
+	std::vector<http_header> headers;
+
+	auto req = http2_request::from_headers(headers);
+
+	EXPECT_TRUE(req.method.empty());
+	EXPECT_TRUE(req.path.empty());
+	EXPECT_TRUE(req.scheme.empty());
+	EXPECT_TRUE(req.authority.empty());
+	EXPECT_TRUE(req.headers.empty());
+}
+
+TEST_F(Http2RequestFromHeadersTest, IgnoresUnknownPseudoHeaders)
+{
+	std::vector<http_header> headers = {
+		{":method", "POST"},
+		{":unknown-pseudo", "some-value"},
+		{"content-type", "text/plain"},
+	};
+
+	auto req = http2_request::from_headers(headers);
+
+	EXPECT_EQ(req.method, "POST");
+	ASSERT_EQ(req.headers.size(), 1);
+	EXPECT_EQ(req.headers[0].name, "content-type");
+}
+
+TEST_F(Http2RequestFromHeadersTest, SkipsEmptyNameHeaders)
+{
+	std::vector<http_header> headers = {
+		{":method", "GET"},
+		{"", "empty-name-value"},
+		{"accept", "*/*"},
+	};
+
+	auto req = http2_request::from_headers(headers);
+
+	EXPECT_EQ(req.method, "GET");
+	ASSERT_EQ(req.headers.size(), 1);
+	EXPECT_EQ(req.headers[0].name, "accept");
+}
+
+TEST_F(Http2RequestFromHeadersTest, OnlyPseudoHeadersNoRegularHeaders)
+{
+	std::vector<http_header> headers = {
+		{":method", "DELETE"},
+		{":path", "/api/resource/123"},
+		{":scheme", "https"},
+	};
+
+	auto req = http2_request::from_headers(headers);
+
+	EXPECT_EQ(req.method, "DELETE");
+	EXPECT_EQ(req.path, "/api/resource/123");
+	EXPECT_TRUE(req.headers.empty());
+}
+
+TEST_F(Http2RequestFromHeadersTest, ConnectRequestFromHeaders)
+{
+	std::vector<http_header> headers = {
+		{":method", "CONNECT"},
+		{":authority", "proxy.example.com:8080"},
+	};
+
+	auto req = http2_request::from_headers(headers);
+
+	EXPECT_EQ(req.method, "CONNECT");
+	EXPECT_EQ(req.authority, "proxy.example.com:8080");
+	EXPECT_TRUE(req.is_valid());
+}
+
+TEST_F(Http2RequestFromHeadersTest, BuiltRequestIsValid)
+{
+	std::vector<http_header> headers = {
+		{":method", "GET"},
+		{":path", "/"},
+		{":scheme", "https"},
+	};
+
+	auto req = http2_request::from_headers(headers);
+
+	EXPECT_TRUE(req.is_valid());
+}

--- a/tests/unit/socket_metrics_test.cpp
+++ b/tests/unit/socket_metrics_test.cpp
@@ -1,0 +1,265 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+*****************************************************************************/
+
+#include "internal/utils/common_defs.h"
+#include <gtest/gtest.h>
+
+#include <thread>
+#include <vector>
+
+using namespace kcenon::network::internal;
+
+/**
+ * @file socket_metrics_test.cpp
+ * @brief Unit tests for socket_metrics and data_mode
+ *
+ * Tests validate:
+ * - socket_metrics default initialization (all counters zero)
+ * - socket_metrics reset() method
+ * - socket_metrics atomic store/load operations
+ * - socket_metrics concurrent access safety
+ * - data_mode enum values and underlying type
+ */
+
+// ============================================================================
+// socket_metrics Default Initialization Tests
+// ============================================================================
+
+class SocketMetricsDefaultTest : public ::testing::Test
+{
+protected:
+	socket_metrics metrics_;
+};
+
+TEST_F(SocketMetricsDefaultTest, AllCountersInitializedToZero)
+{
+	EXPECT_EQ(metrics_.total_bytes_sent.load(), 0);
+	EXPECT_EQ(metrics_.total_bytes_received.load(), 0);
+	EXPECT_EQ(metrics_.current_pending_bytes.load(), 0);
+	EXPECT_EQ(metrics_.peak_pending_bytes.load(), 0);
+	EXPECT_EQ(metrics_.backpressure_events.load(), 0);
+	EXPECT_EQ(metrics_.rejected_sends.load(), 0);
+	EXPECT_EQ(metrics_.send_count.load(), 0);
+	EXPECT_EQ(metrics_.receive_count.load(), 0);
+}
+
+// ============================================================================
+// socket_metrics Atomic Operations Tests
+// ============================================================================
+
+class SocketMetricsAtomicTest : public ::testing::Test
+{
+protected:
+	socket_metrics metrics_;
+};
+
+TEST_F(SocketMetricsAtomicTest, StoreThenLoad)
+{
+	metrics_.total_bytes_sent.store(1024);
+	metrics_.total_bytes_received.store(2048);
+	metrics_.current_pending_bytes.store(512);
+	metrics_.peak_pending_bytes.store(4096);
+	metrics_.backpressure_events.store(3);
+	metrics_.rejected_sends.store(7);
+	metrics_.send_count.store(100);
+	metrics_.receive_count.store(200);
+
+	EXPECT_EQ(metrics_.total_bytes_sent.load(), 1024);
+	EXPECT_EQ(metrics_.total_bytes_received.load(), 2048);
+	EXPECT_EQ(metrics_.current_pending_bytes.load(), 512);
+	EXPECT_EQ(metrics_.peak_pending_bytes.load(), 4096);
+	EXPECT_EQ(metrics_.backpressure_events.load(), 3);
+	EXPECT_EQ(metrics_.rejected_sends.load(), 7);
+	EXPECT_EQ(metrics_.send_count.load(), 100);
+	EXPECT_EQ(metrics_.receive_count.load(), 200);
+}
+
+TEST_F(SocketMetricsAtomicTest, FetchAddAccumulates)
+{
+	metrics_.total_bytes_sent.fetch_add(100);
+	metrics_.total_bytes_sent.fetch_add(200);
+	metrics_.total_bytes_sent.fetch_add(300);
+
+	EXPECT_EQ(metrics_.total_bytes_sent.load(), 600);
+}
+
+TEST_F(SocketMetricsAtomicTest, IncrementSendAndReceiveCount)
+{
+	for (int i = 0; i < 50; ++i)
+	{
+		metrics_.send_count.fetch_add(1);
+	}
+	for (int i = 0; i < 30; ++i)
+	{
+		metrics_.receive_count.fetch_add(1);
+	}
+
+	EXPECT_EQ(metrics_.send_count.load(), 50);
+	EXPECT_EQ(metrics_.receive_count.load(), 30);
+}
+
+// ============================================================================
+// socket_metrics Reset Tests
+// ============================================================================
+
+class SocketMetricsResetTest : public ::testing::Test
+{
+protected:
+	socket_metrics metrics_;
+};
+
+TEST_F(SocketMetricsResetTest, ResetZerosAllCounters)
+{
+	// Set all counters to non-zero values
+	metrics_.total_bytes_sent.store(1000);
+	metrics_.total_bytes_received.store(2000);
+	metrics_.current_pending_bytes.store(500);
+	metrics_.peak_pending_bytes.store(3000);
+	metrics_.backpressure_events.store(10);
+	metrics_.rejected_sends.store(5);
+	metrics_.send_count.store(50);
+	metrics_.receive_count.store(40);
+
+	metrics_.reset();
+
+	EXPECT_EQ(metrics_.total_bytes_sent.load(), 0);
+	EXPECT_EQ(metrics_.total_bytes_received.load(), 0);
+	EXPECT_EQ(metrics_.current_pending_bytes.load(), 0);
+	EXPECT_EQ(metrics_.peak_pending_bytes.load(), 0);
+	EXPECT_EQ(metrics_.backpressure_events.load(), 0);
+	EXPECT_EQ(metrics_.rejected_sends.load(), 0);
+	EXPECT_EQ(metrics_.send_count.load(), 0);
+	EXPECT_EQ(metrics_.receive_count.load(), 0);
+}
+
+TEST_F(SocketMetricsResetTest, ResetOnAlreadyZeroIsNoOp)
+{
+	metrics_.reset();
+
+	EXPECT_EQ(metrics_.total_bytes_sent.load(), 0);
+	EXPECT_EQ(metrics_.send_count.load(), 0);
+}
+
+TEST_F(SocketMetricsResetTest, CountersWorkAfterReset)
+{
+	metrics_.total_bytes_sent.store(999);
+	metrics_.reset();
+
+	metrics_.total_bytes_sent.fetch_add(42);
+	EXPECT_EQ(metrics_.total_bytes_sent.load(), 42);
+}
+
+// ============================================================================
+// socket_metrics Concurrent Access Tests
+// ============================================================================
+
+class SocketMetricsConcurrencyTest : public ::testing::Test
+{
+protected:
+	socket_metrics metrics_;
+};
+
+TEST_F(SocketMetricsConcurrencyTest, ConcurrentFetchAdd)
+{
+	constexpr int num_threads = 8;
+	constexpr int increments_per_thread = 1000;
+
+	std::vector<std::thread> threads;
+	threads.reserve(num_threads);
+
+	for (int t = 0; t < num_threads; ++t)
+	{
+		threads.emplace_back([this]() {
+			for (int i = 0; i < increments_per_thread; ++i)
+			{
+				metrics_.total_bytes_sent.fetch_add(1);
+				metrics_.send_count.fetch_add(1);
+			}
+		});
+	}
+
+	for (auto& th : threads)
+	{
+		th.join();
+	}
+
+	EXPECT_EQ(metrics_.total_bytes_sent.load(),
+			  num_threads * increments_per_thread);
+	EXPECT_EQ(metrics_.send_count.load(),
+			  num_threads * increments_per_thread);
+}
+
+TEST_F(SocketMetricsConcurrencyTest, ConcurrentResetDuringUpdates)
+{
+	constexpr int num_threads = 4;
+	std::atomic<bool> stop{false};
+
+	std::vector<std::thread> threads;
+	for (int t = 0; t < num_threads; ++t)
+	{
+		threads.emplace_back([this, &stop]() {
+			while (!stop.load())
+			{
+				metrics_.total_bytes_sent.fetch_add(1);
+				metrics_.receive_count.fetch_add(1);
+			}
+		});
+	}
+
+	// Reset periodically while threads are updating
+	for (int i = 0; i < 50; ++i)
+	{
+		metrics_.reset();
+		std::this_thread::yield();
+	}
+
+	stop.store(true);
+	for (auto& th : threads)
+	{
+		th.join();
+	}
+
+	// Just verify no crash or UB occurred
+	SUCCEED();
+}
+
+// ============================================================================
+// data_mode Enum Tests
+// ============================================================================
+
+class DataModeTest : public ::testing::Test
+{
+};
+
+TEST_F(DataModeTest, EnumValuesAreCorrect)
+{
+	EXPECT_EQ(static_cast<std::uint8_t>(data_mode::packet_mode), 1);
+	EXPECT_EQ(static_cast<std::uint8_t>(data_mode::file_mode), 2);
+	EXPECT_EQ(static_cast<std::uint8_t>(data_mode::binary_mode), 3);
+}
+
+TEST_F(DataModeTest, EnumValuesAreDistinct)
+{
+	EXPECT_NE(data_mode::packet_mode, data_mode::file_mode);
+	EXPECT_NE(data_mode::packet_mode, data_mode::binary_mode);
+	EXPECT_NE(data_mode::file_mode, data_mode::binary_mode);
+}
+
+TEST_F(DataModeTest, UnderlyingTypeIsUint8)
+{
+	static_assert(std::is_same_v<std::underlying_type_t<data_mode>, std::uint8_t>,
+				  "data_mode underlying type must be uint8_t");
+	SUCCEED();
+}
+
+TEST_F(DataModeTest, RoundTripCast)
+{
+	auto val = static_cast<std::uint8_t>(data_mode::file_mode);
+	auto mode = static_cast<data_mode>(val);
+
+	EXPECT_EQ(mode, data_mode::file_mode);
+}


### PR DESCRIPTION
Closes #725

## Summary
- Add unit tests for `socket_metrics` struct (default initialization, reset, atomic operations, concurrent access) and `data_mode` enum (values, underlying type) from `common_defs.h`
- Add unit tests for all 11 callback enum classes and `to_index()` template helper from `callback_indices.h`
- Add unit tests for `http2_request` struct (RFC 7540 validation, case-insensitive header lookup, typed header accessors, body conversion, static factory method) from `http2_request.h`

## Test Plan
- [x] `network_socket_metrics_test`: 13 tests pass (socket_metrics default init, atomic ops, reset, concurrent access; data_mode enum values)
- [x] `network_callback_indices_test`: 16 tests pass (all 11 callback enums + to_index template helper)
- [x] `network_http2_request_test`: 30 tests pass (is_valid, get_header, content_type/length, get_body_string, from_headers)
- [x] All 59 tests pass locally