### PR TITLE
chore(deps): add vcpkg overlay port for kcenon-network-system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ compile_commands.json
 !CMakeLists.txt
 !cmake/*.cmake
 !cmake/*.cmake.in
+!vcpkg-ports/**/*.cmake
 
 # CMake presets (user-specific)
 CMakeUserPresets.json

--- a/vcpkg-ports/kcenon-network-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-network-system/portfile.cmake
@@ -1,0 +1,69 @@
+# kcenon-network-system portfile
+# High-performance C++20 asynchronous network system with multi-protocol support
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO kcenon/network_system
+    REF e52be358d3fcddca86522a2326e748f127caa559
+    SHA512 0  # TODO: Update with actual SHA512 hash after release
+    HEAD_REF main
+)
+
+# Feature-based protocol and option selection
+set(NET_BUILD_TLS OFF)
+if("tls" IN_LIST FEATURES)
+    set(NET_BUILD_TLS ON)
+endif()
+
+set(NET_BUILD_WEBSOCKET OFF)
+if("websocket" IN_LIST FEATURES)
+    set(NET_BUILD_WEBSOCKET ON)
+endif()
+
+set(NET_BUILD_LZ4 OFF)
+if("lz4-compression" IN_LIST FEATURES)
+    set(NET_BUILD_LZ4 ON)
+endif()
+
+set(NET_BUILD_ZLIB OFF)
+if("zlib-compression" IN_LIST FEATURES)
+    set(NET_BUILD_ZLIB ON)
+endif()
+
+set(NET_ENABLE_GRPC OFF)
+if("grpc" IN_LIST FEATURES)
+    set(NET_ENABLE_GRPC ON)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TLS_SUPPORT=${NET_BUILD_TLS}
+        -DBUILD_WEBSOCKET_SUPPORT=${NET_BUILD_WEBSOCKET}
+        -DBUILD_LZ4_COMPRESSION=${NET_BUILD_LZ4}
+        -DBUILD_ZLIB_COMPRESSION=${NET_BUILD_ZLIB}
+        -DNETWORK_ENABLE_GRPC_OFFICIAL=${NET_ENABLE_GRPC}
+        -DBUILD_TESTS=OFF
+        -DBUILD_SAMPLES=OFF
+        -DNETWORK_BUILD_BENCHMARKS=OFF
+        -DNETWORK_BUILD_INTEGRATION_TESTS=OFF
+        -DBUILD_SHARED_LIBS=OFF
+        -DBUILD_MESSAGING_BRIDGE=OFF
+        -DBUILD_WITH_LOGGER_SYSTEM=OFF
+        -DBUILD_WITH_CONTAINER_SYSTEM=OFF
+        -DBUILD_WITH_MONITORING_SYSTEM=OFF
+        -DBUILD_VERIFY_BUILD=OFF
+        -DNETWORK_BUILD_MODULES=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME NetworkSystem
+    CONFIG_PATH lib/cmake/NetworkSystem
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-ports/kcenon-network-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-network-system/vcpkg.json
@@ -1,0 +1,94 @@
+{
+  "name": "kcenon-network-system",
+  "version": "0.1.0",
+  "port-version": 0,
+  "description": "High-performance C++20 asynchronous network system with multi-protocol support",
+  "homepage": "https://github.com/kcenon/network_system",
+  "license": "BSD-3-Clause",
+  "supports": "!(uwp | xbox)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "kcenon-common-system",
+    "kcenon-thread-system",
+    {
+      "name": "asio",
+      "version>=": "1.30.2"
+    }
+  ],
+  "default-features": [
+    "tls",
+    "websocket",
+    "lz4-compression",
+    "zlib-compression"
+  ],
+  "features": {
+    "tls": {
+      "description": "Enable TLS/SSL support (TLS 1.2/1.3)",
+      "dependencies": [
+        {
+          "name": "openssl",
+          "version>=": "3.0.0"
+        }
+      ]
+    },
+    "websocket": {
+      "description": "Enable WebSocket protocol support (RFC 6455)",
+      "dependencies": [
+        {
+          "name": "openssl",
+          "version>=": "3.0.0"
+        }
+      ]
+    },
+    "http2": {
+      "description": "Enable HTTP/2 protocol support (requires TLS for ALPN)",
+      "dependencies": [
+        {
+          "name": "kcenon-network-system",
+          "default-features": false,
+          "features": [
+            "tls"
+          ]
+        }
+      ]
+    },
+    "quic": {
+      "description": "Enable QUIC protocol support (RFC 9000, experimental)",
+      "dependencies": [
+        {
+          "name": "kcenon-network-system",
+          "default-features": false,
+          "features": [
+            "tls"
+          ]
+        }
+      ]
+    },
+    "grpc": {
+      "description": "Enable official gRPC library integration",
+      "dependencies": [
+        "grpc",
+        "protobuf"
+      ]
+    },
+    "lz4-compression": {
+      "description": "Enable LZ4 compression support",
+      "dependencies": [
+        "lz4"
+      ]
+    },
+    "zlib-compression": {
+      "description": "Enable ZLIB compression support (gzip/deflate)",
+      "dependencies": [
+        "zlib"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Closes #816

## Summary

- Add vcpkg overlay port definition (`vcpkg-ports/kcenon-network-system/`)
- Feature-based protocol and compression selection
- Follows established ecosystem port patterns (common_system, thread_system, etc.)
- Add `.gitignore` exception for `vcpkg-ports/**/*.cmake`

## Port Details

| File | Purpose |
|------|---------|
| `vcpkg-ports/kcenon-network-system/vcpkg.json` | Package manifest with protocol features |
| `vcpkg-ports/kcenon-network-system/portfile.cmake` | Build recipe with feature-conditional CMake options |

### Features

| Feature | Default | Dependencies | Status |
|---------|---------|-------------|--------|
| `tls` | Yes | openssl (>=3.0.0) | Stable |
| `websocket` | Yes | openssl (>=3.0.0) | Stable |
| `http2` | No | tls (self-dependency) | Stable |
| `quic` | No | tls (self-dependency) | Experimental |
| `grpc` | No | grpc, protobuf | Experimental |
| `lz4-compression` | Yes | lz4 | Stable |
| `zlib-compression` | Yes | zlib | Stable |

### Base Dependencies (always included)

- `kcenon-common-system` (Tier 0)
- `kcenon-thread-system` (Tier 1)
- `asio` (>=1.30.2)

### Usage

```bash
# Install with default features (tls, websocket, lz4, zlib)
vcpkg install kcenon-network-system --overlay-ports=./vcpkg-ports

# Install with specific protocol features
vcpkg install kcenon-network-system[tls,websocket,http2] --overlay-ports=./vcpkg-ports

# Install core only (no TLS, no WebSocket)
vcpkg install kcenon-network-system[core] --overlay-ports=./vcpkg-ports
```

## Test Plan

- [ ] `vcpkg install kcenon-network-system[tls,websocket]` succeeds
- [ ] Transitive dependencies (common_system, thread_system) auto-resolved
- [ ] `find_package(NetworkSystem CONFIG)` works in test consumer
- [ ] SHA512 hash validation (currently set to 0 for development)