### PR TITLE
fix(vcpkg): sync local portfile CONFIG_PATH with v0.1.1 release tag

### DIFF
--- a/vcpkg-ports/kcenon-network-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-network-system/portfile.cmake
@@ -32,8 +32,8 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME network_system
-    CONFIG_PATH lib/cmake/network_system
+    PACKAGE_NAME NetworkSystem
+    CONFIG_PATH lib/cmake/NetworkSystem
 )
 
 # Remove empty directories that cause vcpkg post-build validation warnings

--- a/vcpkg-ports/kcenon-network-system/usage
+++ b/vcpkg-ports/kcenon-network-system/usage
@@ -1,0 +1,6 @@
+The package kcenon-network-system provides CMake targets:
+
+    find_package(network_system CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE network_system::NetworkSystem)
+
+Available features: logging

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-network-system",
   "version-semver": "0.1.1",
-  "port-version": 0,
+  "port-version": 3,
   "description": "High-performance asynchronous network messaging library",
   "homepage": "https://github.com/kcenon/network_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## Summary
- Fix `vcpkg_cmake_config_fixup` PACKAGE_NAME and CONFIG_PATH to match v0.1.1 release tag (PascalCase)
- Sync root `vcpkg.json` port-version from 0 to 3
- Add missing `usage` file to local port directory

## Related
- Closes #904
- Related: kcenon/vcpkg-registry#48

## Test plan
- [ ] Verify portfile PACKAGE_NAME matches release tag install path
- [ ] Verify root vcpkg.json port-version matches port definition