### PR TITLE
docs(changelog): add version history note for vcpkg versioning reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,12 @@ For migration assistance, please refer to the migration guides in the `docs/migr
 
 ---
 
+> **Note:** Starting from v0.1.0 (2026-03-10), network_system adopted semantic versioning
+> aligned with vcpkg packaging. Earlier versions (v0.2.0 – v2.0.0) reflect the pre-vcpkg
+> release history and are retained for reference.
+
+---
+
 ## [v2.0.0] - 2026-01-18
 
 ### Added


### PR DESCRIPTION
## Summary
- Add a versioning note to CHANGELOG.md explaining the version reset from v2.0.0 to 0.1.x
- Clarifies that 0.1.x versions are vcpkg-packaged releases while v1.x/v2.x are historical

## Test plan
- [ ] Markdown renders correctly on GitHub
- [ ] Note is positioned between vcpkg-era and pre-vcpkg entries

Closes #901