### PR TITLE
chore(deps): pin zlib minimum version to 1.3

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -45,6 +45,7 @@ The pinned ASIO version must be kept in sync across:
 |--------------------|--------------------------------------------- --|
 | Component          | zlib compression library                       |
 | License            | zlib License                                   |
+| Minimum Version    | 1.3 (CVE-2023-45853 fix)                       |
 | Usage              | HTTP compression support                       |
 | Linking            | Dynamic (shared library)                       |
 | BSD-3 Compatible   | Yes                                            |

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -16,7 +16,10 @@
       "name": "fmt",
       "version>=": "10.0.0"
     },
-    "zlib"
+    {
+      "name": "zlib",
+      "version>=": "1.3"
+    }
   ],
   "features": {
     "ecosystem": {


### PR DESCRIPTION
## Summary

- Pin zlib dependency to `>= 1.3` (CVE-2023-45853 fix release)
- Add minimum version info to LICENSE-THIRD-PARTY
- vcpkg baseline already resolves 1.3.1, so the constraint is satisfied

## Test Plan

- [x] `vcpkg.json` passes JSON validation
- [x] CI build succeeds with pinned version constraint

Closes #786