### PR TITLE
test(quic): add unit tests for varint encoding and frame type utilities (#727)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2906,6 +2906,72 @@ network_gtest_discover_tests(network_http2_request_test
 message(STATUS "HTTP/2 request tests enabled")
 
 ##################################################
+# QUIC Varint Unit Tests (Issue #727)
+##################################################
+
+add_executable(network_quic_varint_unit_test
+    unit/quic_varint_test.cpp
+)
+
+target_link_libraries(network_quic_varint_unit_test PRIVATE
+    NetworkSystem
+    GTest::gtest
+    GTest::gtest_main
+    Threads::Threads
+)
+
+setup_asio_integration(network_quic_varint_unit_test)
+
+if(COMMON_SYSTEM_INCLUDE_DIR)
+    target_include_directories(network_quic_varint_unit_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+    target_compile_definitions(network_quic_varint_unit_test PRIVATE WITH_COMMON_SYSTEM)
+endif()
+
+set_target_properties(network_quic_varint_unit_test PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+network_gtest_discover_tests(network_quic_varint_unit_test
+    DISCOVERY_TIMEOUT 60
+)
+message(STATUS "QUIC varint unit tests enabled")
+
+##################################################
+# QUIC Frame Types Unit Tests (Issue #727)
+##################################################
+
+add_executable(network_quic_frame_types_unit_test
+    unit/quic_frame_types_test.cpp
+)
+
+target_link_libraries(network_quic_frame_types_unit_test PRIVATE
+    NetworkSystem
+    GTest::gtest
+    GTest::gtest_main
+    Threads::Threads
+)
+
+setup_asio_integration(network_quic_frame_types_unit_test)
+
+if(COMMON_SYSTEM_INCLUDE_DIR)
+    target_include_directories(network_quic_frame_types_unit_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+    target_compile_definitions(network_quic_frame_types_unit_test PRIVATE WITH_COMMON_SYSTEM)
+endif()
+
+set_target_properties(network_quic_frame_types_unit_test PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+network_gtest_discover_tests(network_quic_frame_types_unit_test
+    DISCOVERY_TIMEOUT 60
+)
+message(STATUS "QUIC frame types unit tests enabled")
+
+##################################################
 # Integration Tests
 ##################################################
 

--- a/tests/unit/quic_frame_types_test.cpp
+++ b/tests/unit/quic_frame_types_test.cpp
@@ -1,0 +1,431 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+*****************************************************************************/
+
+#include "internal/protocols/quic/frame_types.h"
+#include <gtest/gtest.h>
+
+using namespace kcenon::network::protocols::quic;
+
+/**
+ * @file quic_frame_types_test.cpp
+ * @brief Unit tests for QUIC frame type utilities (RFC 9000)
+ *
+ * Tests validate:
+ * - frame_type enum values match RFC 9000 Section 12.4
+ * - is_stream_frame() boundary detection
+ * - get_stream_flags() flag extraction
+ * - make_stream_type() flag-to-type construction
+ * - stream_flags namespace constants
+ * - frame_type_to_string() for all known types
+ * - get_frame_type() variant visitor
+ * - Frame struct default initialization
+ */
+
+// ============================================================================
+// frame_type Enum Value Tests
+// ============================================================================
+
+class FrameTypeEnumTest : public ::testing::Test
+{
+};
+
+TEST_F(FrameTypeEnumTest, CoreFrameTypes)
+{
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::padding), 0x00);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::ping), 0x01);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::ack), 0x02);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::ack_ecn), 0x03);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::reset_stream), 0x04);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::stop_sending), 0x05);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::crypto), 0x06);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::new_token), 0x07);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::stream_base), 0x08);
+}
+
+TEST_F(FrameTypeEnumTest, FlowControlFrameTypes)
+{
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::max_data), 0x10);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::max_stream_data), 0x11);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::max_streams_bidi), 0x12);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::max_streams_uni), 0x13);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::data_blocked), 0x14);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::stream_data_blocked), 0x15);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::streams_blocked_bidi), 0x16);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::streams_blocked_uni), 0x17);
+}
+
+TEST_F(FrameTypeEnumTest, ConnectionManagementFrameTypes)
+{
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::new_connection_id), 0x18);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::retire_connection_id), 0x19);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::path_challenge), 0x1a);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::path_response), 0x1b);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::connection_close), 0x1c);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::connection_close_app), 0x1d);
+	EXPECT_EQ(static_cast<uint64_t>(frame_type::handshake_done), 0x1e);
+}
+
+// ============================================================================
+// is_stream_frame() Tests
+// ============================================================================
+
+class IsStreamFrameTest : public ::testing::Test
+{
+};
+
+TEST_F(IsStreamFrameTest, BelowRangeIsNotStreamFrame)
+{
+	EXPECT_FALSE(is_stream_frame(0x07));
+}
+
+TEST_F(IsStreamFrameTest, StreamBaseIsStreamFrame)
+{
+	EXPECT_TRUE(is_stream_frame(0x08));
+}
+
+TEST_F(IsStreamFrameTest, AllStreamRangeIsStreamFrame)
+{
+	for (uint64_t type = 0x08; type <= 0x0f; ++type)
+	{
+		EXPECT_TRUE(is_stream_frame(type)) << "Type 0x" << std::hex << type;
+	}
+}
+
+TEST_F(IsStreamFrameTest, AboveRangeIsNotStreamFrame)
+{
+	EXPECT_FALSE(is_stream_frame(0x10));
+}
+
+TEST_F(IsStreamFrameTest, ZeroIsNotStreamFrame)
+{
+	EXPECT_FALSE(is_stream_frame(0x00));
+}
+
+// ============================================================================
+// get_stream_flags() Tests
+// ============================================================================
+
+class GetStreamFlagsTest : public ::testing::Test
+{
+};
+
+TEST_F(GetStreamFlagsTest, BaseTypeHasNoFlags)
+{
+	EXPECT_EQ(get_stream_flags(0x08), 0x00);
+}
+
+TEST_F(GetStreamFlagsTest, FinFlagOnly)
+{
+	EXPECT_EQ(get_stream_flags(0x09), stream_flags::fin);
+}
+
+TEST_F(GetStreamFlagsTest, LenFlagOnly)
+{
+	EXPECT_EQ(get_stream_flags(0x0A), stream_flags::len);
+}
+
+TEST_F(GetStreamFlagsTest, OffFlagOnly)
+{
+	EXPECT_EQ(get_stream_flags(0x0C), stream_flags::off);
+}
+
+TEST_F(GetStreamFlagsTest, AllFlags)
+{
+	uint8_t flags = get_stream_flags(0x0F);
+
+	EXPECT_TRUE(flags & stream_flags::fin);
+	EXPECT_TRUE(flags & stream_flags::len);
+	EXPECT_TRUE(flags & stream_flags::off);
+}
+
+TEST_F(GetStreamFlagsTest, FinAndLenFlags)
+{
+	uint8_t flags = get_stream_flags(0x0B);
+
+	EXPECT_TRUE(flags & stream_flags::fin);
+	EXPECT_TRUE(flags & stream_flags::len);
+	EXPECT_FALSE(flags & stream_flags::off);
+}
+
+// ============================================================================
+// make_stream_type() Tests
+// ============================================================================
+
+class MakeStreamTypeTest : public ::testing::Test
+{
+};
+
+TEST_F(MakeStreamTypeTest, NoFlagsReturnsBase)
+{
+	EXPECT_EQ(make_stream_type(false, false, false), 0x08);
+}
+
+TEST_F(MakeStreamTypeTest, FinOnly)
+{
+	EXPECT_EQ(make_stream_type(true, false, false), 0x09);
+}
+
+TEST_F(MakeStreamTypeTest, LenOnly)
+{
+	EXPECT_EQ(make_stream_type(false, true, false), 0x0A);
+}
+
+TEST_F(MakeStreamTypeTest, OffOnly)
+{
+	EXPECT_EQ(make_stream_type(false, false, true), 0x0C);
+}
+
+TEST_F(MakeStreamTypeTest, AllFlags)
+{
+	EXPECT_EQ(make_stream_type(true, true, true), 0x0F);
+}
+
+TEST_F(MakeStreamTypeTest, FinAndLen)
+{
+	EXPECT_EQ(make_stream_type(true, true, false), 0x0B);
+}
+
+TEST_F(MakeStreamTypeTest, LenAndOff)
+{
+	EXPECT_EQ(make_stream_type(false, true, true), 0x0E);
+}
+
+TEST_F(MakeStreamTypeTest, ResultIsAlwaysInStreamRange)
+{
+	for (int fin = 0; fin <= 1; ++fin)
+	{
+		for (int len = 0; len <= 1; ++len)
+		{
+			for (int off = 0; off <= 1; ++off)
+			{
+				auto type = make_stream_type(fin, len, off);
+				EXPECT_TRUE(is_stream_frame(type))
+					<< "fin=" << fin << " len=" << len << " off=" << off;
+			}
+		}
+	}
+}
+
+// ============================================================================
+// stream_flags Constants Tests
+// ============================================================================
+
+class StreamFlagsConstantsTest : public ::testing::Test
+{
+};
+
+TEST_F(StreamFlagsConstantsTest, FlagValues)
+{
+	EXPECT_EQ(stream_flags::fin, 0x01);
+	EXPECT_EQ(stream_flags::len, 0x02);
+	EXPECT_EQ(stream_flags::off, 0x04);
+	EXPECT_EQ(stream_flags::mask, 0x07);
+	EXPECT_EQ(stream_flags::base, 0x08);
+}
+
+TEST_F(StreamFlagsConstantsTest, MaskCoversAllFlags)
+{
+	EXPECT_EQ(stream_flags::mask,
+			  stream_flags::fin | stream_flags::len | stream_flags::off);
+}
+
+// ============================================================================
+// frame_type_to_string() Tests
+// ============================================================================
+
+class FrameTypeToStringTest : public ::testing::Test
+{
+};
+
+TEST_F(FrameTypeToStringTest, CoreFrameTypeStrings)
+{
+	EXPECT_EQ(frame_type_to_string(frame_type::padding), "PADDING");
+	EXPECT_EQ(frame_type_to_string(frame_type::ping), "PING");
+	EXPECT_EQ(frame_type_to_string(frame_type::ack), "ACK");
+	EXPECT_EQ(frame_type_to_string(frame_type::ack_ecn), "ACK_ECN");
+	EXPECT_EQ(frame_type_to_string(frame_type::reset_stream), "RESET_STREAM");
+	EXPECT_EQ(frame_type_to_string(frame_type::stop_sending), "STOP_SENDING");
+	EXPECT_EQ(frame_type_to_string(frame_type::crypto), "CRYPTO");
+	EXPECT_EQ(frame_type_to_string(frame_type::new_token), "NEW_TOKEN");
+	EXPECT_EQ(frame_type_to_string(frame_type::stream_base), "STREAM");
+}
+
+TEST_F(FrameTypeToStringTest, FlowControlFrameTypeStrings)
+{
+	EXPECT_EQ(frame_type_to_string(frame_type::max_data), "MAX_DATA");
+	EXPECT_EQ(frame_type_to_string(frame_type::max_stream_data), "MAX_STREAM_DATA");
+	EXPECT_EQ(frame_type_to_string(frame_type::max_streams_bidi), "MAX_STREAMS_BIDI");
+	EXPECT_EQ(frame_type_to_string(frame_type::max_streams_uni), "MAX_STREAMS_UNI");
+	EXPECT_EQ(frame_type_to_string(frame_type::data_blocked), "DATA_BLOCKED");
+	EXPECT_EQ(frame_type_to_string(frame_type::stream_data_blocked), "STREAM_DATA_BLOCKED");
+	EXPECT_EQ(frame_type_to_string(frame_type::streams_blocked_bidi), "STREAMS_BLOCKED_BIDI");
+	EXPECT_EQ(frame_type_to_string(frame_type::streams_blocked_uni), "STREAMS_BLOCKED_UNI");
+}
+
+TEST_F(FrameTypeToStringTest, ConnectionFrameTypeStrings)
+{
+	EXPECT_EQ(frame_type_to_string(frame_type::new_connection_id), "NEW_CONNECTION_ID");
+	EXPECT_EQ(frame_type_to_string(frame_type::retire_connection_id), "RETIRE_CONNECTION_ID");
+	EXPECT_EQ(frame_type_to_string(frame_type::path_challenge), "PATH_CHALLENGE");
+	EXPECT_EQ(frame_type_to_string(frame_type::path_response), "PATH_RESPONSE");
+	EXPECT_EQ(frame_type_to_string(frame_type::connection_close), "CONNECTION_CLOSE");
+	EXPECT_EQ(frame_type_to_string(frame_type::connection_close_app), "CONNECTION_CLOSE_APP");
+	EXPECT_EQ(frame_type_to_string(frame_type::handshake_done), "HANDSHAKE_DONE");
+}
+
+TEST_F(FrameTypeToStringTest, UnknownTypeReturnsUnknown)
+{
+	EXPECT_EQ(frame_type_to_string(static_cast<frame_type>(0xFF)), "UNKNOWN");
+}
+
+// ============================================================================
+// get_frame_type() Variant Visitor Tests
+// ============================================================================
+
+class GetFrameTypeTest : public ::testing::Test
+{
+};
+
+TEST_F(GetFrameTypeTest, PaddingFrame)
+{
+	frame f = padding_frame{};
+	EXPECT_EQ(get_frame_type(f), frame_type::padding);
+}
+
+TEST_F(GetFrameTypeTest, PingFrame)
+{
+	frame f = ping_frame{};
+	EXPECT_EQ(get_frame_type(f), frame_type::ping);
+}
+
+TEST_F(GetFrameTypeTest, AckFrameWithoutEcn)
+{
+	ack_frame af;
+	af.ecn = std::nullopt;
+	frame f = af;
+	EXPECT_EQ(get_frame_type(f), frame_type::ack);
+}
+
+TEST_F(GetFrameTypeTest, AckFrameWithEcn)
+{
+	ack_frame af;
+	af.ecn = ecn_counts{};
+	frame f = af;
+	EXPECT_EQ(get_frame_type(f), frame_type::ack_ecn);
+}
+
+TEST_F(GetFrameTypeTest, StreamFrame)
+{
+	frame f = stream_frame{};
+	EXPECT_EQ(get_frame_type(f), frame_type::stream_base);
+}
+
+TEST_F(GetFrameTypeTest, CryptoFrame)
+{
+	frame f = crypto_frame{};
+	EXPECT_EQ(get_frame_type(f), frame_type::crypto);
+}
+
+TEST_F(GetFrameTypeTest, MaxStreamsBidiFrame)
+{
+	max_streams_frame msf;
+	msf.bidirectional = true;
+	frame f = msf;
+	EXPECT_EQ(get_frame_type(f), frame_type::max_streams_bidi);
+}
+
+TEST_F(GetFrameTypeTest, MaxStreamsUniFrame)
+{
+	max_streams_frame msf;
+	msf.bidirectional = false;
+	frame f = msf;
+	EXPECT_EQ(get_frame_type(f), frame_type::max_streams_uni);
+}
+
+TEST_F(GetFrameTypeTest, StreamsBlockedBidiFrame)
+{
+	streams_blocked_frame sbf;
+	sbf.bidirectional = true;
+	frame f = sbf;
+	EXPECT_EQ(get_frame_type(f), frame_type::streams_blocked_bidi);
+}
+
+TEST_F(GetFrameTypeTest, StreamsBlockedUniFrame)
+{
+	streams_blocked_frame sbf;
+	sbf.bidirectional = false;
+	frame f = sbf;
+	EXPECT_EQ(get_frame_type(f), frame_type::streams_blocked_uni);
+}
+
+TEST_F(GetFrameTypeTest, ConnectionCloseFrame)
+{
+	frame f = connection_close_frame{};
+	EXPECT_EQ(get_frame_type(f), frame_type::connection_close);
+}
+
+TEST_F(GetFrameTypeTest, HandshakeDoneFrame)
+{
+	frame f = handshake_done_frame{};
+	EXPECT_EQ(get_frame_type(f), frame_type::handshake_done);
+}
+
+// ============================================================================
+// Frame Struct Default Initialization Tests
+// ============================================================================
+
+class FrameStructDefaultsTest : public ::testing::Test
+{
+};
+
+TEST_F(FrameStructDefaultsTest, PaddingFrameDefaults)
+{
+	padding_frame f;
+	EXPECT_EQ(f.count, 1);
+}
+
+TEST_F(FrameStructDefaultsTest, AckFrameDefaults)
+{
+	ack_frame f;
+	EXPECT_EQ(f.largest_acknowledged, 0);
+	EXPECT_EQ(f.ack_delay, 0);
+	EXPECT_TRUE(f.ranges.empty());
+	EXPECT_FALSE(f.ecn.has_value());
+}
+
+TEST_F(FrameStructDefaultsTest, StreamFrameDefaults)
+{
+	stream_frame f;
+	EXPECT_EQ(f.stream_id, 0);
+	EXPECT_EQ(f.offset, 0);
+	EXPECT_TRUE(f.data.empty());
+	EXPECT_FALSE(f.fin);
+}
+
+TEST_F(FrameStructDefaultsTest, ConnectionCloseFrameDefaults)
+{
+	connection_close_frame f;
+	EXPECT_EQ(f.error_code, 0);
+	EXPECT_EQ(f.frame_type, 0);
+	EXPECT_TRUE(f.reason_phrase.empty());
+	EXPECT_FALSE(f.is_application_error);
+}
+
+TEST_F(FrameStructDefaultsTest, MaxStreamsFrameDefaults)
+{
+	max_streams_frame f;
+	EXPECT_EQ(f.maximum_streams, 0);
+	EXPECT_TRUE(f.bidirectional);
+}
+
+TEST_F(FrameStructDefaultsTest, EcnCountsDefaults)
+{
+	ecn_counts c;
+	EXPECT_EQ(c.ect0, 0);
+	EXPECT_EQ(c.ect1, 0);
+	EXPECT_EQ(c.ecn_ce, 0);
+}

