### PR TITLE
chore(vcpkg): add openssl to root manifest core dependencies

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,6 +10,7 @@
   "dependencies": [
     "kcenon-common-system",
     "kcenon-thread-system",
+    "openssl",
     {
       "name": "asio",
       "version>=": "1.30.2"


### PR DESCRIPTION
## What

### Summary
Add `openssl` to root `vcpkg.json` core dependencies to match port manifest.

### Change Type
- [x] Chore (dependency metadata alignment)

## Why

### Related Issues
- Closes #893

### Motivation
Root vcpkg.json treats OpenSSL as optional `ssl` feature, but `find_package(OpenSSL 3.0.0 REQUIRED)` in CMakeLists.txt makes it unconditionally required. Port manifest already has it correct.

## Where

### Files Changed
| File | Change |
|------|--------|
| `vcpkg.json` | Add `openssl` to `dependencies` array |

## How

### Implementation
Added `"openssl"` string to the `dependencies` array between `kcenon-thread-system` and the `asio` version object.

### Testing Done
- [x] JSON validation (syntax check)
- [x] CI passes on all platforms

### Breaking Changes
None