### PR TITLE
chore(docs): add templates, governance files, and root CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,45 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: 'bug'
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Include file '...'
+2. Call function '...'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Code example**
+```cpp
+// Minimal code example that reproduces the issue
+#include <kcenon/network/tcp_client.h>
+
+int main() {
+    // Your code here
+}
+```
+
+**Error messages**
+```
+// Paste any error messages here
+```
+
+**Environment:**
+ - OS: [e.g., Ubuntu 22.04, Windows 11]
+ - Compiler: [e.g., GCC 11.2, Clang 14.0, MSVC 2022]
+ - C++ Standard: [e.g., C++17, C++20]
+ - CMake version: [e.g., 3.20]
+ - Build type: [Debug/Release]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/kcenon/network_system/tree/main/docs
+    about: Check our documentation for guides and FAQs
+  - name: Discussions
+    url: https://github.com/kcenon/network_system/discussions
+    about: Ask questions and discuss ideas

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: '[FEATURE] '
+labels: 'enhancement'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Proposed API**
+```cpp
+// Example of how the feature would be used
+namespace network {
+    // Your proposed API here
+}
+```
+
+**Use cases**
+Describe specific use cases where this feature would be beneficial.
+
+**Additional context**
+Add any other context, mockups, or examples about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,38 @@
+## Description
+<!-- Provide a brief description of the changes in this PR -->
+
+## Type of Change
+<!-- Mark the relevant option with an "x" -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Performance improvement
+- [ ] Code refactoring
+
+## Related Issues
+<!-- Link to related issues -->
+Fixes #(issue number)
+
+## Checklist
+<!-- Mark completed items with an "x" -->
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published
+
+## Testing
+<!-- Describe the tests you ran to verify your changes -->
+- [ ] Unit tests pass
+- [ ] Integration tests pass
+- [ ] Manual testing completed
+
+## Screenshots (if applicable)
+<!-- Add screenshots to help explain your changes -->
+
+## Additional Notes
+<!-- Add any additional notes or context about the PR -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at **kcenon@naver.com**. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,3 @@
-> **Note**: The canonical version of this document is at the [project root](../../CONTRIBUTING.md). This copy is kept for reference.
-
 # Contributing to Network System
 
 **Version:** 0.1.0.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| Latest  | :white_check_mark: |
+| < Latest | :x:               |
+
+Only the latest release receives security updates. Users are encouraged to
+upgrade to the most recent version.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Network System, please report it
+responsibly through one of the following channels:
+
+- **Email**: [kcenon@naver.com](mailto:kcenon@naver.com)
+- **GitHub Security Advisories**: [Report here](https://github.com/kcenon/network_system/security/advisories/new)
+
+**Please do NOT report security vulnerabilities through public GitHub issues.**
+
+### What to Include
+
+- Description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact assessment
+- Suggested fix (if any)
+
+### Response Timeline
+
+| Stage | Timeframe |
+|-------|-----------|
+| Acknowledgment | Within 7 days |
+| Initial assessment | Within 14 days |
+| Fix and release | Depends on severity |
+
+### After Reporting
+
+1. You will receive an acknowledgment within 7 days
+2. The maintainers will investigate and provide an initial assessment
+3. A fix will be developed and tested
+4. A security advisory will be published with the fix release
+5. Credit will be given to the reporter (unless anonymity is requested)
+
+## Security Best Practices
+
+When using Network System in your projects:
+
+- Always use the latest stable release
+- Monitor the [GitHub Security Advisories](https://github.com/kcenon/network_system/security/advisories) page for updates


### PR DESCRIPTION
## Summary

- Copy `CONTRIBUTING.md` from `docs/contributing/` to project root for GitHub discoverability
- Add GitHub Issue templates (bug report, feature request) with project-specific examples
- Add comprehensive PR template matching common_system standards
- Add CODE_OF_CONDUCT.md (Contributor Covenant v2.1)
- Add SECURITY.md with vulnerability reporting guidelines

## Related Issues

Closes #895
Closes #896 (duplicate)

## Type of Change

- [x] Documentation update

## Test Plan

- [x] Verify issue templates appear when creating new issues
- [x] Verify PR template loads when creating new PRs
- [x] Verify CODE_OF_CONDUCT.md renders correctly
- [x] Verify SECURITY.md links are correct
- [x] Verify root CONTRIBUTING.md matches docs/contributing/ version