### PR TITLE
docs: document TLS 1.3-only policy rationale for messaging layer

### DIFF
--- a/src/core/secure_messaging_server.cpp
+++ b/src/core/secure_messaging_server.cpp
@@ -65,8 +65,17 @@ namespace kcenon::network::core
 			asio::ssl::context::no_tlsv1_1 |
 			asio::ssl::context::single_dh_use);
 
-		// Enforce TLS 1.3 minimum version using native OpenSSL handle
-		// This prevents protocol downgrade attacks (CVSS 7.5)
+		// Enforce TLS 1.3 minimum version using native OpenSSL handle.
+		// This prevents protocol downgrade attacks (CVSS 7.5).
+		//
+		// NOTE: This TLS 1.3-only policy is intentionally stricter than the
+		// BCP 195 basic profile used in pacs_system (which allows TLS 1.2).
+		// Rationale:
+		//   - network_system handles internal service-to-service messaging
+		//     where all endpoints are under our control and support TLS 1.3.
+		//   - pacs_system must interoperate with legacy DICOM equipment that
+		//     may only support TLS 1.2, hence the broader BCP 195 profile.
+		// See: pacs_system/src/security/tls_policy.cpp  bcp195_basic_profile()
 		SSL_CTX* native_ctx = ssl_context_->native_handle();
 		if (native_ctx)
 		{


### PR DESCRIPTION
## Summary
- Add comment in `secure_messaging_server.cpp` explaining why TLS 1.3-only is enforced
- Document the intentional difference from `pacs_system`'s BCP 195 basic profile (TLS 1.2 allowed)
- Rationale: messaging is internal (all endpoints support TLS 1.3); PACS needs TLS 1.2 for legacy DICOM equipment interoperability

## Test plan
- [x] Local cmake configure passes
- [ ] CI build validates no compilation issues from comment changes
- [ ] No functional changes; documentation-only