### PR TITLE
feat(examples): add examples directory with usage examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
 option(BUILD_TESTS "Build tests" ON)
 option(BUILD_SAMPLES "Build samples" ON)
+option(BUILD_EXAMPLES "Build usage examples" OFF)
 option(BUILD_WEBSOCKET_SUPPORT "Build WebSocket protocol support (RFC 6455)" ON)
 option(BUILD_MESSAGING_BRIDGE "Build messaging_system bridge" ON)
 option(ENABLE_COVERAGE "Enable code coverage" OFF)
@@ -846,6 +847,15 @@ if(BUILD_SAMPLES)
     endif()
 endif()
 
+if(BUILD_EXAMPLES)
+    message(STATUS "Building network_system examples")
+
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/examples/CMakeLists.txt)
+        add_subdirectory(examples)
+        message(STATUS "Network system examples enabled")
+    endif()
+endif()
+
 ##################################################
 # Benchmarks
 ##################################################
@@ -977,6 +987,7 @@ message(STATUS "  Shared libs: ${BUILD_SHARED_LIBS}")
 message(STATUS "  Tests: ${BUILD_TESTS}")
 message(STATUS "  Integration tests: ${NETWORK_BUILD_INTEGRATION_TESTS}")
 message(STATUS "  Samples: ${BUILD_SAMPLES}")
+message(STATUS "  Examples: ${BUILD_EXAMPLES}")
 message(STATUS "  Verify build: ${BUILD_VERIFY_BUILD}")
 message(STATUS "  TLS/SSL support: ${BUILD_TLS_SUPPORT}")
 message(STATUS "  WebSocket support: ${BUILD_WEBSOCKET_SUPPORT}")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,137 @@
