### PR TITLE
chore: add local vcpkg portfile for registry synchronization

### DIFF
--- a/vcpkg-ports/kcenon-network-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-network-system/portfile.cmake
@@ -1,0 +1,49 @@
+# kcenon-network-system portfile
+# Modern C++20 async network library with TCP/UDP, HTTP/1.1, WebSocket, and TLS 1.3
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO kcenon/network_system
+    REF "v${VERSION}"
+    SHA512 2d147a3eac787919842c0d74c80eaf560e761b90dd435ba2f8d7d9459bf2a79d3dd637d20abe7204ffc72b98e82e4c0a6384b9a20ef8282777da05fca994304d
+    HEAD_REF main
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        logging BUILD_WITH_LOGGER_SYSTEM
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_TESTS=OFF
+        -DBUILD_SAMPLES=OFF
+        -DBUILD_WEBSOCKET_SUPPORT=ON
+        -DBUILD_MESSAGING_BRIDGE=OFF
+        -DNETWORK_BUILD_BENCHMARKS=OFF
+        -DNETWORK_BUILD_INTEGRATION_TESTS=OFF
+        -DNETWORK_BUILD_MODULES=OFF
+        -DBUILD_WITH_COMMON_SYSTEM=ON
+        -DFETCHCONTENT_FULLY_DISCONNECTED=ON
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME network_system
+    CONFIG_PATH lib/cmake/network_system
+)
+
+# Remove empty directories that cause vcpkg post-build validation warnings
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/include/kcenon/network/core"
+    "${CURRENT_PACKAGES_DIR}/include/kcenon/network/experimental"
+    "${CURRENT_PACKAGES_DIR}/include/kcenon/network/http"
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-ports/kcenon-network-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-network-system/vcpkg.json
@@ -1,0 +1,35 @@
+{
+  "name": "kcenon-network-system",
+  "version": "0.1.1",
+  "port-version": 3,
+  "description": "Modern C++20 async network library with TCP/UDP, HTTP/1.1, WebSocket, and TLS 1.3 support",
+  "homepage": "https://github.com/kcenon/network_system",
+  "license": "BSD-3-Clause",
+  "supports": "!(uwp | xbox)",
+  "dependencies": [
+    "kcenon-common-system",
+    "kcenon-thread-system",
+    "asio",
+    "openssl",
+    {
+      "name": "zlib",
+      "version>=": "1.3"
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "logging": {
+      "description": "Enable logger_system integration (optional -- runtime binding via ILogger by default)",
+      "dependencies": [
+        "kcenon-logger-system"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `vcpkg-ports/kcenon-network-system/` with `portfile.cmake` and `vcpkg.json` mirroring the canonical vcpkg-registry

## Rationale

Standardize portfile management (Strategy B: local + registry sync) across the ecosystem, following the pattern already established by `monitoring_system`. Local portfiles enable atomic source+port changes and CI validation.

## Test plan

- [ ] Verify portfile matches the canonical registry version
- [ ] CI builds pass without regression

Ref: kcenon/vcpkg-registry#36