### PR TITLE
chore(cmake): Standardize namespace to snake_case (NetworkSystem:: → network_system::)

### DIFF
--- a/cmake/NetworkSystemInstall.cmake
+++ b/cmake/NetworkSystemInstall.cmake
@@ -68,7 +68,7 @@ function(install_cmake_config_files)
     # Install export targets
     install(EXPORT network_system-targets
         FILE network_system-targets.cmake
-        NAMESPACE NetworkSystem::
+        NAMESPACE network_system::
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/network_system
     )
 

--- a/cmake/network_system-config.cmake.in
+++ b/cmake/network_system-config.cmake.in
@@ -43,7 +43,7 @@ set(network_system_FOUND TRUE)
 # Provide information about the package
 set(network_system_VERSION @PROJECT_VERSION@)
 set(network_system_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@/network_system")
-set(network_system_LIBRARIES NetworkSystem::NetworkSystem)
+set(network_system_LIBRARIES network_system::NetworkSystem)
 
 # Legacy variables for backward compatibility
 set(NetworkSystem_FOUND TRUE)


### PR DESCRIPTION
## Summary

- Change CMake export namespace from `NetworkSystem::` to `network_system::` to adopt ecosystem convention of `<package_name>::` snake_case namespace
- Update the `network_system_LIBRARIES` variable to reference the new `network_system::NetworkSystem` target
- Existing backward compatibility variables (`NetworkSystem_FOUND`, `NetworkSystem_LIBRARIES`, etc.) remain in place and continue to work for downstream consumers still using the old namespace convention

## Related Issues

- Closes #852
- Part of kcenon/common_system#456

## What Changed

| File | Change |
|------|--------|
| `cmake/NetworkSystemInstall.cmake` | `NAMESPACE NetworkSystem::` → `NAMESPACE network_system::` in `install(EXPORT ...)` |
| `cmake/network_system-config.cmake.in` | `network_system_LIBRARIES` updated to `network_system::NetworkSystem` |

## Backward Compatibility

The config file already provides legacy variable aliases:

```cmake
set(NetworkSystem_FOUND TRUE)
set(NetworkSystem_LIBRARIES ${network_system_LIBRARIES})
# ... etc.
```

These variables continue to resolve correctly under the new namespace.

## Test plan

- [ ] Verify `find_package(network_system)` resolves `network_system::NetworkSystem` target
- [ ] Verify legacy `${NetworkSystem_LIBRARIES}` variable still works for existing consumers
- [ ] CI builds pass on all platforms