### PR TITLE
chore(deps): align gRPC minimum version to ecosystem standard (1.51.1)

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -61,6 +61,41 @@ The pinned ASIO version must be kept in sync across:
 | Linking            | Dynamic (shared library)                       |
 | BSD-3 Compatible   | Yes                                            |
 
+## LZ4 (Optional — compression)
+
+| Item               | Value                                          |
+|--------------------|----------------------------------------------|
+| Component          | LZ4 compression library                        |
+| License            | BSD-2-Clause                                   |
+| Pinned Version     | 1.9.4                                          |
+| Usage              | LZ4 compression support                        |
+| Linking            | Dynamic (shared library)                       |
+| BSD-3 Compatible   | Yes                                            |
+
+## gRPC (Optional — NETWORK_ENABLE_GRPC_OFFICIAL)
+
+| Item               | Value                                          |
+|--------------------|----------------------------------------------|
+| Component          | gRPC C++ framework                             |
+| License            | Apache-2.0                                     |
+| Pinned Version     | 1.51.1                                         |
+| Usage              | Official gRPC protocol support                 |
+| Linking            | Dynamic (shared library)                       |
+| BSD-3 Compatible   | Yes                                            |
+| Condition          | Enabled when NETWORK_ENABLE_GRPC_OFFICIAL=ON   |
+
+## Protocol Buffers (Optional — with gRPC)
+
+| Item               | Value                                          |
+|--------------------|----------------------------------------------|
+| Component          | Google Protocol Buffers                        |
+| License            | BSD-3-Clause                                   |
+| Pinned Version     | 3.21.12                                        |
+| Usage              | Serialization for gRPC service definitions     |
+| Linking            | Dynamic (shared library)                       |
+| BSD-3 Compatible   | Yes                                            |
+| Condition          | Enabled when NETWORK_ENABLE_GRPC_OFFICIAL=ON   |
+
 ## All Dependencies (License Summary)
 
 | Dependency        | License        | Type     | BSD-3 Compatible |
@@ -69,5 +104,8 @@ The pinned ASIO version must be kept in sync across:
 | fmt               | MIT            | Core     | Yes              |
 | zlib              | zlib           | Core     | Yes              |
 | OpenSSL           | Apache-2.0     | Optional | Yes              |
+| LZ4               | BSD-2-Clause   | Optional | Yes              |
+| gRPC              | Apache-2.0     | Optional | Yes              |
+| Protocol Buffers  | BSD-3-Clause   | Optional | Yes              |
 | GTest/GMock       | BSD-3-Clause   | Testing  | Yes              |
 | Google Benchmark  | Apache-2.0     | Testing  | Yes              |

--- a/cmake/NetworkSystemDependencies.cmake
+++ b/cmake/NetworkSystemDependencies.cmake
@@ -682,8 +682,8 @@ endfunction()
 #   - vcpkg:  vcpkg install grpc
 #
 # Required versions:
-#   - grpc++ >= 1.50.0
-#   - protobuf >= 3.21.0
+#   - grpc++ >= 1.51.1
+#   - protobuf >= 3.21.12
 #   - abseil (bundled with grpc, but may need explicit linking)
 ##################################################
 function(find_grpc_library)
@@ -702,8 +702,8 @@ function(find_grpc_library)
         # Get version if available
         if(DEFINED gRPC_VERSION)
             message(STATUS "  gRPC version: ${gRPC_VERSION}")
-            if(gRPC_VERSION VERSION_LESS "1.50.0")
-                message(WARNING "gRPC version ${gRPC_VERSION} is below recommended 1.50.0")
+            if(gRPC_VERSION VERSION_LESS "1.51.1")
+                message(WARNING "gRPC version ${gRPC_VERSION} is below recommended 1.51.1")
             endif()
         endif()
 
@@ -714,8 +714,8 @@ function(find_grpc_library)
         endif()
         message(STATUS "  Protobuf version: ${Protobuf_VERSION}")
 
-        if(Protobuf_VERSION VERSION_LESS "3.21.0")
-            message(WARNING "Protobuf version ${Protobuf_VERSION} is below recommended 3.21.0")
+        if(Protobuf_VERSION VERSION_LESS "3.21.12")
+            message(WARNING "Protobuf version ${Protobuf_VERSION} is below recommended 3.21.12")
         endif()
 
         # Find absl (required by gRPC >= 1.50)
@@ -781,8 +781,8 @@ function(find_grpc_library)
     message(WARNING "  Windows: vcpkg install grpc:x64-windows")
     message(WARNING "")
     message(WARNING "Required versions:")
-    message(WARNING "  grpc++ >= 1.50.0")
-    message(WARNING "  protobuf >= 3.21.0")
+    message(WARNING "  grpc++ >= 1.51.1")
+    message(WARNING "  protobuf >= 3.21.12")
     message(WARNING "========================================")
 
     set(GRPC_FOUND FALSE PARENT_SCOPE)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -27,6 +27,8 @@
     { "name": "zlib", "version": "1.3.1" },
     { "name": "openssl", "version": "3.3.0" },
     { "name": "lz4", "version": "1.9.4" },
+    { "name": "grpc", "version": "1.51.1" },
+    { "name": "protobuf", "version": "3.21.12" },
     { "name": "gtest", "version": "1.14.0" },
     { "name": "benchmark", "version": "1.8.3" }
   ],


### PR DESCRIPTION
## Summary

- Align gRPC minimum version from 1.50.0 to ecosystem standard 1.51.1
- Align Protobuf minimum version from 3.21.0 to ecosystem standard 3.21.12
- Add gRPC and Protobuf version overrides to `vcpkg.json`
- Document gRPC, Protobuf, and LZ4 in `LICENSE-THIRD-PARTY`

## Why

SBOM analysis revealed gRPC version drift across the ecosystem:
- logger_system: gRPC >= 1.51.1
- monitoring_system: gRPC 1.51.1 (pinned)
- network_system: gRPC >= 1.50.0 (lower minimum)

Unified version tracking simplifies CVE assessment and prevents ABI issues
when systems are composed together.

Closes #792

## Where

| File | Change |
|------|--------|
| `cmake/NetworkSystemDependencies.cmake` | Version checks 1.50.0 -> 1.51.1, 3.21.0 -> 3.21.12 |
| `vcpkg.json` | Add grpc 1.51.1 and protobuf 3.21.12 overrides |
| `LICENSE-THIRD-PARTY` | Add gRPC, Protobuf, LZ4 entries |

## Test plan

- [x] CMake configuration succeeds with gRPC disabled (default)
- [x] Version check logic warns correctly for older gRPC versions
- [x] vcpkg.json is valid JSON and parses correctly
- [x] LICENSE-THIRD-PARTY documents all dependencies in vcpkg.json