+cmake_minimum_required(VERSION 3.20)
+
+##################################################
+# Network System Examples CMakeLists.txt
+#
+# Focused, minimal examples for learning
+# the network_system API.
+##################################################
+
+project(network_system_examples
+    VERSION 0.1.0
+    DESCRIPTION "Network System Usage Examples"
+    LANGUAGES CXX
+)
+
+# C++ Standard
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Include integration module for ASIO setup
+include(NetworkSystemIntegration)
+
+# Find required packages
+find_package(Threads REQUIRED)
+
+##################################################
+# Example Programs
+##################################################
+
+# Core examples (always built)
+set(EXAMPLE_PROGRAMS
+    tcp_echo_server
+    tcp_client
+    udp_echo
+    connection_pool
+    observer_pattern
+)
+
+# WebSocket example (requires BUILD_WEBSOCKET_SUPPORT)
+if(BUILD_WEBSOCKET_SUPPORT)
+    list(APPEND EXAMPLE_PROGRAMS websocket_chat)
+endif()
+
+# Output directory
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/examples)
+
+##################################################
+# Build Each Example
+##################################################
+
+set(EXAMPLE_TARGETS)
+
+foreach(EXAMPLE ${EXAMPLE_PROGRAMS})
+    add_executable(example_${EXAMPLE} ${EXAMPLE}.cpp)
+    list(APPEND EXAMPLE_TARGETS example_${EXAMPLE})
+
+    set_target_properties(example_${EXAMPLE} PROPERTIES
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS OFF
+    )
+
+    target_link_libraries(example_${EXAMPLE} PRIVATE
+        NetworkSystem
+        Threads::Threads
+    )
+
+    # Configure ASIO
+    setup_asio_integration(example_${EXAMPLE})
+
+    # Platform-specific libraries
+    if(WIN32)
+        target_link_libraries(example_${EXAMPLE} PRIVATE
+            ws2_32
+            wsock32
+        )
+        target_compile_definitions(example_${EXAMPLE} PRIVATE
+            _WIN32_WINNT=0x0601
+            WIN32_LEAN_AND_MEAN
+            NOMINMAX
+        )
+    elseif(UNIX AND NOT APPLE)
+        target_link_libraries(example_${EXAMPLE} PRIVATE
+            pthread
+        )
+    endif()
+
+    # Compiler warnings
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(example_${EXAMPLE} PRIVATE
+            -Wall
+            -Wextra
+            -Wpedantic
+            -Wno-unused-parameter
+        )
+    elseif(MSVC)
+        target_compile_options(example_${EXAMPLE} PRIVATE
+            /W4
+            /wd4100
+        )
+    endif()
+
+    message(STATUS "Network example configured: ${EXAMPLE}")
+endforeach()
+
+##################################################
+# Installation
+##################################################
+
+install(TARGETS ${EXAMPLE_TARGETS}
+    RUNTIME DESTINATION bin/examples
+    COMPONENT examples
+)
+
+install(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt
+    ${CMAKE_CURRENT_SOURCE_DIR}/README.md
+    DESTINATION share/network_system/examples
+    COMPONENT examples
+)
+
+# Install example source files
+foreach(EXAMPLE ${EXAMPLE_PROGRAMS})
+    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE}.cpp
+        DESTINATION share/network_system/examples
+        COMPONENT examples
+    )
+endforeach()
+
+##################################################
+# Summary
+##################################################
+
+message(STATUS "Network System Examples configured:")
+message(STATUS "  Examples: ${EXAMPLE_PROGRAMS}")
+message(STATUS "  Output directory: ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,114 @@
+# Network System Examples
+
+Focused, minimal examples demonstrating common network\_system usage patterns. Each example is self-contained and can be built and run independently.
+
+For more comprehensive demonstrations (HTTP, gRPC, QUIC, memory profiling), see the [samples/](../samples/) directory.
+
+## Building
+
+Examples are built when `BUILD_EXAMPLES=ON` is set (off by default):
+
+```bash
+cmake -B build -DBUILD_EXAMPLES=ON
+cmake --build build
+```
+
+Binaries are placed in `build/bin/examples/`.
+
+## Examples
+
+### tcp\_echo\_server
+
+A minimal TCP server that echoes received data back to the client. Shows server lifecycle, session tracking, and callback-based event handling.
+
+```bash
+./build/bin/examples/example_tcp_echo_server
+```
+
+### tcp\_client
+
+A TCP client that connects to a server, sends text and binary messages, and prints responses. Pair with `tcp_echo_server`.
+
+```bash
+# Terminal 1
+./build/bin/examples/example_tcp_echo_server
+
+# Terminal 2
+./build/bin/examples/example_tcp_client
+```
+
+### websocket\_chat
+
+A self-contained WebSocket chat demo. Starts a server and two clients in separate threads, demonstrating broadcast messaging over WebSocket.
+
+Requires `BUILD_WEBSOCKET_SUPPORT=ON` (enabled by default).
+
+```bash
+./build/bin/examples/example_websocket_chat
+```
+
+### connection\_pool
+
+Demonstrates TCP connection pooling with the `tcp_facade`. Covers pool initialization, single-threaded acquire/release, and multi-threaded concurrent access with throughput measurement.
+
+```bash
+./build/bin/examples/example_connection_pool
+```
+
+### udp\_echo
+
+A UDP echo server and client running in a single program. Shows datagram-based communication with message boundary preservation.
+
+```bash
+./build/bin/examples/example_udp_echo
+```
+
+### observer\_pattern
+
+Demonstrates the `connection_observer` interface, `null_connection_observer`, and `callback_adapter` for handling client events. Compares the observer pattern with callback-based approaches.
+
+```bash
+./build/bin/examples/example_observer_pattern
+```
+
+## Key Concepts
+
+| Concept | Examples |
+|---------|----------|
+| TCP server/client | `tcp_echo_server`, `tcp_client` |
+| UDP communication | `udp_echo` |
+| WebSocket | `websocket_chat` |
+| Connection pooling | `connection_pool` |
+| Observer pattern | `observer_pattern` |
+| Result\<T\> error handling | All examples |
+| Session management | `tcp_echo_server`, `websocket_chat` |
+| Facade API | All examples |
+
+## API Quick Reference
+
+All examples use the facade API (`tcp_facade`, `udp_facade`, `websocket_facade`) which provides a simplified interface for creating clients and servers. The facade returns `i_protocol_client` and `i_protocol_server` interfaces that offer a consistent API across all protocols.
+
+### Common Pattern
+
+```cpp
+#include <kcenon/network/facade/tcp_facade.h>
+
+using namespace kcenon::network;
+
+facade::tcp_facade tcp;
+
+// Server
+auto server = tcp.create_server({ .port = 9000 });
+server->set_receive_callback([](std::string_view session_id, const std::vector<uint8_t>& data) {
+    // handle data
+});
+server->start(9000);
+
+// Client
+auto client = tcp.create_client({ .host = "127.0.0.1", .port = 9000 });
+client->set_receive_callback([](const std::vector<uint8_t>& data) {
+    // handle data
+});
+client->start("127.0.0.1", 9000);
+client->send(std::vector<uint8_t>{'h', 'i'});
+```

--- a/examples/connection_pool.cpp
+++ b/examples/connection_pool.cpp
@@ -1,0 +1,183 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, Network System Project
+All rights reserved.
+*****************************************************************************/
+
+/**
+ * @file connection_pool.cpp
+ * @brief TCP connection pool usage example
+ *
+ * Demonstrates:
+ * - Creating a connection pool via tcp_facade
+ * - Acquiring and releasing connections
+ * - Monitoring pool utilization
+ * - Concurrent access from multiple threads
+ * - Proper error handling with Result<T>
+ *
+ * The example starts a local echo server, then exercises the pool
+ * with single-threaded and multi-threaded workloads.
+ */
+
+#include <kcenon/network/facade/tcp_facade.h>
+#include <kcenon/network/interfaces/i_session.h>
+#include "internal/core/connection_pool.h"
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace kcenon::network;
+
+int main() {
+    std::cout << "=== Connection Pool Example ===" << std::endl;
+
+    // --- Set up a local echo server for testing ---
+    facade::tcp_facade tcp;
+    constexpr uint16_t port = 9002;
+
+    auto server = tcp.create_server({
+        .port = port,
+        .server_id = "PoolTestServer",
+    });
+
+    std::mutex sessions_mutex;
+    std::map<std::string, std::shared_ptr<interfaces::i_session>> sessions;
+
+    server->set_connection_callback(
+        [&sessions, &sessions_mutex](std::shared_ptr<interfaces::i_session> session) {
+            std::lock_guard<std::mutex> lock(sessions_mutex);
+            sessions[std::string(session->id())] = session;
+        });
+
+    server->set_disconnection_callback(
+        [&sessions, &sessions_mutex](std::string_view session_id) {
+            std::lock_guard<std::mutex> lock(sessions_mutex);
+            sessions.erase(std::string(session_id));
+        });
+
+    server->set_receive_callback(
+        [&sessions, &sessions_mutex](std::string_view session_id,
+                                     const std::vector<uint8_t>& data) {
+            std::lock_guard<std::mutex> lock(sessions_mutex);
+            auto it = sessions.find(std::string(session_id));
+            if (it != sessions.end()) {
+                it->second->send(std::vector<uint8_t>(data));
+            }
+        });
+
+    auto server_result = server->start(port);
+    if (server_result.is_err()) {
+        std::cerr << "Server start failed: " << server_result.error().message << std::endl;
+        return 1;
+    }
+    std::cout << "Echo server started on port " << port << std::endl;
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // --- Create and initialize the connection pool ---
+    constexpr size_t pool_size = 5;
+
+    auto pool = tcp.create_connection_pool({
+        .host = "127.0.0.1",
+        .port = port,
+        .pool_size = pool_size,
+    });
+
+    auto init_result = pool->initialize();
+    if (init_result.is_err()) {
+        std::cerr << "Pool init failed: " << init_result.error().message << std::endl;
+        server->stop();
+        return 1;
+    }
+    std::cout << "Connection pool initialized: " << pool->pool_size() << " connections"
+              << std::endl;
+
+    // --- Single-threaded usage ---
+    std::cout << "\n--- Single-threaded usage ---" << std::endl;
+    {
+        auto client = pool->acquire();
+        std::cout << "Acquired connection. Active: " << pool->active_count() << "/"
+                  << pool->pool_size() << std::endl;
+
+        std::vector<uint8_t> data = {'p', 'i', 'n', 'g'};
+        auto result = client->send_packet(std::move(data));
+        if (result.is_ok()) {
+            std::cout << "Sent 'ping' successfully" << std::endl;
+        } else {
+            std::cerr << "Send failed: " << result.error().message << std::endl;
+        }
+
+        pool->release(std::move(client));
+        std::cout << "Released connection. Active: " << pool->active_count() << "/"
+                  << pool->pool_size() << std::endl;
+    }
+
+    // --- Multi-threaded usage ---
+    std::cout << "\n--- Multi-threaded usage ---" << std::endl;
+    {
+        constexpr int num_workers = 4;
+        constexpr int requests_per_worker = 10;
+
+        std::atomic<int> success_count{0};
+        std::atomic<int> failure_count{0};
+        std::vector<std::future<void>> futures;
+
+        auto start_time = std::chrono::steady_clock::now();
+
+        for (int w = 0; w < num_workers; ++w) {
+            futures.push_back(
+                std::async(std::launch::async, [&pool, w, &success_count, &failure_count]() {
+                    for (int i = 0; i < requests_per_worker; ++i) {
+                        auto client = pool->acquire();
+
+                        std::vector<uint8_t> data = {
+                            static_cast<uint8_t>('A' + w),
+                            static_cast<uint8_t>('0' + i),
+                        };
+
+                        auto result = client->send_packet(std::move(data));
+                        if (result.is_ok()) {
+                            success_count.fetch_add(1, std::memory_order_relaxed);
+                        } else {
+                            failure_count.fetch_add(1, std::memory_order_relaxed);
+                        }
+
+                        pool->release(std::move(client));
+                        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+                    }
+                }));
+        }
+
+        for (auto& f : futures) {
+            f.wait();
+        }
+
+        auto end_time = std::chrono::steady_clock::now();
+        auto duration_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time)
+                .count();
+
+        int total = num_workers * requests_per_worker;
+        std::cout << "Completed " << success_count.load() << "/" << total
+                  << " requests in " << duration_ms << " ms" << std::endl;
+        std::cout << "Failed: " << failure_count.load() << std::endl;
+        if (duration_ms > 0) {
+            std::cout << "Throughput: " << (total * 1000 / duration_ms) << " req/s"
+                      << std::endl;
+        }
+    }
+
+    // --- Cleanup ---
+    std::cout << "\nStopping server..." << std::endl;
+    server->stop();
+    std::cout << "=== Connection pool example completed ===" << std::endl;
+
+    return 0;
+}

