### PR TITLE
docs(doxyfile): Add ecosystem-standard ALIASES

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -39,7 +39,8 @@ PYTHON_DOCSTRING       = YES
 INHERIT_DOCS           = YES
 SEPARATE_MEMBER_PAGES  = NO
 TAB_SIZE               = 4
-ALIASES                =
+ALIASES                = "thread_safety=@par Thread Safety:^^" \
+                         "performance=@par Performance:^^"
 OPTIMIZE_OUTPUT_FOR_C  = NO
 OPTIMIZE_OUTPUT_JAVA   = NO
 OPTIMIZE_FOR_FORTRAN   = NO


### PR DESCRIPTION
## What

### Summary
Replace empty ALIASES line with `@thread_safety` and `@performance` custom ALIASES, aligning with the ecosystem standard established by monitoring_system.

### Change Type
- [x] Documentation

## Why

### Related Issues
- Part of kcenon/common_system#472

### Motivation
Custom ALIASES enable consistent cross-referencing of thread safety guarantees and performance characteristics in API documentation across all 8 ecosystem libraries.

## How

### Implementation Details
Replaced empty `ALIASES =` with monitoring_system's two standard aliases.

### Test Plan
- [ ] Doxygen build succeeds (`build-Doxygen.yaml` workflow)