### PR TITLE
docs(readme): standardize badge labels and add License badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 [![Code Quality](https://github.com/kcenon/network_system/actions/workflows/code-quality.yml/badge.svg)](https://github.com/kcenon/network_system/actions/workflows/code-quality.yml)
 [![Coverage](https://github.com/kcenon/network_system/actions/workflows/coverage.yml/badge.svg)](https://github.com/kcenon/network_system/actions/workflows/coverage.yml)
 [![codecov](https://codecov.io/gh/kcenon/network_system/branch/main/graph/badge.svg)](https://codecov.io/gh/kcenon/network_system)
-[![Doxygen](https://github.com/kcenon/network_system/actions/workflows/build-Doxygen.yaml/badge.svg)](https://github.com/kcenon/network_system/actions/workflows/build-Doxygen.yaml)
+[![Documentation](https://github.com/kcenon/network_system/actions/workflows/build-Doxygen.yaml/badge.svg)](https://github.com/kcenon/network_system/actions/workflows/build-Doxygen.yaml)
+[![License](https://img.shields.io/github/license/kcenon/network_system)](https://github.com/kcenon/network_system/blob/main/LICENSE)
 
 # Network System
 


### PR DESCRIPTION
Part of kcenon/common_system#467

## Summary
- Rename "Doxygen" badge to "Documentation" for ecosystem consistency
- Add License badge for BSD-3-Clause

## Test plan
- [ ] Badges render correctly on GitHub