--- a/examples/observer_pattern.cpp
+++ b/examples/observer_pattern.cpp
@@ -1,0 +1,208 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, Network System Project
+All rights reserved.
+*****************************************************************************/
+
+/**
+ * @file observer_pattern.cpp
+ * @brief Demonstrates the connection_observer and callback_adapter patterns
+ *
+ * Demonstrates:
+ * - Implementing connection_observer for unified event handling
+ * - Using null_connection_observer for partial event handling
+ * - Using callback_adapter for functional-style event handling
+ * - Setting an observer on a TCP client
+ *
+ * These patterns provide alternatives to individual callback setters
+ * and centralize event handling in a single object.
+ */
+
+#include <kcenon/network/facade/tcp_facade.h>
+#include <kcenon/network/interfaces/connection_observer.h>
+#include <kcenon/network/interfaces/i_session.h>
+
+#include <chrono>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <span>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace kcenon::network;
+
+/**
+ * @brief Custom observer that handles all connection events
+ *
+ * This demonstrates the recommended pattern for handling client events.
+ * All events go through a single object, making it easy to maintain state.
+ */
+class chat_observer : public interfaces::connection_observer {
+public:
+    explicit chat_observer(const std::string& name) : name_(name) {}
+
+    auto on_connected() -> void override {
+        std::cout << "[" << name_ << "] Connected to server." << std::endl;
+    }
+
+    auto on_disconnected(std::optional<std::string_view> reason) -> void override {
+        std::cout << "[" << name_ << "] Disconnected";
+        if (reason.has_value()) {
+            std::cout << " (reason: " << reason.value() << ")";
+        }
+        std::cout << std::endl;
+    }
+
+    auto on_receive(std::span<const uint8_t> data) -> void override {
+        std::string message(data.begin(), data.end());
+        std::cout << "[" << name_ << "] Received: " << message << std::endl;
+        ++message_count_;
+    }
+
+    auto on_error(std::error_code ec) -> void override {
+        std::cerr << "[" << name_ << "] Error: " << ec.message() << std::endl;
+    }
+
+    [[nodiscard]] auto message_count() const -> int { return message_count_; }
+
+private:
+    std::string name_;
+    int message_count_ = 0;
+};
+
+/**
+ * @brief Partial observer that only handles receive events
+ *
+ * Inherits from null_connection_observer so unneeded methods are no-ops.
+ */
+class receive_only_observer : public interfaces::null_connection_observer {
+public:
+    auto on_receive(std::span<const uint8_t> data) -> void override {
+        std::string message(data.begin(), data.end());
+        std::cout << "[ReceiveOnly] Got: " << message << std::endl;
+    }
+};
+
+int main() {
+    std::cout << "=== Observer Pattern Example ===" << std::endl;
+
+    // --- Start a local echo server ---
+    facade::tcp_facade tcp;
+    constexpr uint16_t port = 9004;
+
+    auto server = tcp.create_server({
+        .port = port,
+        .server_id = "ObserverTestServer",
+    });
+
+    std::mutex sessions_mutex;
+    std::map<std::string, std::shared_ptr<interfaces::i_session>> sessions;
+
+    server->set_connection_callback(
+        [&sessions, &sessions_mutex](std::shared_ptr<interfaces::i_session> session) {
+            std::lock_guard<std::mutex> lock(sessions_mutex);
+            sessions[std::string(session->id())] = session;
+        });
+
+    server->set_disconnection_callback(
+        [&sessions, &sessions_mutex](std::string_view session_id) {
+            std::lock_guard<std::mutex> lock(sessions_mutex);
+            sessions.erase(std::string(session_id));
+        });
+
+    server->set_receive_callback(
+        [&sessions, &sessions_mutex](std::string_view session_id,
+                                     const std::vector<uint8_t>& data) {
+            std::lock_guard<std::mutex> lock(sessions_mutex);
+            auto it = sessions.find(std::string(session_id));
+            if (it != sessions.end()) {
+                it->second->send(std::vector<uint8_t>(data));
+            }
+        });
+
+    auto server_result = server->start(port);
+    if (server_result.is_err()) {
+        std::cerr << "Server start failed: " << server_result.error().message << std::endl;
+        return 1;
+    }
+    std::cout << "Echo server running on port " << port << std::endl;
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // --- Example 1: Full connection_observer ---
+    std::cout << "\n--- Example 1: Full connection_observer ---" << std::endl;
+    {
+        auto client = tcp.create_client({
+            .host = "127.0.0.1",
+            .port = port,
+            .client_id = "ObserverClient",
+        });
+
+        auto observer = std::make_shared<chat_observer>("FullObserver");
+        client->set_observer(observer);
+
+        auto result = client->start("127.0.0.1", port);
+        if (result.is_ok()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+            std::string msg = "Hello via observer!";
+            std::vector<uint8_t> data(msg.begin(), msg.end());
+            client->send(std::move(data));
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+            std::cout << "Messages received: " << observer->message_count() << std::endl;
+        }
+
+        client->stop();
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    // --- Example 2: callback_adapter (functional style) ---
+    std::cout << "\n--- Example 2: callback_adapter ---" << std::endl;
+    {
+        auto client = tcp.create_client({
+            .host = "127.0.0.1",
+            .port = port,
+            .client_id = "AdapterClient",
+        });
+
+        auto adapter = std::make_shared<interfaces::callback_adapter>();
+        adapter->on_connected([]() {
+                   std::cout << "[Adapter] Connected!" << std::endl;
+               })
+            .on_receive([](std::span<const uint8_t> data) {
+                std::string msg(data.begin(), data.end());
+                std::cout << "[Adapter] Received: " << msg << std::endl;
+            })
+            .on_disconnected([](std::optional<std::string_view> reason) {
+                std::cout << "[Adapter] Disconnected." << std::endl;
+            })
+            .on_error([](std::error_code ec) {
+                std::cerr << "[Adapter] Error: " << ec.message() << std::endl;
+            });
+
+        client->set_observer(adapter);
+
+        auto result = client->start("127.0.0.1", port);
+        if (result.is_ok()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+            std::string msg = "Hello via callback_adapter!";
+            std::vector<uint8_t> data(msg.begin(), msg.end());
+            client->send(std::move(data));
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        }
+
+        client->stop();
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    // --- Cleanup ---
+    server->stop();
+    std::cout << "\n=== Observer pattern example completed ===" << std::endl;
+
+    return 0;
+}

--- a/examples/tcp_client.cpp
+++ b/examples/tcp_client.cpp
@@ -1,0 +1,131 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, Network System Project
+All rights reserved.
+*****************************************************************************/
+
+/**
+ * @file tcp_client.cpp
+ * @brief Minimal TCP client using the facade API
+ *
+ * Demonstrates:
+ * - Creating a TCP client via tcp_facade
+ * - Connecting to a server
+ * - Sending text and binary messages
+ * - Receiving responses via callback
+ * - Checking connection status
+ * - Clean disconnection
+ *
+ * Pair with the tcp_echo_server example:
+ *   1. Start tcp_echo_server
+ *   2. Run this tcp_client
+ */
+
+#include <kcenon/network/facade/tcp_facade.h>
+
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace kcenon::network;
+
+int main() {
+    std::cout << "=== TCP Client Example ===" << std::endl;
+
+    // Create TCP facade and client
+    facade::tcp_facade tcp;
+    constexpr uint16_t port = 9000;
+    const std::string host = "127.0.0.1";
+
+    auto client = tcp.create_client({
+        .host = host,
+        .port = port,
+        .client_id = "ExampleClient",
+    });
+
+    // Set up receive callback to print server responses
+    client->set_receive_callback([](const std::vector<uint8_t>& data) {
+        std::string message(data.begin(), data.end());
+        std::cout << "[Client] Received: " << message << std::endl;
+    });
+
+    // Set up connection and disconnection callbacks
+    client->set_connected_callback([]() {
+        std::cout << "[Client] Connected to server." << std::endl;
+    });
+
+    client->set_disconnected_callback([]() {
+        std::cout << "[Client] Disconnected from server." << std::endl;
+    });
+
+    // Set up error callback
+    client->set_error_callback([](std::error_code ec) {
+        std::cerr << "[Client] Error: " << ec.message() << std::endl;
+    });
+
+    // Connect to the server
+    std::cout << "[Client] Connecting to " << host << ":" << port << "..." << std::endl;
+
+    auto connect_result = client->start(host, port);
+    if (connect_result.is_err()) {
+        std::cerr << "[Client] Connection failed: " << connect_result.error().message
+                  << std::endl;
+        return 1;
+    }
+
+    // Wait for connection to establish
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    // Check connection status
+    if (!client->is_connected()) {
+        std::cerr << "[Client] Not connected." << std::endl;
+        client->stop();
+        return 1;
+    }
+
+    // Send text messages
+    std::vector<std::string> messages = {
+        "Hello, server!",
+        "This is a TCP client example.",
+        "Goodbye!",
+    };
+
+    for (const auto& msg : messages) {
+        std::vector<uint8_t> data(msg.begin(), msg.end());
+        std::cout << "[Client] Sending: " << msg << std::endl;
+
+        auto send_result = client->send(std::move(data));
+        if (send_result.is_err()) {
+            std::cerr << "[Client] Send failed: " << send_result.error().message
+                      << std::endl;
+        }
+
+        // Wait for echo response
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+
+    // Send binary data
+    std::cout << "[Client] Sending binary data..." << std::endl;
+    std::vector<uint8_t> binary_data = {0x01, 0x02, 0x03, 0x04, 0xFF};
+    auto binary_result = client->send(std::move(binary_data));
+    if (binary_result.is_err()) {
+        std::cerr << "[Client] Binary send failed: " << binary_result.error().message
+                  << std::endl;
+    }
+
+    // Wait for response
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    // Disconnect
+    std::cout << "[Client] Disconnecting..." << std::endl;
+    auto stop_result = client->stop();
+    if (stop_result.is_err()) {
+        std::cerr << "[Client] Stop error: " << stop_result.error().message << std::endl;
+    }
+
+    std::cout << "[Client] Done." << std::endl;
+    return 0;
+}

--- a/examples/tcp_echo_server.cpp
+++ b/examples/tcp_echo_server.cpp
@@ -1,0 +1,139 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, Network System Project
+All rights reserved.
+*****************************************************************************/
+
+/**
+ * @file tcp_echo_server.cpp
+ * @brief Minimal TCP echo server using the facade API
+ *
+ * Demonstrates:
+ * - Creating a TCP server via tcp_facade
+ * - Setting up connection, disconnection, receive, and error callbacks
+ * - Session management with thread-safe session tracking
+ * - Echoing received data back to the client
+ * - Graceful shutdown
+ *
+ * Run this server, then connect with the tcp_client example or any TCP client:
+ *   echo "hello" | nc localhost 9000
+ */
+
+#include <kcenon/network/facade/tcp_facade.h>
+#include <kcenon/network/interfaces/i_session.h>
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <string>
+#include <thread>
+
+using namespace kcenon::network;
+
+// Global flag for graceful shutdown
+static std::atomic<bool> g_running{true};
+
+void signal_handler(int /*signum*/) {
+    g_running.store(false);
+}
+
+int main() {
+    std::cout << "=== TCP Echo Server Example ===" << std::endl;
+
+    // Register signal handler for graceful shutdown
+    std::signal(SIGINT, signal_handler);
+    std::signal(SIGTERM, signal_handler);
+
+    // Create TCP facade and server
+    facade::tcp_facade tcp;
+    constexpr uint16_t port = 9000;
+
+    auto server = tcp.create_server({
+        .port = port,
+        .server_id = "EchoServer",
+    });
+
+    // Thread-safe session storage for echoing data back
+    std::mutex sessions_mutex;
+    std::map<std::string, std::shared_ptr<interfaces::i_session>> sessions;
+
+    // Track new connections
+    server->set_connection_callback(
+        [&sessions, &sessions_mutex](std::shared_ptr<interfaces::i_session> session) {
+            std::lock_guard<std::mutex> lock(sessions_mutex);
+            std::string id(session->id());
+            sessions[id] = session;
+            std::cout << "[Server] Client connected: " << id << std::endl;
+        });
+
+    // Track disconnections
+    server->set_disconnection_callback(
+        [&sessions, &sessions_mutex](std::string_view session_id) {
+            std::lock_guard<std::mutex> lock(sessions_mutex);
+            sessions.erase(std::string(session_id));
+            std::cout << "[Server] Client disconnected: " << session_id << std::endl;
+        });
+
+    // Echo received data back to the sender
+    server->set_receive_callback(
+        [&sessions, &sessions_mutex](std::string_view session_id,
+                                     const std::vector<uint8_t>& data) {
+            std::string message(data.begin(), data.end());
+            std::cout << "[Server] Received from " << session_id << ": " << message
+                      << std::endl;
+
+            // Find the session and echo data back
+            std::shared_ptr<interfaces::i_session> session;
+            {
+                std::lock_guard<std::mutex> lock(sessions_mutex);
+                auto it = sessions.find(std::string(session_id));
+                if (it != sessions.end()) {
+                    session = it->second;
+                }
+            }
+
+            if (session) {
+                auto result = session->send(std::vector<uint8_t>(data));
+                if (result.is_err()) {
+                    std::cerr << "[Server] Echo failed: " << result.error().message
+                              << std::endl;
+                }
+            }
+        });
+
+    // Log errors
+    server->set_error_callback(
+        [](std::string_view session_id, std::error_code ec) {
+            std::cerr << "[Server] Error on " << session_id << ": " << ec.message()
+                      << std::endl;
+        });
+
+    // Start the server
+    auto result = server->start(port);
+    if (result.is_err()) {
+        std::cerr << "Failed to start server: " << result.error().message << std::endl;
+        return 1;
+    }
+
+    std::cout << "[Server] Listening on port " << port << std::endl;
+    std::cout << "[Server] Press Ctrl+C to stop." << std::endl;
+
+    // Main loop: wait until shutdown signal
+    while (g_running.load()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    // Graceful shutdown
+    std::cout << "\n[Server] Shutting down..." << std::endl;
+    auto stop_result = server->stop();
+    if (stop_result.is_err()) {
+        std::cerr << "[Server] Stop error: " << stop_result.error().message << std::endl;
+    }
+
+    std::cout << "[Server] Stopped." << std::endl;
+    return 0;
+}

--- a/examples/udp_echo.cpp
+++ b/examples/udp_echo.cpp
@@ -1,0 +1,162 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, Network System Project
+All rights reserved.
+*****************************************************************************/
+
+/**
+ * @file udp_echo.cpp
+ * @brief Minimal UDP echo server and client
+ *
+ * Demonstrates:
+ * - Creating a UDP server via udp_facade
+ * - Creating a UDP client via udp_facade
+ * - Datagram-based communication (message boundaries preserved)
+ * - Session tracking on the server side
+ * - Error handling with Result<T>
+ *
+ * The server echoes each received datagram back to its sender.
+ * The client sends a series of messages and prints the echoed responses.
+ */
+
+#include <kcenon/network/facade/udp_facade.h>
+#include <kcenon/network/interfaces/i_session.h>
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+using namespace kcenon::network;
+
+static std::atomic<bool> g_done{false};
+
+void run_server() {
+    facade::udp_facade udp;
+    constexpr uint16_t port = 9003;
+
+    auto server = udp.create_server({
+        .port = port,
+        .server_id = "UdpEchoServer",
+    });
+
+    std::mutex sessions_mutex;
+    std::unordered_map<std::string, std::shared_ptr<interfaces::i_session>> sessions;
+
+    server->set_connection_callback(
+        [&sessions, &sessions_mutex](std::shared_ptr<interfaces::i_session> session) {
+            std::lock_guard<std::mutex> lock(sessions_mutex);
+            sessions[std::string(session->id())] = session;
+            std::cout << "[Server] New peer: " << session->id() << std::endl;
+        });
+
+    server->set_disconnection_callback(
+        [&sessions, &sessions_mutex](std::string_view session_id) {
+            std::lock_guard<std::mutex> lock(sessions_mutex);
+            sessions.erase(std::string(session_id));
+        });
+
+    server->set_receive_callback(
+        [&sessions, &sessions_mutex](std::string_view session_id,
+                                     const std::vector<uint8_t>& data) {
+            std::string msg(data.begin(), data.end());
+            std::cout << "[Server] From " << session_id << ": " << msg << std::endl;
+
+            // Echo back
+            std::shared_ptr<interfaces::i_session> session;
+            {
+                std::lock_guard<std::mutex> lock(sessions_mutex);
+                auto it = sessions.find(std::string(session_id));
+                if (it != sessions.end()) {
+                    session = it->second;
+                }
+            }
+            if (session) {
+                std::string echo = "Echo: " + msg;
+                std::vector<uint8_t> echo_data(echo.begin(), echo.end());
+                session->send(std::move(echo_data));
+            }
+        });
+
+    server->set_error_callback(
+        [](std::string_view session_id, std::error_code ec) {
+            std::cerr << "[Server] Error on " << session_id << ": " << ec.message()
+                      << std::endl;
+        });
+
+    std::cout << "[Server] UDP echo server on port " << port << std::endl;
+
+    while (!g_done.load()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    std::cout << "[Server] Stopped." << std::endl;
+}
+
+void run_client() {
+    // Give server time to start
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+    facade::udp_facade udp;
+    auto client = udp.create_client({
+        .host = "127.0.0.1",
+        .port = 9003,
+        .client_id = "UdpClient",
+    });
+
+    client->set_receive_callback([](const std::vector<uint8_t>& data) {
+        std::string msg(data.begin(), data.end());
+        std::cout << "[Client] Received: " << msg << std::endl;
+    });
+
+    client->set_error_callback([](std::error_code ec) {
+        std::cerr << "[Client] Error: " << ec.message() << std::endl;
+    });
+
+    // Send messages
+    std::vector<std::string> messages = {
+        "Hello UDP!",
+        "Datagrams preserve boundaries",
+        "Fast and lightweight",
+    };
+
+    for (const auto& msg : messages) {
+        std::vector<uint8_t> data(msg.begin(), msg.end());
+        std::cout << "[Client] Sending: " << msg << std::endl;
+
+        auto result = client->send(std::move(data));
+        if (result.is_err()) {
+            std::cerr << "[Client] Send failed: " << result.error().message << std::endl;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+
+    // Wait for final responses
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    g_done.store(true);
+}
+
+int main() {
+    std::cout << "=== UDP Echo Example ===" << std::endl;
+
+    try {
+        std::thread server_thread(run_server);
+        std::thread client_thread(run_client);
+
+        client_thread.join();
+        server_thread.join();
+
+        std::cout << "\n=== UDP echo example completed ===" << std::endl;
+    } catch (const std::exception& e) {
+        std::cerr << "Exception: " << e.what() << std::endl;
+        return 1;
+    }
+
+    return 0;
+}

--- a/examples/websocket_chat.cpp
+++ b/examples/websocket_chat.cpp
@@ -1,0 +1,195 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, Network System Project
+All rights reserved.
+*****************************************************************************/
+
+/**
+ * @file websocket_chat.cpp
+ * @brief WebSocket chat server and client in a single program
+ *
+ * Demonstrates:
+ * - Creating a WebSocket server via websocket_facade
+ * - Creating a WebSocket client via websocket_facade
+ * - Broadcasting messages from one client to all connected sessions
+ * - Session tracking on the server side
+ * - Full-duplex communication over WebSocket (RFC 6455)
+ *
+ * This example starts a server and two clients in separate threads,
+ * simulating a simple chat room.
+ */
+
+#include <kcenon/network/facade/websocket_facade.h>
+#include <kcenon/network/interfaces/i_session.h>
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace kcenon::network;
+
+// Shared state
+static std::atomic<bool> g_server_ready{false};
+static std::atomic<bool> g_done{false};
+
+/**
+ * @brief Run a WebSocket chat server that broadcasts messages to all clients
+ */
+void run_server() {
+    facade::websocket_facade ws;
+    constexpr uint16_t port = 9001;
+
+    auto server = ws.create_server({
+        .port = port,
+        .path = "/chat",
+        .server_id = "ChatServer",
+    });
+
+    // Track connected sessions
+    std::mutex sessions_mutex;
+    std::map<std::string, std::shared_ptr<interfaces::i_session>> sessions;
+
+    server->set_connection_callback(
+        [&sessions, &sessions_mutex](std::shared_ptr<interfaces::i_session> session) {
+            std::lock_guard<std::mutex> lock(sessions_mutex);
+            std::string id(session->id());
+            sessions[id] = session;
+            std::cout << "[Server] User joined: " << id << " ("
+                      << sessions.size() << " online)" << std::endl;
+        });
+
+    server->set_disconnection_callback(
+        [&sessions, &sessions_mutex](std::string_view session_id) {
+            std::lock_guard<std::mutex> lock(sessions_mutex);
+            sessions.erase(std::string(session_id));
+            std::cout << "[Server] User left: " << session_id << " ("
+                      << sessions.size() << " online)" << std::endl;
+        });
+
+    // Broadcast received messages to all connected clients
+    server->set_receive_callback(
+        [&sessions, &sessions_mutex](std::string_view sender_id,
+                                     const std::vector<uint8_t>& data) {
+            std::string message(data.begin(), data.end());
+            std::cout << "[Server] " << sender_id << " says: " << message << std::endl;
+
+            // Broadcast to all sessions
+            std::string broadcast = std::string(sender_id) + ": " + message;
+            std::vector<uint8_t> broadcast_data(broadcast.begin(), broadcast.end());
+
+            std::lock_guard<std::mutex> lock(sessions_mutex);
+            for (auto& [id, session] : sessions) {
+                session->send(std::vector<uint8_t>(broadcast_data));
+            }
+        });
+
+    server->set_error_callback(
+        [](std::string_view session_id, std::error_code ec) {
+            std::cerr << "[Server] Error on " << session_id << ": " << ec.message()
+                      << std::endl;
+        });
+
+    auto result = server->start(port);
+    if (result.is_err()) {
+        std::cerr << "[Server] Failed to start: " << result.error().message << std::endl;
+        return;
+    }
+
+    std::cout << "[Server] Chat server running on ws://localhost:" << port << "/chat"
+              << std::endl;
+    g_server_ready.store(true);
+
+    // Wait until chat is done
+    while (!g_done.load()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    server->stop();
+    std::cout << "[Server] Stopped." << std::endl;
+}
+
+/**
+ * @brief Run a WebSocket chat client that sends messages
+ */
+void run_client(const std::string& name, const std::vector<std::string>& messages) {
+    // Wait for server to be ready
+    while (!g_server_ready.load()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    facade::websocket_facade ws;
+    auto client = ws.create_client({
+        .client_id = name,
+    });
+
+    // Print received broadcast messages
+    client->set_receive_callback([&name](const std::vector<uint8_t>& data) {
+        std::string msg(data.begin(), data.end());
+        std::cout << "  [" << name << " received] " << msg << std::endl;
+    });
+
+    client->set_error_callback([&name](std::error_code ec) {
+        std::cerr << "  [" << name << "] Error: " << ec.message() << std::endl;
+    });
+
+    // Connect to the chat server
+    auto connect_result = client->start("127.0.0.1", 9001);
+    if (connect_result.is_err()) {
+        std::cerr << "  [" << name << "] Connection failed: "
+                  << connect_result.error().message << std::endl;
+        return;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    // Send messages with delays
+    for (const auto& msg : messages) {
+        std::vector<uint8_t> data(msg.begin(), msg.end());
+        auto send_result = client->send(std::move(data));
+        if (send_result.is_err()) {
+            std::cerr << "  [" << name << "] Send failed: "
+                      << send_result.error().message << std::endl;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(600));
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    client->stop();
+}
+
+int main() {
+    std::cout << "=== WebSocket Chat Example ===" << std::endl;
+
+    try {
+        // Start server
+        std::thread server_thread(run_server);
+
+        // Start two clients with different messages
+        std::thread client1(run_client, "Alice",
+                            std::vector<std::string>{"Hello everyone!", "How are you?"});
+        std::thread client2(run_client, "Bob",
+                            std::vector<std::string>{"Hi Alice!", "I am fine, thanks!"});
+
+        // Wait for clients to finish
+        client1.join();
+        client2.join();
+
+        // Signal server to stop
+        g_done.store(true);
+        server_thread.join();
+
+        std::cout << "\n=== Chat example completed ===" << std::endl;
+    } catch (const std::exception& e) {
+        std::cerr << "Exception: " << e.what() << std::endl;
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Closes #910

## Summary

- Add `examples/` directory with 6 focused, minimal C++20 usage examples using the facade API
- Examples cover TCP server/client, WebSocket chat, UDP echo, connection pooling, and the observer pattern
- Add `BUILD_EXAMPLES` CMake option (OFF by default) with integration into the root build system
- Add `examples/README.md` documenting each example with build instructions and API quick reference

### Examples

| Example | Description |
|---------|-------------|
| `tcp_echo_server` | TCP server with session management and data echoing |
| `tcp_client` | TCP client with text and binary messaging |
| `websocket_chat` | WebSocket server/client broadcast chat demo |
| `connection_pool` | TCP connection pool with multi-threaded access |
| `udp_echo` | UDP datagram echo server and client |
| `observer_pattern` | connection_observer, null_connection_observer, and callback_adapter |

## Test Plan

- [ ] Verify `BUILD_EXAMPLES=OFF` (default) does not affect the existing build
- [ ] Verify `BUILD_EXAMPLES=ON` compiles all examples without errors
- [ ] Verify `BUILD_WEBSOCKET_SUPPORT=OFF` correctly excludes `websocket_chat`
- [ ] Run each example binary to confirm it executes without crashes