### PR TITLE
fix(ci): use matrix variable for build shell in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,15 @@ jobs:
           - os: ubuntu-latest
             artifact_name: network_system-linux-x64
             archive_ext: tar.gz
+            build_shell: bash
           - os: macos-latest
             artifact_name: network_system-macos-x64
             archive_ext: tar.gz
+            build_shell: bash
           - os: windows-latest
             artifact_name: network_system-windows-x64
             archive_ext: zip
+            build_shell: msys2 {0}
 
     steps:
     - uses: actions/checkout@v6
@@ -64,7 +67,7 @@ jobs:
           mingw-w64-x86_64-gcc
 
     - name: Configure CMake
-      shell: ${{ matrix.os == 'windows-latest' && 'msys2 {0}' || 'bash' }}
+      shell: ${{ matrix.build_shell }}
       run: |
         cmake -B build -G Ninja \
           -DCMAKE_BUILD_TYPE=Release \
@@ -79,13 +82,13 @@ jobs:
           -DBUILD_SAMPLES=OFF
 
     - name: Build
-      shell: ${{ matrix.os == 'windows-latest' && 'msys2 {0}' || 'bash' }}
+      shell: ${{ matrix.build_shell }}
       run: |
         cmake --build build --config Release
         cmake --install build
 
     - name: Run Tests
-      shell: ${{ matrix.os == 'windows-latest' && 'msys2 {0}' || 'bash' }}
+      shell: ${{ matrix.build_shell }}
       run: |
         cd build
         ctest --output-on-failure --timeout 60


### PR DESCRIPTION
Closes #830

## Summary
- Fix release workflow parsing failure by moving shell specification from inline expression to matrix variable
- Previous approach `${{ matrix.os == 'windows-latest' && 'msys2 {0}' || 'bash' }}` caused GitHub Actions to fail with 0 jobs (expression parsing error due to `{0}`)
- New approach adds `build_shell` to matrix include entries and references via `${{ matrix.build_shell }}`

## Root Cause
GitHub Actions expression parser cannot handle `{0}` inside `${{ }}` expressions. The `{0}` is a shell placeholder for the script file path, but the expression evaluator treats it as invalid syntax.

## Test Plan
- [ ] Release workflow YAML is parseable (jobs actually start)
- [ ] Windows build uses MSYS2 shell correctly
- [ ] Linux/macOS builds use bash shell correctly