--- a/tests/unit/quic_varint_test.cpp
+++ b/tests/unit/quic_varint_test.cpp
@@ -1,0 +1,432 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+*****************************************************************************/
+
+#include "internal/protocols/quic/varint.h"
+#include <gtest/gtest.h>
+
+using namespace kcenon::network::protocols::quic;
+
+/**
+ * @file quic_varint_test.cpp
+ * @brief Unit tests for QUIC variable-length integer encoding (RFC 9000 Section 16)
+ *
+ * Tests validate:
+ * - encoded_length() boundary values for all 4 ranges
+ * - length_from_prefix() for all prefix patterns
+ * - is_valid() range validation
+ * - encode()/decode() roundtrip for all ranges
+ * - encode_with_length() minimum length requirement
+ * - Decode error handling (empty, truncated)
+ * - Boundary value encoding/decoding
+ */
+
+// ============================================================================
+// encoded_length() Tests
+// ============================================================================
+
+class VarintEncodedLengthTest : public ::testing::Test
+{
+};
+
+TEST_F(VarintEncodedLengthTest, OneByteRange)
+{
+	EXPECT_EQ(varint::encoded_length(0), 1);
+	EXPECT_EQ(varint::encoded_length(1), 1);
+	EXPECT_EQ(varint::encoded_length(63), 1);
+}
+
+TEST_F(VarintEncodedLengthTest, TwoByteRange)
+{
+	EXPECT_EQ(varint::encoded_length(64), 2);
+	EXPECT_EQ(varint::encoded_length(100), 2);
+	EXPECT_EQ(varint::encoded_length(16383), 2);
+}
+
+TEST_F(VarintEncodedLengthTest, FourByteRange)
+{
+	EXPECT_EQ(varint::encoded_length(16384), 4);
+	EXPECT_EQ(varint::encoded_length(1000000), 4);
+	EXPECT_EQ(varint::encoded_length(1073741823), 4);
+}
+
+TEST_F(VarintEncodedLengthTest, EightByteRange)
+{
+	EXPECT_EQ(varint::encoded_length(1073741824), 8);
+	EXPECT_EQ(varint::encoded_length(varint_max), 8);
+}
+
+TEST_F(VarintEncodedLengthTest, IsConstexpr)
+{
+	constexpr auto len = varint::encoded_length(42);
+
+	static_assert(len == 1, "encoded_length should be constexpr");
+	EXPECT_EQ(len, 1);
+}
+
+// ============================================================================
+// length_from_prefix() Tests
+// ============================================================================
+
+class VarintLengthFromPrefixTest : public ::testing::Test
+{
+};
+
+TEST_F(VarintLengthFromPrefixTest, PrefixZeroMeansOneByte)
+{
+	// 0b00xxxxxx -> 1 byte
+	EXPECT_EQ(varint::length_from_prefix(0x00), 1);
+	EXPECT_EQ(varint::length_from_prefix(0x3F), 1);
+	EXPECT_EQ(varint::length_from_prefix(0x25), 1);
+}
+
+TEST_F(VarintLengthFromPrefixTest, PrefixOneMeansTwoBytes)
+{
+	// 0b01xxxxxx -> 2 bytes
+	EXPECT_EQ(varint::length_from_prefix(0x40), 2);
+	EXPECT_EQ(varint::length_from_prefix(0x7F), 2);
+}
+
+TEST_F(VarintLengthFromPrefixTest, PrefixTwoMeansFourBytes)
+{
+	// 0b10xxxxxx -> 4 bytes
+	EXPECT_EQ(varint::length_from_prefix(0x80), 4);
+	EXPECT_EQ(varint::length_from_prefix(0xBF), 4);
+}
+
+TEST_F(VarintLengthFromPrefixTest, PrefixThreeMeansEightBytes)
+{
+	// 0b11xxxxxx -> 8 bytes
+	EXPECT_EQ(varint::length_from_prefix(0xC0), 8);
+	EXPECT_EQ(varint::length_from_prefix(0xFF), 8);
+}
+
+TEST_F(VarintLengthFromPrefixTest, IsConstexpr)
+{
+	constexpr auto len = varint::length_from_prefix(0xC0);
+
+	static_assert(len == 8, "length_from_prefix should be constexpr");
+	EXPECT_EQ(len, 8);
+}
+
+// ============================================================================
+// is_valid() Tests
+// ============================================================================
+
+class VarintIsValidTest : public ::testing::Test
+{
+};
+
+TEST_F(VarintIsValidTest, ZeroIsValid)
+{
+	EXPECT_TRUE(varint::is_valid(0));
+}
+
+TEST_F(VarintIsValidTest, MaxValueIsValid)
+{
+	EXPECT_TRUE(varint::is_valid(varint_max));
+}
+
+TEST_F(VarintIsValidTest, BeyondMaxIsInvalid)
+{
+	EXPECT_FALSE(varint::is_valid(varint_max + 1));
+}
+
+TEST_F(VarintIsValidTest, Uint64MaxIsInvalid)
+{
+	EXPECT_FALSE(varint::is_valid(UINT64_MAX));
+}
+
+TEST_F(VarintIsValidTest, IsConstexpr)
+{
+	constexpr bool valid = varint::is_valid(42);
+
+	static_assert(valid, "is_valid should be constexpr");
+	EXPECT_TRUE(valid);
+}
+
+// ============================================================================
+// Encode/Decode Roundtrip Tests
+// ============================================================================
+
+class VarintRoundtripTest : public ::testing::Test
+{
+};
+
+TEST_F(VarintRoundtripTest, RoundtripZero)
+{
+	auto encoded = varint::encode(0);
+	ASSERT_EQ(encoded.size(), 1);
+
+	auto decoded = varint::decode(encoded);
+	ASSERT_FALSE(decoded.is_err());
+	EXPECT_EQ(decoded.value().first, 0);
+	EXPECT_EQ(decoded.value().second, 1);
+}
+
+TEST_F(VarintRoundtripTest, RoundtripOneByteMax)
+{
+	auto encoded = varint::encode(63);
+	ASSERT_EQ(encoded.size(), 1);
+
+	auto decoded = varint::decode(encoded);
+	ASSERT_FALSE(decoded.is_err());
+	EXPECT_EQ(decoded.value().first, 63);
+	EXPECT_EQ(decoded.value().second, 1);
+}
+
+TEST_F(VarintRoundtripTest, RoundtripTwoByteMin)
+{
+	auto encoded = varint::encode(64);
+	ASSERT_EQ(encoded.size(), 2);
+
+	auto decoded = varint::decode(encoded);
+	ASSERT_FALSE(decoded.is_err());
+	EXPECT_EQ(decoded.value().first, 64);
+	EXPECT_EQ(decoded.value().second, 2);
+}
+
+TEST_F(VarintRoundtripTest, RoundtripTwoByteMax)
+{
+	auto encoded = varint::encode(16383);
+	ASSERT_EQ(encoded.size(), 2);
+
+	auto decoded = varint::decode(encoded);
+	ASSERT_FALSE(decoded.is_err());
+	EXPECT_EQ(decoded.value().first, 16383);
+	EXPECT_EQ(decoded.value().second, 2);
+}
+
+TEST_F(VarintRoundtripTest, RoundtripFourByteMin)
+{
+	auto encoded = varint::encode(16384);
+	ASSERT_EQ(encoded.size(), 4);
+
+	auto decoded = varint::decode(encoded);
+	ASSERT_FALSE(decoded.is_err());
+	EXPECT_EQ(decoded.value().first, 16384);
+	EXPECT_EQ(decoded.value().second, 4);
+}
+
+TEST_F(VarintRoundtripTest, RoundtripFourByteMax)
+{
+	auto encoded = varint::encode(1073741823);
+	ASSERT_EQ(encoded.size(), 4);
+
+	auto decoded = varint::decode(encoded);
+	ASSERT_FALSE(decoded.is_err());
+	EXPECT_EQ(decoded.value().first, 1073741823);
+	EXPECT_EQ(decoded.value().second, 4);
+}
+
+TEST_F(VarintRoundtripTest, RoundtripEightByteMin)
+{
+	auto encoded = varint::encode(1073741824);
+	ASSERT_EQ(encoded.size(), 8);
+
+	auto decoded = varint::decode(encoded);
+	ASSERT_FALSE(decoded.is_err());
+	EXPECT_EQ(decoded.value().first, 1073741824);
+	EXPECT_EQ(decoded.value().second, 8);
+}
+
+TEST_F(VarintRoundtripTest, RoundtripVarintMax)
+{
+	auto encoded = varint::encode(varint_max);
+	ASSERT_EQ(encoded.size(), 8);
+
+	auto decoded = varint::decode(encoded);
+	ASSERT_FALSE(decoded.is_err());
+	EXPECT_EQ(decoded.value().first, varint_max);
+	EXPECT_EQ(decoded.value().second, 8);
+}
+
+TEST_F(VarintRoundtripTest, RoundtripArbitraryValues)
+{
+	std::vector<uint64_t> values = {1, 42, 255, 1000, 65535, 1000000, 100000000};
+
+	for (auto value : values)
+	{
+		auto encoded = varint::encode(value);
+		auto decoded = varint::decode(encoded);
+		ASSERT_FALSE(decoded.is_err()) << "Failed for value: " << value;
+		EXPECT_EQ(decoded.value().first, value) << "Roundtrip mismatch for: " << value;
+	}
+}
+
+// ============================================================================
+// Encode Tests
+// ============================================================================
+
+class VarintEncodeTest : public ::testing::Test
+{
+};
+
+TEST_F(VarintEncodeTest, EncodeSetsCorrectPrefix)
+{
+	// 1-byte: prefix 0b00
+	auto one = varint::encode(0);
+	EXPECT_EQ(one[0] >> 6, 0);
+
+	// 2-byte: prefix 0b01
+	auto two = varint::encode(64);
+	EXPECT_EQ(two[0] >> 6, 1);
+
+	// 4-byte: prefix 0b10
+	auto four = varint::encode(16384);
+	EXPECT_EQ(four[0] >> 6, 2);
+
+	// 8-byte: prefix 0b11
+	auto eight = varint::encode(1073741824);
+	EXPECT_EQ(eight[0] >> 6, 3);
+}
+
+// ============================================================================
+// Decode Error Tests
+// ============================================================================
+
+class VarintDecodeErrorTest : public ::testing::Test
+{
+};
+
+TEST_F(VarintDecodeErrorTest, EmptyInputReturnsError)
+{
+	std::vector<uint8_t> empty;
+
+	auto result = varint::decode(empty);
+
+	EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(VarintDecodeErrorTest, TruncatedTwoByteReturnsError)
+{
+	// Prefix 0b01 indicates 2 bytes, but only 1 byte provided
+	std::vector<uint8_t> truncated = {0x40};
+
+	auto result = varint::decode(truncated);
+
+	EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(VarintDecodeErrorTest, TruncatedFourByteReturnsError)
+{
+	// Prefix 0b10 indicates 4 bytes, but only 2 bytes provided
+	std::vector<uint8_t> truncated = {0x80, 0x00};
+
+	auto result = varint::decode(truncated);
+
+	EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(VarintDecodeErrorTest, TruncatedEightByteReturnsError)
+{
+	// Prefix 0b11 indicates 8 bytes, but only 4 bytes provided
+	std::vector<uint8_t> truncated = {0xC0, 0x00, 0x00, 0x00};
+
+	auto result = varint::decode(truncated);
+
+	EXPECT_TRUE(result.is_err());
+}
+
+// ============================================================================
+// encode_with_length() Tests
+// ============================================================================
+
+class VarintEncodeWithLengthTest : public ::testing::Test
+{
+};
+
+TEST_F(VarintEncodeWithLengthTest, MinLengthOneByte)
+{
+	auto result = varint::encode_with_length(42, 1);
+
+	ASSERT_FALSE(result.is_err());
+	EXPECT_EQ(result.value().size(), 1);
+
+	auto decoded = varint::decode(result.value());
+	ASSERT_FALSE(decoded.is_err());
+	EXPECT_EQ(decoded.value().first, 42);
+}
+
+TEST_F(VarintEncodeWithLengthTest, MinLengthTwoBytes)
+{
+	auto result = varint::encode_with_length(42, 2);
+
+	ASSERT_FALSE(result.is_err());
+	EXPECT_EQ(result.value().size(), 2);
+
+	auto decoded = varint::decode(result.value());
+	ASSERT_FALSE(decoded.is_err());
+	EXPECT_EQ(decoded.value().first, 42);
+}
+
+TEST_F(VarintEncodeWithLengthTest, MinLengthFourBytes)
+{
+	auto result = varint::encode_with_length(42, 4);
+
+	ASSERT_FALSE(result.is_err());
+	EXPECT_EQ(result.value().size(), 4);
+
+	auto decoded = varint::decode(result.value());
+	ASSERT_FALSE(decoded.is_err());
+	EXPECT_EQ(decoded.value().first, 42);
+}
+
+TEST_F(VarintEncodeWithLengthTest, MinLengthEightBytes)
+{
+	auto result = varint::encode_with_length(42, 8);
+
+	ASSERT_FALSE(result.is_err());
+	EXPECT_EQ(result.value().size(), 8);
+
+	auto decoded = varint::decode(result.value());
+	ASSERT_FALSE(decoded.is_err());
+	EXPECT_EQ(decoded.value().first, 42);
+}
+
+TEST_F(VarintEncodeWithLengthTest, InvalidMinLengthReturnsError)
+{
+	// Invalid min_length (not 1, 2, 4, or 8)
+	auto result = varint::encode_with_length(42, 3);
+
+	EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(VarintEncodeWithLengthTest, ValueExceedsOneByteForcesLarger)
+{
+	// Value 100 needs 2 bytes minimum, requesting min_length=1 should still work
+	// by upgrading to the necessary size
+	auto result = varint::encode_with_length(100, 1);
+
+	ASSERT_FALSE(result.is_err());
+	// The value 100 needs at least 2 bytes
+	EXPECT_GE(result.value().size(), 2);
+
+	auto decoded = varint::decode(result.value());
+	ASSERT_FALSE(decoded.is_err());
+	EXPECT_EQ(decoded.value().first, 100);
+}
+
+// ============================================================================
+// Constants Tests
+// ============================================================================
+
+class VarintConstantsTest : public ::testing::Test
+{
+};
+
+TEST_F(VarintConstantsTest, MaxConstants)
+{
+	EXPECT_EQ(varint::max_1byte, 63);
+	EXPECT_EQ(varint::max_2byte, 16383);
+	EXPECT_EQ(varint::max_4byte, 1073741823);
+	EXPECT_EQ(varint::max_8byte, varint_max);
+}
+
+TEST_F(VarintConstantsTest, VarintMaxIs2Power62Minus1)
+{
+	EXPECT_EQ(varint_max, (1ULL << 62) - 1);
+}


### PR DESCRIPTION
Closes #727

## Summary
- Add comprehensive unit tests for QUIC varint encoding/decoding (RFC 9000 Section 16): boundary values for all 4 encoding ranges, encode/decode roundtrip, prefix parsing, encode_with_length, and error handling (empty/truncated input)
- Add unit tests for QUIC frame type utilities: frame_type enum values (RFC 9000 Section 12.4), stream frame detection and flag extraction/construction, frame_type_to_string for all 24 frame types, get_frame_type variant visitor with conditional dispatch (ACK/ECN, bidi/uni), and frame struct default initialization

## Test Plan
- [x] `network_quic_varint_unit_test`: 37 tests pass (encoded_length, length_from_prefix, is_valid, encode/decode roundtrip, encode_with_length, decode errors, constants)
- [x] `network_quic_frame_types_unit_test`: 46 tests pass (frame_type enum, is_stream_frame, get_stream_flags, make_stream_type, stream_flags constants, frame_type_to_string, get_frame_type variant, frame struct defaults)
- [x] All 83 tests pass locally