### PR TITLE
test(core/utils): add unit tests for openssl_compat and network_context (#729)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2972,6 +2972,72 @@ network_gtest_discover_tests(network_quic_frame_types_unit_test
 message(STATUS "QUIC frame types unit tests enabled")
 
 ##################################################
+# OpenSSL Compat Unit Tests (Issue #729)
+##################################################
+
+add_executable(network_openssl_compat_test
+    unit/openssl_compat_test.cpp
+)
+
+target_link_libraries(network_openssl_compat_test PRIVATE
+    NetworkSystem
+    GTest::gtest
+    GTest::gtest_main
+    Threads::Threads
+)
+
+setup_asio_integration(network_openssl_compat_test)
+
+if(COMMON_SYSTEM_INCLUDE_DIR)
+    target_include_directories(network_openssl_compat_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+    target_compile_definitions(network_openssl_compat_test PRIVATE WITH_COMMON_SYSTEM)
+endif()
+
+set_target_properties(network_openssl_compat_test PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+network_gtest_discover_tests(network_openssl_compat_test
+    DISCOVERY_TIMEOUT 60
+)
+message(STATUS "OpenSSL compat unit tests enabled")
+
+##################################################
+# Network Context Unit Tests (Issue #729)
+##################################################
+
+add_executable(network_context_test
+    unit/network_context_test.cpp
+)
+
+target_link_libraries(network_context_test PRIVATE
+    NetworkSystem
+    GTest::gtest
+    GTest::gtest_main
+    Threads::Threads
+)
+
+setup_asio_integration(network_context_test)
+
+if(COMMON_SYSTEM_INCLUDE_DIR)
+    target_include_directories(network_context_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+    target_compile_definitions(network_context_test PRIVATE WITH_COMMON_SYSTEM)
+endif()
+
+set_target_properties(network_context_test PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+network_gtest_discover_tests(network_context_test
+    DISCOVERY_TIMEOUT 60
+)
+message(STATUS "Network context unit tests enabled")
+
+##################################################
 # Integration Tests
 ##################################################
 

--- a/tests/unit/network_context_test.cpp
+++ b/tests/unit/network_context_test.cpp
@@ -1,0 +1,318 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+*****************************************************************************/
+
+#include "internal/core/network_context.h"
+#include <gtest/gtest.h>
+
+#include <memory>
+
+namespace ctx = kcenon::network::core;
+namespace integration = kcenon::network::integration;
+
+/**
+ * @file network_context_test.cpp
+ * @brief Unit tests for network_context singleton
+ *
+ * Tests validate:
+ * - Singleton instance() consistency
+ * - is_initialized() initial state
+ * - set/get round-trip for thread pool, logger, monitoring
+ * - initialize()/shutdown() lifecycle transitions
+ * - Idempotent initialize and shutdown
+ */
+
+// ============================================================================
+// Singleton Tests
+// ============================================================================
+
+class NetworkContextSingletonTest : public ::testing::Test
+{
+};
+
+TEST_F(NetworkContextSingletonTest, InstanceReturnsSameReference)
+{
+	auto& ctx1 = ctx::network_context::instance();
+	auto& ctx2 = ctx::network_context::instance();
+
+	EXPECT_EQ(&ctx1, &ctx2);
+}
+
+TEST_F(NetworkContextSingletonTest, InstanceReturnsSameAddressAcrossCalls)
+{
+	ctx::network_context* ptr1 = &ctx::network_context::instance();
+	ctx::network_context* ptr2 = &ctx::network_context::instance();
+	ctx::network_context* ptr3 = &ctx::network_context::instance();
+
+	EXPECT_EQ(ptr1, ptr2);
+	EXPECT_EQ(ptr2, ptr3);
+}
+
+// ============================================================================
+// Thread Pool Getter/Setter Tests
+// ============================================================================
+
+class NetworkContextThreadPoolTest : public ::testing::Test
+{
+protected:
+	void TearDown() override
+	{
+		// Reset to null to avoid polluting other tests
+		ctx::network_context::instance().set_thread_pool(nullptr);
+	}
+};
+
+TEST_F(NetworkContextThreadPoolTest, GetThreadPoolCallDoesNotCrash)
+{
+	ctx::network_context::instance().set_thread_pool(nullptr);
+
+	auto pool = ctx::network_context::instance().get_thread_pool();
+
+	// May or may not be null depending on prior initialization
+	// Just verify the call doesn't crash
+	SUCCEED();
+}
+
+TEST_F(NetworkContextThreadPoolTest, SetAndGetThreadPoolRoundTrip)
+{
+	auto mock_pool = std::make_shared<integration::basic_thread_pool>(1);
+	ctx::network_context::instance().set_thread_pool(mock_pool);
+
+	auto retrieved = ctx::network_context::instance().get_thread_pool();
+
+	EXPECT_EQ(retrieved.get(), mock_pool.get());
+}
+
+TEST_F(NetworkContextThreadPoolTest, SetNullThreadPool)
+{
+	auto pool = std::make_shared<integration::basic_thread_pool>(1);
+	ctx::network_context::instance().set_thread_pool(pool);
+
+	// Set to null
+	ctx::network_context::instance().set_thread_pool(nullptr);
+
+	auto retrieved = ctx::network_context::instance().get_thread_pool();
+	EXPECT_EQ(retrieved, nullptr);
+}
+
+TEST_F(NetworkContextThreadPoolTest, ReplaceThreadPool)
+{
+	auto pool1 = std::make_shared<integration::basic_thread_pool>(1);
+	auto pool2 = std::make_shared<integration::basic_thread_pool>(1);
+
+	ctx::network_context::instance().set_thread_pool(pool1);
+	EXPECT_EQ(ctx::network_context::instance().get_thread_pool().get(),
+			  pool1.get());
+
+	ctx::network_context::instance().set_thread_pool(pool2);
+	EXPECT_EQ(ctx::network_context::instance().get_thread_pool().get(),
+			  pool2.get());
+}
+
+// ============================================================================
+// Logger Getter/Setter Tests
+// ============================================================================
+
+class NetworkContextLoggerTest : public ::testing::Test
+{
+protected:
+	void TearDown() override
+	{
+		ctx::network_context::instance().set_logger(nullptr);
+	}
+};
+
+TEST_F(NetworkContextLoggerTest, SetAndGetLoggerRoundTrip)
+{
+	auto mock_logger = std::make_shared<integration::basic_logger>(
+		integration::log_level::info);
+	ctx::network_context::instance().set_logger(mock_logger);
+
+	auto retrieved = ctx::network_context::instance().get_logger();
+
+	EXPECT_EQ(retrieved.get(), mock_logger.get());
+}
+
+TEST_F(NetworkContextLoggerTest, SetNullLogger)
+{
+	auto logger = std::make_shared<integration::basic_logger>(
+		integration::log_level::info);
+	ctx::network_context::instance().set_logger(logger);
+
+	ctx::network_context::instance().set_logger(nullptr);
+
+	auto retrieved = ctx::network_context::instance().get_logger();
+	EXPECT_EQ(retrieved, nullptr);
+}
+
+// ============================================================================
+// Monitoring Getter/Setter Tests
+// ============================================================================
+
+class NetworkContextMonitoringTest : public ::testing::Test
+{
+protected:
+	void TearDown() override
+	{
+		ctx::network_context::instance().set_monitoring(nullptr);
+	}
+};
+
+TEST_F(NetworkContextMonitoringTest, SetAndGetMonitoringRoundTrip)
+{
+	auto mock_monitoring = std::make_shared<integration::basic_monitoring>();
+	ctx::network_context::instance().set_monitoring(mock_monitoring);
+
+	auto retrieved = ctx::network_context::instance().get_monitoring();
+
+	EXPECT_EQ(retrieved.get(), mock_monitoring.get());
+}
+
+TEST_F(NetworkContextMonitoringTest, GetMonitoringReturnsDefaultWhenNull)
+{
+	ctx::network_context::instance().set_monitoring(nullptr);
+
+	auto monitoring = ctx::network_context::instance().get_monitoring();
+
+	// Should return a default monitoring from the integration manager
+	// (may or may not be null depending on the integration manager state)
+	SUCCEED();
+}
+
+// ============================================================================
+// Lifecycle Tests
+// ============================================================================
+
+class NetworkContextLifecycleTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+		// Ensure clean state before each lifecycle test
+		ctx::network_context::instance().shutdown();
+		ctx::network_context::instance().set_thread_pool(nullptr);
+		ctx::network_context::instance().set_logger(nullptr);
+		ctx::network_context::instance().set_monitoring(nullptr);
+	}
+
+	void TearDown() override
+	{
+		// Always clean up
+		ctx::network_context::instance().shutdown();
+		ctx::network_context::instance().set_thread_pool(nullptr);
+		ctx::network_context::instance().set_logger(nullptr);
+		ctx::network_context::instance().set_monitoring(nullptr);
+	}
+};
+
+TEST_F(NetworkContextLifecycleTest, NotInitializedAfterShutdown)
+{
+	EXPECT_FALSE(ctx::network_context::instance().is_initialized());
+}
+
+TEST_F(NetworkContextLifecycleTest, InitializeSetsInitializedTrue)
+{
+	ctx::network_context::instance().initialize(1);
+
+	EXPECT_TRUE(ctx::network_context::instance().is_initialized());
+}
+
+TEST_F(NetworkContextLifecycleTest, ShutdownSetsInitializedFalse)
+{
+	ctx::network_context::instance().initialize(1);
+	ASSERT_TRUE(ctx::network_context::instance().is_initialized());
+
+	ctx::network_context::instance().shutdown();
+
+	EXPECT_FALSE(ctx::network_context::instance().is_initialized());
+}
+
+TEST_F(NetworkContextLifecycleTest, DoubleInitializeIsIdempotent)
+{
+	ctx::network_context::instance().initialize(1);
+	EXPECT_TRUE(ctx::network_context::instance().is_initialized());
+
+	// Second initialize should not crash or change state
+	ctx::network_context::instance().initialize(2);
+	EXPECT_TRUE(ctx::network_context::instance().is_initialized());
+}
+
+TEST_F(NetworkContextLifecycleTest, DoubleShutdownIsIdempotent)
+{
+	ctx::network_context::instance().initialize(1);
+
+	ctx::network_context::instance().shutdown();
+	EXPECT_FALSE(ctx::network_context::instance().is_initialized());
+
+	// Second shutdown should not crash
+	ctx::network_context::instance().shutdown();
+	EXPECT_FALSE(ctx::network_context::instance().is_initialized());
+}
+
+TEST_F(NetworkContextLifecycleTest, InitializeCreatesThreadPool)
+{
+	ctx::network_context::instance().initialize(2);
+
+	auto pool = ctx::network_context::instance().get_thread_pool();
+
+	EXPECT_NE(pool, nullptr);
+}
+
+TEST_F(NetworkContextLifecycleTest, InitializeCreatesLogger)
+{
+	ctx::network_context::instance().initialize(1);
+
+	auto logger = ctx::network_context::instance().get_logger();
+
+	EXPECT_NE(logger, nullptr);
+}
+
+TEST_F(NetworkContextLifecycleTest, ReinitializeAfterShutdown)
+{
+	ctx::network_context::instance().initialize(1);
+	EXPECT_TRUE(ctx::network_context::instance().is_initialized());
+
+	ctx::network_context::instance().shutdown();
+	EXPECT_FALSE(ctx::network_context::instance().is_initialized());
+
+	// Should be able to re-initialize
+	ctx::network_context::instance().initialize(1);
+	EXPECT_TRUE(ctx::network_context::instance().is_initialized());
+}
+
+TEST_F(NetworkContextLifecycleTest, InitializeWithZeroThreadsAutoDetects)
+{
+	// thread_count=0 should auto-detect via hardware_concurrency
+	ctx::network_context::instance().initialize(0);
+
+	EXPECT_TRUE(ctx::network_context::instance().is_initialized());
+	EXPECT_NE(ctx::network_context::instance().get_thread_pool(), nullptr);
+}
+
+TEST_F(NetworkContextLifecycleTest, PresetThreadPoolIsNotReplacedByInitialize)
+{
+	auto custom_pool = std::make_shared<integration::basic_thread_pool>(1);
+	ctx::network_context::instance().set_thread_pool(custom_pool);
+
+	ctx::network_context::instance().initialize(4);
+
+	// The pre-set pool should be preserved
+	EXPECT_EQ(ctx::network_context::instance().get_thread_pool().get(),
+			  custom_pool.get());
+}
+
+TEST_F(NetworkContextLifecycleTest, PresetLoggerIsNotReplacedByInitialize)
+{
+	auto custom_logger = std::make_shared<integration::basic_logger>(
+		integration::log_level::debug);
+	ctx::network_context::instance().set_logger(custom_logger);
+
+	ctx::network_context::instance().initialize(1);
+
+	// The pre-set logger should be preserved
+	EXPECT_EQ(ctx::network_context::instance().get_logger().get(),
+			  custom_logger.get());
+}

--- a/tests/unit/openssl_compat_test.cpp
+++ b/tests/unit/openssl_compat_test.cpp
@@ -1,0 +1,247 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+*****************************************************************************/
+
+#include <string>
+
+#include "internal/utils/openssl_compat.h"
+#include <gtest/gtest.h>
+
+using namespace kcenon::network::internal;
+
+/**
+ * @file openssl_compat_test.cpp
+ * @brief Unit tests for OpenSSL compatibility utilities
+ *
+ * Tests validate:
+ * - NETWORK_OPENSSL_VERSION_3_X macro is defined
+ * - openssl_version_string() returns valid string
+ * - get_openssl_error() returns "No OpenSSL error" on clean queue
+ * - clear_openssl_errors() clears the error queue
+ * - Deprecated warning suppression macros compile correctly
+ */
+
+// ============================================================================
+// Version Macro Tests
+// ============================================================================
+
+class OpenSslVersionMacroTest : public ::testing::Test
+{
+};
+
+TEST_F(OpenSslVersionMacroTest, Version3XMacroIsDefined)
+{
+#ifdef NETWORK_OPENSSL_VERSION_3_X
+	EXPECT_EQ(NETWORK_OPENSSL_VERSION_3_X, 1);
+#else
+	GTEST_SKIP() << "NETWORK_OPENSSL_VERSION_3_X not defined";
+#endif
+}
+
+TEST_F(OpenSslVersionMacroTest, OpenSslVersionNumberAbove3)
+{
+	EXPECT_GE(OPENSSL_VERSION_NUMBER, 0x30000000L);
+}
+
+// ============================================================================
+// openssl_version_string() Tests
+// ============================================================================
+
+class OpenSslVersionStringTest : public ::testing::Test
+{
+};
+
+TEST_F(OpenSslVersionStringTest, ReturnsNonNull)
+{
+	const char* version = openssl_version_string();
+
+	EXPECT_NE(version, nullptr);
+}
+
+TEST_F(OpenSslVersionStringTest, ReturnsNonEmptyString)
+{
+	const char* version = openssl_version_string();
+
+	ASSERT_NE(version, nullptr);
+	EXPECT_GT(std::string(version).size(), 0);
+}
+
+TEST_F(OpenSslVersionStringTest, ContainsOpenSSL)
+{
+	const char* version = openssl_version_string();
+
+	ASSERT_NE(version, nullptr);
+	std::string version_str(version);
+	// OpenSSL version string typically contains "OpenSSL"
+	EXPECT_NE(version_str.find("OpenSSL"), std::string::npos)
+		<< "Version string: " << version_str;
+}
+
+TEST_F(OpenSslVersionStringTest, ConsistentAcrossCalls)
+{
+	const char* version1 = openssl_version_string();
+	const char* version2 = openssl_version_string();
+
+	EXPECT_STREQ(version1, version2);
+}
+
+// ============================================================================
+// get_openssl_error() Tests
+// ============================================================================
+
+class OpenSslGetErrorTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+		// Start each test with a clean error queue
+		clear_openssl_errors();
+	}
+};
+
+TEST_F(OpenSslGetErrorTest, ReturnsNoErrorOnCleanQueue)
+{
+	std::string error = get_openssl_error();
+
+	EXPECT_EQ(error, "No OpenSSL error");
+}
+
+TEST_F(OpenSslGetErrorTest, ReturnsNonEmptyString)
+{
+	std::string error = get_openssl_error();
+
+	EXPECT_FALSE(error.empty());
+}
+
+TEST_F(OpenSslGetErrorTest, ConsecutiveCallsReturnNoError)
+{
+	// First call consumes any existing error
+	get_openssl_error();
+
+	// Second call should also return no error
+	std::string error = get_openssl_error();
+
+	EXPECT_EQ(error, "No OpenSSL error");
+}
+
+// ============================================================================
+// clear_openssl_errors() Tests
+// ============================================================================
+
+class OpenSslClearErrorsTest : public ::testing::Test
+{
+};
+
+TEST_F(OpenSslClearErrorsTest, ClearOnEmptyQueueIsNoOp)
+{
+	// Should not crash when clearing an already-empty queue
+	clear_openssl_errors();
+
+	std::string error = get_openssl_error();
+	EXPECT_EQ(error, "No OpenSSL error");
+}
+
+TEST_F(OpenSslClearErrorsTest, ClearsErrorQueue)
+{
+	// Push a synthetic error onto the queue
+	ERR_put_error(ERR_LIB_SYS, 0, ERR_R_INTERNAL_ERROR, __FILE__, __LINE__);
+
+	// Queue should have an error now
+	EXPECT_NE(ERR_peek_error(), 0UL);
+
+	// Clear should remove all errors
+	clear_openssl_errors();
+
+	// Queue should be empty
+	EXPECT_EQ(ERR_peek_error(), 0UL);
+	EXPECT_EQ(get_openssl_error(), "No OpenSSL error");
+}
+
+TEST_F(OpenSslClearErrorsTest, ClearsMultipleErrors)
+{
+	// Push multiple errors
+	ERR_put_error(ERR_LIB_SYS, 0, ERR_R_INTERNAL_ERROR, __FILE__, __LINE__);
+	ERR_put_error(ERR_LIB_SYS, 0, ERR_R_MALLOC_FAILURE, __FILE__, __LINE__);
+
+	clear_openssl_errors();
+
+	EXPECT_EQ(ERR_peek_error(), 0UL);
+	EXPECT_EQ(get_openssl_error(), "No OpenSSL error");
+}
+
+// ============================================================================
+// get_openssl_error() with Real Error Tests
+// ============================================================================
+
+class OpenSslErrorWithRealErrorTest : public ::testing::Test
+{
+protected:
+	void SetUp() override
+	{
+		clear_openssl_errors();
+	}
+
+	void TearDown() override
+	{
+		clear_openssl_errors();
+	}
+};
+
+TEST_F(OpenSslErrorWithRealErrorTest, ReturnsErrorStringWhenErrorExists)
+{
+	// Push a synthetic error
+	ERR_put_error(ERR_LIB_SYS, 0, ERR_R_INTERNAL_ERROR, __FILE__, __LINE__);
+
+	std::string error = get_openssl_error();
+
+	// Should NOT be "No OpenSSL error"
+	EXPECT_NE(error, "No OpenSSL error");
+	EXPECT_FALSE(error.empty());
+}
+
+TEST_F(OpenSslErrorWithRealErrorTest, ConsumesErrorFromQueue)
+{
+	ERR_put_error(ERR_LIB_SYS, 0, ERR_R_INTERNAL_ERROR, __FILE__, __LINE__);
+
+	// First call consumes the error
+	get_openssl_error();
+
+	// Second call should return no error (consumed)
+	std::string error = get_openssl_error();
+	EXPECT_EQ(error, "No OpenSSL error");
+}
+
+// ============================================================================
+// Deprecated Warning Suppression Macro Tests
+// ============================================================================
+
+class OpenSslDeprecationMacroTest : public ::testing::Test
+{
+};
+
+TEST_F(OpenSslDeprecationMacroTest, MacrosCompileCorrectly)
+{
+	// These macros should compile without errors
+	NETWORK_OPENSSL_SUPPRESS_DEPRECATED_START
+	// Code that might use deprecated APIs would go here
+	[[maybe_unused]] int dummy = 42;
+	NETWORK_OPENSSL_SUPPRESS_DEPRECATED_END
+
+	SUCCEED();
+}
+
+TEST_F(OpenSslDeprecationMacroTest, MacrosCanBeNested)
+{
+	NETWORK_OPENSSL_SUPPRESS_DEPRECATED_START
+	{
+		[[maybe_unused]] int outer = 1;
+		// Nested usage should also compile
+		[[maybe_unused]] int inner = 2;
+	}
+	NETWORK_OPENSSL_SUPPRESS_DEPRECATED_END
+
+	SUCCEED();
+}


### PR DESCRIPTION
Closes #729

## Summary
- Add 16 unit tests for `openssl_compat.h` utilities (version macros, version string, error queue operations, deprecation suppression macros)
- Add 21 unit tests for `network_context` singleton (singleton guarantee, thread pool/logger/monitoring get/set round-trips, lifecycle transitions, idempotent initialize/shutdown, pre-set resource preservation)
- Register both test targets in `tests/CMakeLists.txt`

## Test Plan
- [x] `network_openssl_compat_test`: 16 tests passed across 6 test suites
- [x] `network_context_test`: 21 tests passed across 5 test suites
- [x] Full build completes without errors