### PR TITLE
Add vcpkg version overrides for IEC 62304 compliance

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -15,6 +15,15 @@
     },
     "zlib"
   ],
+  "overrides": [
+    { "name": "asio", "version": "1.30.2" },
+    { "name": "fmt", "version": "10.2.1" },
+    { "name": "zlib", "version": "1.3.1" },
+    { "name": "openssl", "version": "3.3.0" },
+    { "name": "lz4", "version": "1.9.4" },
+    { "name": "gtest", "version": "1.14.0" },
+    { "name": "benchmark", "version": "1.8.3" }
+  ],
   "features": {
     "ecosystem": {
       "description": "Enable kcenon ecosystem dependencies (requires vcpkg registry registration)",


### PR DESCRIPTION
## Summary
Add vcpkg version overrides to pin exact SOUP versions for IEC 62304 Clause 8.1.2 compliance (configuration items shall be uniquely identified).

Versions are pinned from vcpkg baseline c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d.

## Motivation
- Closes the gap between web/server SOUP version pinning (npm ci, pip --require-hashes) and C++ ecosystem
- Ensures reproducible builds even if vcpkg baseline is updated
- Refs kcenon/flonics_project#245

## Test plan
- [x] Verify vcpkg.json is valid JSON
- [x] Verify overrides match baseline versions
- [x] Verify CI build succeeds with pinned versions