### PR TITLE
fix(security): mark no_tls policy as deprecated

### DIFF
--- a/include/kcenon/network/policy/tls_policy.h
+++ b/include/kcenon/network/policy/tls_policy.h
@@ -50,7 +50,7 @@ namespace kcenon::network::policy {
  * messaging_client<tcp_protocol, no_tls> plain_client;
  * \endcode
  */
-struct no_tls {
+struct [[deprecated("Use require_tls or optional_tls for production deployments")]] no_tls {
     static constexpr bool enabled = false;
 };
 


### PR DESCRIPTION
## What

Adds `[[deprecated]]` attribute to the `no_tls` struct to emit compiler warnings when used, guiding users toward TLS-enabled policies for production deployments.

## Why

Fixes #871 -- Using `no_tls` in production is a security risk. While the struct must remain available for testing and development, a deprecation warning makes the security implication visible at compile time.

## How

- `tls_policy.h`: Added `[[deprecated("Use require_tls or optional_tls for production deployments")]]` to the `no_tls` struct declaration

### Breaking Changes

None -- Existing code compiles and functions identically. Users will see deprecation warnings which can be suppressed if intentional (e.g., test code).