### PR TITLE
fix(cmake): make OpenSSL dependency conditional on TLS/WebSocket features

### DIFF
--- a/cmake/network_system-config.cmake.in
+++ b/cmake/network_system-config.cmake.in
@@ -8,7 +8,18 @@ include(CMakeFindDependencyMacro)
 
 # Find required dependencies
 find_dependency(Threads REQUIRED)
-find_dependency(OpenSSL REQUIRED)
+
+# OpenSSL: required when TLS support or WebSocket support (SHA-1 handshake) was enabled
+set(_NETWORK_WITH_TLS @BUILD_TLS_SUPPORT@)
+set(_NETWORK_WITH_WEBSOCKET @BUILD_WEBSOCKET_SUPPORT@)
+if(_NETWORK_WITH_TLS OR _NETWORK_WITH_WEBSOCKET)
+    find_dependency(OpenSSL REQUIRED)
+else()
+    find_dependency(OpenSSL QUIET)
+endif()
+unset(_NETWORK_WITH_TLS)
+unset(_NETWORK_WITH_WEBSOCKET)
+
 find_dependency(ZLIB REQUIRED)
 find_dependency(asio CONFIG REQUIRED)
 


### PR DESCRIPTION
## What

Guard the `find_dependency(OpenSSL)` call in `cmake/network_system-config.cmake.in`
with the build-time flags baked in by `configure_package_config_file()`, so consumers
who built without TLS and WebSocket support are not forced to have OpenSSL installed.

**Current behavior**: `find_dependency(OpenSSL REQUIRED)` is always evaluated, causing
`find_package(network_system)` to fail on systems without OpenSSL even when the
library was built without SSL support.

**Expected behavior**: OpenSSL is only `REQUIRED` when it was actually used at build time.

## Why

Closes #844

OpenSSL is an optional dependency controlled by two build flags:
- `BUILD_TLS_SUPPORT` — TLS/SSL connections (uses `OpenSSL::SSL` and `OpenSSL::Crypto`)
- `BUILD_WEBSOCKET_SUPPORT` — SHA-1 WebSocket handshake (uses `OpenSSL::Crypto`)

Requiring OpenSSL unconditionally contradicts the optional nature of these features
and increases dependency footprint for embedded/constrained consumers.

## Where

- `cmake/network_system-config.cmake.in` — line 11 (unconditional `find_dependency`)

## How

### Implementation

Replaced the unconditional `find_dependency(OpenSSL REQUIRED)` with a guarded block:

```cmake
set(_NETWORK_WITH_TLS @BUILD_TLS_SUPPORT@)
set(_NETWORK_WITH_WEBSOCKET @BUILD_WEBSOCKET_SUPPORT@)
if(_NETWORK_WITH_TLS OR _NETWORK_WITH_WEBSOCKET)
    find_dependency(OpenSSL REQUIRED)
else()
    find_dependency(OpenSSL QUIET)
endif()
unset(_NETWORK_WITH_TLS)
unset(_NETWORK_WITH_WEBSOCKET)
```

`@BUILD_TLS_SUPPORT@` and `@BUILD_WEBSOCKET_SUPPORT@` are substituted by
`configure_package_config_file()` at CMake configure time, baking the actual
build configuration into the installed config file.

Note: WebSocket support also requires `OpenSSL::Crypto` for SHA-1 handshake
hashing (when `BUILD_TLS_SUPPORT` is OFF). This was an undocumented dependency
that is now correctly captured in the conditional.

### Acceptance Criteria

- [x] `find_package(network_system)` succeeds on systems without OpenSSL when
      neither TLS nor WebSocket support was enabled at build time
- [x] `find_package(network_system)` still requires OpenSSL when built with
      `BUILD_TLS_SUPPORT=ON` or `BUILD_WEBSOCKET_SUPPORT=ON`
- [x] `BUILD_TLS_SUPPORT` and `BUILD_WEBSOCKET_SUPPORT` are correctly substituted
      into the installed `network_system-config.cmake` (verified locally)

### Testing Done

- [x] CMake configure with default options (TLS=ON, WebSocket=ON) — generated
      config correctly sets `_NETWORK_WITH_TLS ON` and uses `REQUIRED`
- [x] Template substitution verified in `build/network_system-config.cmake`