### PR TITLE
fix(ci): quote msys2 shell value in release workflow matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           - os: windows-latest
             artifact_name: network_system-windows-x64
             archive_ext: zip
-            build_shell: msys2 {0}
+            build_shell: 'msys2 {0}'
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Closes #830

## Summary
- Quote `msys2 {0}` value in release workflow matrix to fix YAML parsing error
- YAML interprets unquoted `{0}` as flow mapping syntax, causing 0 jobs to start

## Root Cause
In YAML, `{0}` without quotes is interpreted as a flow mapping `{0: null}`. This causes the entire workflow file to fail parsing at the GitHub Actions level, resulting in immediate failure with 0 jobs.

Fix: `build_shell: 'msys2 {0}'` (single-quoted)

## Test Plan
- [ ] Release workflow parses correctly (jobs actually start)
- [ ] Windows build uses MSYS2 shell
- [ ] Linux/macOS builds use bash