### PR TITLE
test(events/concepts): add unit tests for network_metric_event and network_concepts (#731)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3038,6 +3038,72 @@ network_gtest_discover_tests(network_context_test
 message(STATUS "Network context unit tests enabled")
 
 ##################################################
+# Network Metric Event Unit Tests (Issue #731)
+##################################################
+
+add_executable(network_metric_event_test
+    unit/network_metric_event_test.cpp
+)
+
+target_link_libraries(network_metric_event_test PRIVATE
+    NetworkSystem
+    GTest::gtest
+    GTest::gtest_main
+    Threads::Threads
+)
+
+setup_asio_integration(network_metric_event_test)
+
+if(COMMON_SYSTEM_INCLUDE_DIR)
+    target_include_directories(network_metric_event_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+    target_compile_definitions(network_metric_event_test PRIVATE WITH_COMMON_SYSTEM)
+endif()
+
+set_target_properties(network_metric_event_test PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+network_gtest_discover_tests(network_metric_event_test
+    DISCOVERY_TIMEOUT 60
+)
+message(STATUS "Network metric event unit tests enabled")
+
+##################################################
+# Network Concepts Unit Tests (Issue #731)
+##################################################
+
+add_executable(network_concepts_test
+    unit/network_concepts_test.cpp
+)
+
+target_link_libraries(network_concepts_test PRIVATE
+    NetworkSystem
+    GTest::gtest
+    GTest::gtest_main
+    Threads::Threads
+)
+
+setup_asio_integration(network_concepts_test)
+
+if(COMMON_SYSTEM_INCLUDE_DIR)
+    target_include_directories(network_concepts_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+    target_compile_definitions(network_concepts_test PRIVATE WITH_COMMON_SYSTEM)
+endif()
+
+set_target_properties(network_concepts_test PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+network_gtest_discover_tests(network_concepts_test
+    DISCOVERY_TIMEOUT 60
+)
+message(STATUS "Network concepts unit tests enabled")
+
+##################################################
 # Integration Tests
 ##################################################
 

--- a/tests/unit/network_concepts_test.cpp
+++ b/tests/unit/network_concepts_test.cpp
@@ -1,0 +1,409 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+*****************************************************************************/
+
+#include "kcenon/network/detail/concepts/network_concepts.h"
+#include <gtest/gtest.h>
+
+#include <array>
+#include <functional>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace concepts = kcenon::network::concepts;
+
+/**
+ * @file network_concepts_test.cpp
+ * @brief Unit tests for C++20 network concepts
+ *
+ * Tests validate:
+ * - ByteBuffer concept satisfaction and rejection
+ * - MutableByteBuffer concept satisfaction and rejection
+ * - DataReceiveHandler concept satisfaction
+ * - ErrorHandler concept satisfaction
+ * - ConnectionHandler concept satisfaction
+ * - SessionHandler concept satisfaction
+ * - DisconnectionHandler concept satisfaction
+ * - RetryCallback concept satisfaction
+ * - DataTransformer concept satisfaction
+ * - Duration concept satisfaction
+ */
+
+// ============================================================================
+// Test Helper Types
+// ============================================================================
+
+// Satisfies ByteBuffer
+struct mock_buffer
+{
+	const void* data() const { return nullptr; }
+	std::size_t size() const { return 0; }
+};
+
+// Satisfies MutableByteBuffer
+struct mock_mutable_buffer
+{
+	void* data() { return nullptr; }
+	const void* data() const { return nullptr; }
+	std::size_t size() const { return 0; }
+	void resize(std::size_t) {}
+};
+
+// Does NOT satisfy ByteBuffer (missing size())
+struct no_size_buffer
+{
+	const void* data() const { return nullptr; }
+};
+
+// Does NOT satisfy ByteBuffer (missing data())
+struct no_data_buffer
+{
+	std::size_t size() const { return 0; }
+};
+
+// Satisfies DataTransformer
+struct mock_transformer
+{
+	bool transform(std::vector<uint8_t>&) { return true; }
+};
+
+// Satisfies ReversibleDataTransformer
+struct mock_reversible_transformer
+{
+	bool transform(std::vector<uint8_t>&) { return true; }
+	bool reverse_transform(std::vector<uint8_t>&) { return true; }
+};
+
+// Does NOT satisfy DataTransformer (wrong return type)
+struct bad_transformer
+{
+	void transform(std::vector<uint8_t>&) {}
+};
+
+// Mock session for SessionHandler tests
+struct mock_session
+{
+	std::string get_session_id() { return "test-session"; }
+	void start_session() {}
+	void stop_session() {}
+};
+
+// Mock client for NetworkClient tests
+struct mock_client
+{
+	bool is_connected() { return true; }
+	void send_packet(std::vector<uint8_t>) {}
+	void stop_client() {}
+};
+
+// Mock server for NetworkServer tests
+struct mock_server
+{
+	void start_server(unsigned short) {}
+	void stop_server() {}
+};
+
+// ============================================================================
+// ByteBuffer Concept Tests
+// ============================================================================
+
+class ByteBufferConceptTest : public ::testing::Test
+{
+};
+
+TEST_F(ByteBufferConceptTest, VectorUint8Satisfies)
+{
+	static_assert(concepts::ByteBuffer<std::vector<uint8_t>>,
+				  "vector<uint8_t> should satisfy ByteBuffer");
+	SUCCEED();
+}
+
+TEST_F(ByteBufferConceptTest, StringSatisfies)
+{
+	static_assert(concepts::ByteBuffer<std::string>,
+				  "string should satisfy ByteBuffer");
+	SUCCEED();
+}
+
+TEST_F(ByteBufferConceptTest, ArraySatisfies)
+{
+	static_assert(concepts::ByteBuffer<std::array<uint8_t, 16>>,
+				  "array<uint8_t, 16> should satisfy ByteBuffer");
+	SUCCEED();
+}
+
+TEST_F(ByteBufferConceptTest, CustomBufferSatisfies)
+{
+	static_assert(concepts::ByteBuffer<mock_buffer>,
+				  "mock_buffer should satisfy ByteBuffer");
+	SUCCEED();
+}
+
+TEST_F(ByteBufferConceptTest, MissingSizeDoesNotSatisfy)
+{
+	static_assert(!concepts::ByteBuffer<no_size_buffer>,
+				  "no_size_buffer should NOT satisfy ByteBuffer");
+	SUCCEED();
+}
+
+TEST_F(ByteBufferConceptTest, MissingDataDoesNotSatisfy)
+{
+	static_assert(!concepts::ByteBuffer<no_data_buffer>,
+				  "no_data_buffer should NOT satisfy ByteBuffer");
+	SUCCEED();
+}
+
+TEST_F(ByteBufferConceptTest, IntDoesNotSatisfy)
+{
+	static_assert(!concepts::ByteBuffer<int>,
+				  "int should NOT satisfy ByteBuffer");
+	SUCCEED();
+}
+
+// ============================================================================
+// MutableByteBuffer Concept Tests
+// ============================================================================
+
+class MutableByteBufferConceptTest : public ::testing::Test
+{
+};
+
+TEST_F(MutableByteBufferConceptTest, VectorUint8Satisfies)
+{
+	static_assert(concepts::MutableByteBuffer<std::vector<uint8_t>>,
+				  "vector<uint8_t> should satisfy MutableByteBuffer");
+	SUCCEED();
+}
+
+TEST_F(MutableByteBufferConceptTest, CustomMutableBufferSatisfies)
+{
+	static_assert(concepts::MutableByteBuffer<mock_mutable_buffer>,
+				  "mock_mutable_buffer should satisfy MutableByteBuffer");
+	SUCCEED();
+}
+
+TEST_F(MutableByteBufferConceptTest, ConstBufferDoesNotSatisfy)
+{
+	// mock_buffer has no resize() and data() returns const void*
+	static_assert(!concepts::MutableByteBuffer<mock_buffer>,
+				  "mock_buffer should NOT satisfy MutableByteBuffer");
+	SUCCEED();
+}
+
+TEST_F(MutableByteBufferConceptTest, StringSatisfies)
+{
+	static_assert(concepts::MutableByteBuffer<std::string>,
+				  "string should satisfy MutableByteBuffer");
+	SUCCEED();
+}
+
+// ============================================================================
+// Callback Concept Tests
+// ============================================================================
+
+class CallbackConceptTest : public ::testing::Test
+{
+};
+
+TEST_F(CallbackConceptTest, DataReceiveHandlerLambda)
+{
+	auto handler = [](const std::vector<uint8_t>&) {};
+	static_assert(concepts::DataReceiveHandler<decltype(handler)>,
+				  "Lambda should satisfy DataReceiveHandler");
+	SUCCEED();
+}
+
+TEST_F(CallbackConceptTest, DataReceiveHandlerFunction)
+{
+	static_assert(
+		concepts::DataReceiveHandler<std::function<void(const std::vector<uint8_t>&)>>,
+		"std::function should satisfy DataReceiveHandler");
+	SUCCEED();
+}
+
+TEST_F(CallbackConceptTest, ErrorHandlerLambda)
+{
+	auto handler = [](std::error_code) {};
+	static_assert(concepts::ErrorHandler<decltype(handler)>,
+				  "Lambda should satisfy ErrorHandler");
+	SUCCEED();
+}
+
+TEST_F(CallbackConceptTest, ConnectionHandlerLambda)
+{
+	auto handler = []() {};
+	static_assert(concepts::ConnectionHandler<decltype(handler)>,
+				  "Lambda should satisfy ConnectionHandler");
+	SUCCEED();
+}
+
+TEST_F(CallbackConceptTest, DisconnectionHandlerLambda)
+{
+	auto handler = [](const std::string&) {};
+	static_assert(concepts::DisconnectionHandler<decltype(handler)>,
+				  "Lambda should satisfy DisconnectionHandler");
+	SUCCEED();
+}
+
+TEST_F(CallbackConceptTest, RetryCallbackLambda)
+{
+	auto handler = [](std::size_t) {};
+	static_assert(concepts::RetryCallback<decltype(handler)>,
+				  "Lambda should satisfy RetryCallback");
+	SUCCEED();
+}
+
+TEST_F(CallbackConceptTest, SessionHandlerLambda)
+{
+	auto handler = [](std::shared_ptr<mock_session>) {};
+	static_assert(concepts::SessionHandler<decltype(handler), mock_session>,
+				  "Lambda should satisfy SessionHandler");
+	SUCCEED();
+}
+
+TEST_F(CallbackConceptTest, SessionDataHandlerLambda)
+{
+	auto handler = [](std::shared_ptr<mock_session>,
+					  const std::vector<uint8_t>&) {};
+	static_assert(
+		concepts::SessionDataHandler<decltype(handler), mock_session>,
+		"Lambda should satisfy SessionDataHandler");
+	SUCCEED();
+}
+
+TEST_F(CallbackConceptTest, SessionErrorHandlerLambda)
+{
+	auto handler = [](std::shared_ptr<mock_session>, std::error_code) {};
+	static_assert(
+		concepts::SessionErrorHandler<decltype(handler), mock_session>,
+		"Lambda should satisfy SessionErrorHandler");
+	SUCCEED();
+}
+
+// ============================================================================
+// Network Component Concept Tests
+// ============================================================================
+
+class NetworkComponentConceptTest : public ::testing::Test
+{
+};
+
+TEST_F(NetworkComponentConceptTest, MockClientSatisfiesNetworkClient)
+{
+	static_assert(concepts::NetworkClient<mock_client>,
+				  "mock_client should satisfy NetworkClient");
+	SUCCEED();
+}
+
+TEST_F(NetworkComponentConceptTest, MockServerSatisfiesNetworkServer)
+{
+	static_assert(concepts::NetworkServer<mock_server>,
+				  "mock_server should satisfy NetworkServer");
+	SUCCEED();
+}
+
+TEST_F(NetworkComponentConceptTest, MockSessionSatisfiesNetworkSession)
+{
+	static_assert(concepts::NetworkSession<mock_session>,
+				  "mock_session should satisfy NetworkSession");
+	SUCCEED();
+}
+
+TEST_F(NetworkComponentConceptTest, IntDoesNotSatisfyNetworkClient)
+{
+	static_assert(!concepts::NetworkClient<int>,
+				  "int should NOT satisfy NetworkClient");
+	SUCCEED();
+}
+
+// ============================================================================
+// DataTransformer Concept Tests
+// ============================================================================
+
+class DataTransformerConceptTest : public ::testing::Test
+{
+};
+
+TEST_F(DataTransformerConceptTest, MockTransformerSatisfies)
+{
+	static_assert(concepts::DataTransformer<mock_transformer>,
+				  "mock_transformer should satisfy DataTransformer");
+	SUCCEED();
+}
+
+TEST_F(DataTransformerConceptTest, ReversibleTransformerSatisfiesBase)
+{
+	static_assert(concepts::DataTransformer<mock_reversible_transformer>,
+				  "mock_reversible_transformer should satisfy DataTransformer");
+	SUCCEED();
+}
+
+TEST_F(DataTransformerConceptTest, ReversibleTransformerSatisfiesFull)
+{
+	static_assert(
+		concepts::ReversibleDataTransformer<mock_reversible_transformer>,
+		"mock_reversible_transformer should satisfy ReversibleDataTransformer");
+	SUCCEED();
+}
+
+TEST_F(DataTransformerConceptTest, BasicTransformerDoesNotSatisfyReversible)
+{
+	static_assert(!concepts::ReversibleDataTransformer<mock_transformer>,
+				  "mock_transformer should NOT satisfy ReversibleDataTransformer");
+	SUCCEED();
+}
+
+TEST_F(DataTransformerConceptTest, BadTransformerDoesNotSatisfy)
+{
+	static_assert(!concepts::DataTransformer<bad_transformer>,
+				  "bad_transformer should NOT satisfy DataTransformer");
+	SUCCEED();
+}
+
+// ============================================================================
+// Duration Concept Tests
+// ============================================================================
+
+class DurationConceptTest : public ::testing::Test
+{
+};
+
+TEST_F(DurationConceptTest, MillisecondsSatisfies)
+{
+	static_assert(concepts::Duration<std::chrono::milliseconds>,
+				  "milliseconds should satisfy Duration");
+	SUCCEED();
+}
+
+TEST_F(DurationConceptTest, SecondsSatisfies)
+{
+	static_assert(concepts::Duration<std::chrono::seconds>,
+				  "seconds should satisfy Duration");
+	SUCCEED();
+}
+
+TEST_F(DurationConceptTest, MicrosecondsSatisfies)
+{
+	static_assert(concepts::Duration<std::chrono::microseconds>,
+				  "microseconds should satisfy Duration");
+	SUCCEED();
+}
+
+TEST_F(DurationConceptTest, IntDoesNotSatisfy)
+{
+	static_assert(!concepts::Duration<int>,
+				  "int should NOT satisfy Duration");
+	SUCCEED();
+}
+
+TEST_F(DurationConceptTest, StringDoesNotSatisfy)
+{
+	static_assert(!concepts::Duration<std::string>,
+				  "string should NOT satisfy Duration");
+	SUCCEED();
+}

--- a/tests/unit/network_metric_event_test.cpp
+++ b/tests/unit/network_metric_event_test.cpp
@@ -1,0 +1,354 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+*****************************************************************************/
+
+#include "kcenon/network/events/network_metric_event.h"
+#include <gtest/gtest.h>
+
+#include <string>
+
+namespace events = kcenon::network::events;
+
+/**
+ * @file network_metric_event_test.cpp
+ * @brief Unit tests for network metric event structs
+ *
+ * Tests validate:
+ * - network_metric_type enum values
+ * - network_metric_event default and parametric constructors
+ * - network_connection_event default and parametric constructors
+ * - network_transfer_event default and parametric constructors
+ * - network_latency_event default and parametric constructors
+ * - network_health_event default and parametric constructors
+ * - Copy and move semantics for all event types
+ */
+
+// ============================================================================
+// network_metric_type Enum Tests
+// ============================================================================
+
+class NetworkMetricTypeTest : public ::testing::Test
+{
+};
+
+TEST_F(NetworkMetricTypeTest, EnumValuesAreDistinct)
+{
+	auto counter = events::network_metric_type::counter;
+	auto gauge = events::network_metric_type::gauge;
+	auto histogram = events::network_metric_type::histogram;
+	auto summary = events::network_metric_type::summary;
+
+	EXPECT_NE(counter, gauge);
+	EXPECT_NE(counter, histogram);
+	EXPECT_NE(counter, summary);
+	EXPECT_NE(gauge, histogram);
+	EXPECT_NE(gauge, summary);
+	EXPECT_NE(histogram, summary);
+}
+
+// ============================================================================
+// network_metric_event Tests
+// ============================================================================
+
+class NetworkMetricEventTest : public ::testing::Test
+{
+};
+
+TEST_F(NetworkMetricEventTest, DefaultConstructor)
+{
+	events::network_metric_event event;
+
+	EXPECT_TRUE(event.name.empty());
+	EXPECT_DOUBLE_EQ(event.value, 0.0);
+	EXPECT_TRUE(event.unit.empty());
+	EXPECT_EQ(event.type, events::network_metric_type::counter);
+	EXPECT_TRUE(event.labels.empty());
+}
+
+TEST_F(NetworkMetricEventTest, ParametricConstructorMinimal)
+{
+	events::network_metric_event event("cpu.usage", 75.5);
+
+	EXPECT_EQ(event.name, "cpu.usage");
+	EXPECT_DOUBLE_EQ(event.value, 75.5);
+	EXPECT_EQ(event.type, events::network_metric_type::counter);
+	EXPECT_TRUE(event.labels.empty());
+	EXPECT_TRUE(event.unit.empty());
+}
+
+TEST_F(NetworkMetricEventTest, ParametricConstructorFull)
+{
+	std::map<std::string, std::string> labels = {{"host", "server1"},
+												  {"region", "us-east"}};
+	events::network_metric_event event("network.bytes_sent", 1024.0,
+									   events::network_metric_type::histogram,
+									   labels, "bytes");
+
+	EXPECT_EQ(event.name, "network.bytes_sent");
+	EXPECT_DOUBLE_EQ(event.value, 1024.0);
+	EXPECT_EQ(event.type, events::network_metric_type::histogram);
+	EXPECT_EQ(event.unit, "bytes");
+	EXPECT_EQ(event.labels.size(), 2);
+	EXPECT_EQ(event.labels.at("host"), "server1");
+}
+
+TEST_F(NetworkMetricEventTest, TimestampIsSet)
+{
+	auto before = std::chrono::steady_clock::now();
+	events::network_metric_event event("test", 1.0);
+	auto after = std::chrono::steady_clock::now();
+
+	EXPECT_GE(event.timestamp, before);
+	EXPECT_LE(event.timestamp, after);
+}
+
+TEST_F(NetworkMetricEventTest, CopySemantics)
+{
+	events::network_metric_event original("test.metric", 42.0,
+										  events::network_metric_type::gauge);
+
+	events::network_metric_event copy(original);
+
+	EXPECT_EQ(copy.name, original.name);
+	EXPECT_DOUBLE_EQ(copy.value, original.value);
+	EXPECT_EQ(copy.type, original.type);
+}
+
+TEST_F(NetworkMetricEventTest, MoveSemantics)
+{
+	events::network_metric_event original("test.metric", 42.0);
+	std::string original_name = original.name;
+
+	events::network_metric_event moved(std::move(original));
+
+	EXPECT_EQ(moved.name, original_name);
+	EXPECT_DOUBLE_EQ(moved.value, 42.0);
+}
+
+// ============================================================================
+// network_connection_event Tests
+// ============================================================================
+
+class NetworkConnectionEventTest : public ::testing::Test
+{
+};
+
+TEST_F(NetworkConnectionEventTest, DefaultConstructor)
+{
+	events::network_connection_event event;
+
+	EXPECT_TRUE(event.connection_id.empty());
+	EXPECT_TRUE(event.event_type.empty());
+	EXPECT_TRUE(event.protocol.empty());
+	EXPECT_TRUE(event.remote_address.empty());
+	EXPECT_TRUE(event.labels.empty());
+}
+
+TEST_F(NetworkConnectionEventTest, ParametricConstructorMinimal)
+{
+	events::network_connection_event event("conn-123", "accepted");
+
+	EXPECT_EQ(event.connection_id, "conn-123");
+	EXPECT_EQ(event.event_type, "accepted");
+	EXPECT_EQ(event.protocol, "tcp");
+	EXPECT_TRUE(event.remote_address.empty());
+}
+
+TEST_F(NetworkConnectionEventTest, ParametricConstructorFull)
+{
+	std::map<std::string, std::string> labels = {{"tls", "true"}};
+	events::network_connection_event event("conn-456", "closed", "websocket",
+										   "192.168.1.1:8080", labels);
+
+	EXPECT_EQ(event.connection_id, "conn-456");
+	EXPECT_EQ(event.event_type, "closed");
+	EXPECT_EQ(event.protocol, "websocket");
+	EXPECT_EQ(event.remote_address, "192.168.1.1:8080");
+	EXPECT_EQ(event.labels.at("tls"), "true");
+}
+
+TEST_F(NetworkConnectionEventTest, CopyAndMoveSemantics)
+{
+	events::network_connection_event original("conn-1", "accepted", "quic");
+
+	events::network_connection_event copy(original);
+	EXPECT_EQ(copy.connection_id, "conn-1");
+	EXPECT_EQ(copy.protocol, "quic");
+
+	events::network_connection_event moved(std::move(copy));
+	EXPECT_EQ(moved.connection_id, "conn-1");
+}
+
+// ============================================================================
+// network_transfer_event Tests
+// ============================================================================
+
+class NetworkTransferEventTest : public ::testing::Test
+{
+};
+
+TEST_F(NetworkTransferEventTest, DefaultConstructor)
+{
+	events::network_transfer_event event;
+
+	EXPECT_TRUE(event.connection_id.empty());
+	EXPECT_TRUE(event.direction.empty());
+	EXPECT_EQ(event.bytes, 0);
+	EXPECT_EQ(event.packets, 0);
+	EXPECT_TRUE(event.labels.empty());
+}
+
+TEST_F(NetworkTransferEventTest, ParametricConstructorMinimal)
+{
+	events::network_transfer_event event("conn-1", "sent", 4096);
+
+	EXPECT_EQ(event.connection_id, "conn-1");
+	EXPECT_EQ(event.direction, "sent");
+	EXPECT_EQ(event.bytes, 4096);
+	EXPECT_EQ(event.packets, 1);
+}
+
+TEST_F(NetworkTransferEventTest, ParametricConstructorFull)
+{
+	std::map<std::string, std::string> labels = {{"stream", "0"}};
+	events::network_transfer_event event("conn-2", "received", 65536, 10,
+										 labels);
+
+	EXPECT_EQ(event.bytes, 65536);
+	EXPECT_EQ(event.packets, 10);
+	EXPECT_EQ(event.labels.at("stream"), "0");
+}
+
+TEST_F(NetworkTransferEventTest, CopyAndMoveSemantics)
+{
+	events::network_transfer_event original("conn-1", "sent", 1024, 2);
+
+	events::network_transfer_event copy(original);
+	EXPECT_EQ(copy.bytes, 1024);
+
+	events::network_transfer_event moved(std::move(copy));
+	EXPECT_EQ(moved.bytes, 1024);
+	EXPECT_EQ(moved.packets, 2);
+}
+
+// ============================================================================
+// network_latency_event Tests
+// ============================================================================
+
+class NetworkLatencyEventTest : public ::testing::Test
+{
+};
+
+TEST_F(NetworkLatencyEventTest, DefaultConstructor)
+{
+	events::network_latency_event event;
+
+	EXPECT_TRUE(event.connection_id.empty());
+	EXPECT_DOUBLE_EQ(event.latency_ms, 0.0);
+	EXPECT_TRUE(event.operation.empty());
+	EXPECT_TRUE(event.labels.empty());
+}
+
+TEST_F(NetworkLatencyEventTest, ParametricConstructorMinimal)
+{
+	events::network_latency_event event("conn-1", 15.5);
+
+	EXPECT_EQ(event.connection_id, "conn-1");
+	EXPECT_DOUBLE_EQ(event.latency_ms, 15.5);
+	EXPECT_EQ(event.operation, "roundtrip");
+}
+
+TEST_F(NetworkLatencyEventTest, ParametricConstructorFull)
+{
+	std::map<std::string, std::string> labels = {{"endpoint", "/api/data"}};
+	events::network_latency_event event("conn-2", 250.0, "request", labels);
+
+	EXPECT_EQ(event.connection_id, "conn-2");
+	EXPECT_DOUBLE_EQ(event.latency_ms, 250.0);
+	EXPECT_EQ(event.operation, "request");
+	EXPECT_EQ(event.labels.at("endpoint"), "/api/data");
+}
+
+TEST_F(NetworkLatencyEventTest, CopyAndMoveSemantics)
+{
+	events::network_latency_event original("conn-1", 100.0, "response");
+
+	events::network_latency_event copy(original);
+	EXPECT_DOUBLE_EQ(copy.latency_ms, 100.0);
+
+	events::network_latency_event moved(std::move(copy));
+	EXPECT_DOUBLE_EQ(moved.latency_ms, 100.0);
+	EXPECT_EQ(moved.operation, "response");
+}
+
+// ============================================================================
+// network_health_event Tests
+// ============================================================================
+
+class NetworkHealthEventTest : public ::testing::Test
+{
+};
+
+TEST_F(NetworkHealthEventTest, DefaultConstructor)
+{
+	events::network_health_event event;
+
+	EXPECT_TRUE(event.connection_id.empty());
+	EXPECT_FALSE(event.is_alive);
+	EXPECT_DOUBLE_EQ(event.response_time_ms, 0.0);
+	EXPECT_EQ(event.missed_heartbeats, 0);
+	EXPECT_DOUBLE_EQ(event.packet_loss_rate, 0.0);
+	EXPECT_TRUE(event.labels.empty());
+}
+
+TEST_F(NetworkHealthEventTest, ParametricConstructorMinimal)
+{
+	events::network_health_event event("conn-1", true);
+
+	EXPECT_EQ(event.connection_id, "conn-1");
+	EXPECT_TRUE(event.is_alive);
+	EXPECT_DOUBLE_EQ(event.response_time_ms, 0.0);
+	EXPECT_EQ(event.missed_heartbeats, 0);
+	EXPECT_DOUBLE_EQ(event.packet_loss_rate, 0.0);
+}
+
+TEST_F(NetworkHealthEventTest, ParametricConstructorFull)
+{
+	std::map<std::string, std::string> labels = {{"server", "primary"}};
+	events::network_health_event event("conn-2", false, 500.0, 3, 0.15,
+									   labels);
+
+	EXPECT_EQ(event.connection_id, "conn-2");
+	EXPECT_FALSE(event.is_alive);
+	EXPECT_DOUBLE_EQ(event.response_time_ms, 500.0);
+	EXPECT_EQ(event.missed_heartbeats, 3);
+	EXPECT_DOUBLE_EQ(event.packet_loss_rate, 0.15);
+	EXPECT_EQ(event.labels.at("server"), "primary");
+}
+
+TEST_F(NetworkHealthEventTest, CopyAndMoveSemantics)
+{
+	events::network_health_event original("conn-1", true, 10.0, 0, 0.0);
+
+	events::network_health_event copy(original);
+	EXPECT_TRUE(copy.is_alive);
+	EXPECT_DOUBLE_EQ(copy.response_time_ms, 10.0);
+
+	events::network_health_event moved(std::move(copy));
+	EXPECT_TRUE(moved.is_alive);
+	EXPECT_EQ(moved.connection_id, "conn-1");
+}
+
+TEST_F(NetworkHealthEventTest, AliveToDeadTransition)
+{
+	events::network_health_event alive("conn-1", true, 5.0, 0, 0.0);
+	events::network_health_event dead("conn-1", false, 0.0, 4, 0.75);
+
+	EXPECT_TRUE(alive.is_alive);
+	EXPECT_FALSE(dead.is_alive);
+	EXPECT_GT(dead.missed_heartbeats, alive.missed_heartbeats);
+	EXPECT_GT(dead.packet_loss_rate, alive.packet_loss_rate);
+}


### PR DESCRIPTION
Closes #731

## Summary
- Add 24 unit tests for `network_metric_event.h` event structs: `network_metric_event`, `network_connection_event`, `network_transfer_event`, `network_latency_event`, `network_health_event`, and `network_metric_type` enum
- Add 34 unit tests for `network_concepts.h` C++20 concepts: `ByteBuffer`, `MutableByteBuffer`, `DataReceiveHandler`, `ErrorHandler`, `ConnectionHandler`, `SessionHandler`, `SessionDataHandler`, `SessionErrorHandler`, `DisconnectionHandler`, `RetryCallback`, `NetworkClient`, `NetworkServer`, `NetworkSession`, `DataTransformer`, `ReversibleDataTransformer`, `Duration`
- Register both test targets in `tests/CMakeLists.txt`

## Test Plan
- [x] `network_metric_event_test`: 24 tests passed across 6 test suites
- [x] `network_concepts_test`: 34 tests passed across 6 test suites
- [x] Full build completes without errors