### PR TITLE
chore(vcpkg): update portfile REF to v0.1.1 and fix SHA512 placeholder

### DIFF
--- a/vcpkg-ports/kcenon-network-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-network-system/portfile.cmake
@@ -4,8 +4,8 @@
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kcenon/network_system
-    REF e52be358d3fcddca86522a2326e748f127caa559
-    SHA512 0  # TODO: Update with actual SHA512 hash after release
+    REF v0.1.1
+    SHA512 2d147a3eac787919842c0d74c80eaf560e761b90dd435ba2f8d7d9459bf2a79d3dd637d20abe7204ffc72b98e82e4c0a6384b9a20ef8282777da05fca994304d
     HEAD_REF main
 )
 

--- a/vcpkg-ports/kcenon-network-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-network-system/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kcenon-network-system",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "port-version": 0,
   "description": "High-performance C++20 asynchronous network system with multi-protocol support",
   "homepage": "https://github.com/kcenon/network_system",


### PR DESCRIPTION
## What

Updates the local vcpkg overlay port to use the stable `v0.1.1` release tag instead of a raw commit hash, and replaces the `SHA512 0` placeholder with the actual computed hash.

### Change Type
- [x] Chore (maintenance, no functional changes)

### Affected Components
- `vcpkg-ports/kcenon-network-system/portfile.cmake`
- `vcpkg-ports/kcenon-network-system/vcpkg.json`

## Why

### Problem Solved
- `SHA512 0` in `portfile.cmake` made the port unbuildable — vcpkg rejects any download whose hash does not match
- Raw commit hash REF (`e52be35...`) lacks semantic version tracking and prevents stable registry submissions
- Port version `0.1.0` was stale; GitHub releases `v0.1.0` and `v0.1.1` already exist

### Related Issues
- Closes #837

### Analysis
During investigation, two fixes from the `monitoring_system` central portfile were found to be **already merged upstream** in `v0.1.1`:
1. `kcenon::common_system` target candidate — already in `cmake/NetworkSystemDependencies.cmake:475`
2. `find_dependency(OpenSSL)` / `find_dependency(ZLIB)` — already in `cmake/NetworkSystemConfig.cmake.in`

The local portfile retains fine-grained feature flags (tls, websocket, lz4-compression, zlib-compression, grpc, http2, quic) rather than hardcoding options, keeping it flexible for downstream users.

## How

### Changes Made
| File | Before | After |
|------|--------|-------|
| `portfile.cmake` REF | `e52be358...` (raw commit) | `v0.1.1` (semver tag) |
| `portfile.cmake` SHA512 | `0` (placeholder) | actual SHA512 of v0.1.1 archive |
| `vcpkg.json` version | `0.1.0` | `0.1.1` |

### SHA512 Verification
```
shasum -a 512 network_system-v0.1.1.tar.gz
2d147a3eac787919842c0d74c80eaf560e761b90dd435ba2f8d7d9459bf2a79d3dd637d20abe7204ffc72b98e82e4c0a6384b9a20ef8282777da05fca994304d
```
Source: `https://github.com/kcenon/network_system/archive/refs/tags/v0.1.1.tar.gz`

### Testing
- [ ] `vcpkg install kcenon-network-system --overlay-ports=vcpkg-ports` with vcpkg installed

### Breaking Changes
None — port metadata update only.

## Notes for Central Registry (monitoring_system)
The central portfile at `monitoring_system/vcpkg-ports/kcenon-network-system/` also needs its REF updated from `c0c907b...` to `v0.1.1` and its now-redundant patch/workarounds removed. This is tracked separately in that repository.