### PR TITLE
docs(doxygen): Add @code examples to public API headers

### DIFF
--- a/include/kcenon/network/network_system.h
+++ b/include/kcenon/network/network_system.h
@@ -36,6 +36,16 @@
  * This header provides access to all core Network System functionality
  * including messaging clients, servers, and session management.
  *
+ * @code
+ * #include <kcenon/network/network_system.h>
+ * using namespace kcenon::network;
+ *
+ * // Use the facade for simplified TCP client/server creation
+ * facade::tcp_facade tcp;
+ * auto client = tcp.create_client({.host = "127.0.0.1", .port = 8080});
+ * auto server = tcp.create_server({.port = 8080});
+ * @endcode
+ *
  * @author kcenon
  * @date 2025-09-19
  */


### PR DESCRIPTION
## What

### Summary
Add @code usage examples to core public API headers for improved Doxygen documentation.

### Change Type
- [x] Documentation

## Why

### Related Issues
- Part of kcenon/common_system#476

### Motivation
API documentation without inline examples forces users to read source code or tests. @code blocks in Doxygen comments serve as inline tutorials directly in the generated docs.

## How

### Test Plan
- [ ] Doxygen build succeeds without warnings
- [ ] Code examples render correctly in generated HTML docs