### PR TITLE
docs: replace GIT_TAG main with tagged versions in FetchContent examples

### DIFF
--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -180,31 +180,31 @@ include(FetchContent)
 FetchContent_Declare(
     common_system
     GIT_REPOSITORY https://github.com/kcenon/common_system.git
-    GIT_TAG main
+    GIT_TAG v0.2.0 # Pin to a specific release tag; do NOT use main
 )
 
 FetchContent_Declare(
     thread_system
     GIT_REPOSITORY https://github.com/kcenon/thread_system.git
-    GIT_TAG main
+    GIT_TAG v0.3.0 # Pin to a specific release tag; do NOT use main
 )
 
 FetchContent_Declare(
     logger_system
     GIT_REPOSITORY https://github.com/kcenon/logger_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0 # Pin to a specific release tag; do NOT use main
 )
 
 FetchContent_Declare(
     container_system
     GIT_REPOSITORY https://github.com/kcenon/container_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0 # Pin to a specific release tag; do NOT use main
 )
 
 FetchContent_Declare(
     network_system
     GIT_REPOSITORY https://github.com/kcenon/network_system.git
-    GIT_TAG main
+    GIT_TAG v0.1.0 # Pin to a specific release tag; do NOT use main
 )
 
 FetchContent_MakeAvailable(common_system thread_system logger_system container_system network_system)


### PR DESCRIPTION
## Summary

- Replace all `GIT_TAG main` references with pinned release tags in FetchContent examples
- Prevents users from copy-pasting non-reproducible build configurations

Part of kcenon/common_system#448

## Changed Files

- `docs/guides/QUICK_START.md` — Updated 5 FetchContent declarations:
  - `common_system`: `main` -> `v0.2.0`
  - `thread_system`: `main` -> `v0.3.0`
  - `logger_system`: `main` -> `v0.1.0`
  - `container_system`: `main` -> `v0.1.0`
  - `network_system`: `main` -> `v0.1.0`

## Test Plan

- [x] Verify all `GIT_TAG main` references are replaced
- [x] Confirm tagged versions match each library's latest release