### PR TITLE
fix(vcpkg): sync vcpkg.json version to 0.1.1

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-network-system",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "port-version": 0,
   "description": "High-performance asynchronous network messaging library",
   "homepage": "https://github.com/kcenon/network_system",


### PR DESCRIPTION
## Summary
- Sync vcpkg.json version from 0.1.0 to 0.1.1
- Aligns with CMakeLists.txt project version and vcpkg registry baseline

## Test plan
- [ ] Verify vcpkg.json version matches CMakeLists.txt
- [ ] Verify vcpkg.json version matches registry baseline

Closes #846