### PR TITLE
feat(ci): add fuzzing CI workflow for protocol parsing

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -1,0 +1,276 @@
+name: Fuzzing Tests
+
+on:
+  schedule:
+    - cron: '0 2 * * 1'  # Every Monday at 02:00 UTC
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/protocols/**'
+      - 'src/internal/http_parser*'
+      - 'src/internal/websocket_frame*'
+      - 'include/kcenon/network/detail/protocols/**'
+      - 'fuzz/**'
+  workflow_dispatch:
+    inputs:
+      fuzz_duration:
+        description: 'Fuzzing duration in seconds'
+        required: false
+        default: '300'
+
+jobs:
+  fuzz:
+    name: Fuzz Testing
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout network_system
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          path: network_system
+
+      - name: Checkout common_system
+        uses: actions/checkout@v6
+        with:
+          repository: kcenon/common_system
+          path: common_system
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build clang llvm \
+            libgtest-dev libfmt-dev libssl-dev liblz4-dev zlib1g-dev python3
+
+      - name: Install ASIO from source
+        run: |
+          # Ubuntu 24.04's libasio-dev (1.28.1) has a recycling allocator bug.
+          # Install ASIO 1.32.0 from source for compatibility with sanitizers.
+          curl -L https://github.com/chriskohlhoff/asio/archive/asio-1-32-0.tar.gz -o asio.tar.gz
+          tar xzf asio.tar.gz
+          sudo mkdir -p /usr/local/include
+          sudo cp -r asio-asio-1-32-0/asio/include/asio /usr/local/include/
+          sudo cp asio-asio-1-32-0/asio/include/asio.hpp /usr/local/include/
+
+      - name: Build common_system dependency
+        run: |
+          cd common_system
+          CC=clang CXX=clang++ cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
+            -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined" \
+            -DBUILD_TESTS=OFF \
+            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_SAMPLES=OFF
+          cmake --build build
+          cmake --install build --prefix ${{ github.workspace }}/deps/install
+
+      - name: Generate seed corpus
+        run: |
+          cd network_system
+          python3 fuzz/generate_corpus.py
+          ls -la corpus/
+
+      - name: Configure with Fuzzing
+        run: |
+          cd network_system
+          CC=clang CXX=clang++ cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/install \
+            -DBUILD_FUZZING=ON \
+            -DBUILD_WITH_COMMON_SYSTEM=ON \
+            -DBUILD_WITH_LOGGER_SYSTEM=OFF \
+            -DBUILD_WITH_THREAD_SYSTEM=OFF \
+            -DBUILD_WITH_CONTAINER_SYSTEM=OFF \
+            -DBUILD_MESSAGING_BRIDGE=OFF \
+            -DBUILD_TESTS=OFF \
+            -DBUILD_SAMPLES=OFF \
+            -DBUILD_EXAMPLES=OFF \
+            -DASIO_INCLUDE_DIR=/usr/local/include \
+            -DSKIP_ASIO_RECYCLING_WORKAROUND=ON
+
+      - name: Build fuzz targets
+        run: |
+          cd network_system
+          cmake --build build --target \
+            fuzz_http2_frame \
+            fuzz_quic_varint \
+            fuzz_quic_frame \
+            fuzz_grpc_frame \
+            fuzz_hpack_decode
+
+      - name: Run HTTP/2 frame fuzzing
+        id: fuzz_http2
+        continue-on-error: true
+        run: |
+          cd network_system
+          DURATION=${{ github.event.inputs.fuzz_duration || '300' }}
+          echo "Running fuzz_http2_frame for ${DURATION} seconds..."
+          timeout ${DURATION} ./build/fuzz/fuzz_http2_frame corpus/http2_frame \
+            -max_len=4096 \
+            -print_final_stats=1 \
+            2>&1 | tee fuzz_http2_frame.log || true
+
+          if ls crash-* 1> /dev/null 2>&1; then
+            echo "crash_found=true" >> $GITHUB_OUTPUT
+            echo "::error::Crash found in fuzz_http2_frame"
+          else
+            echo "crash_found=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run QUIC varint fuzzing
+        id: fuzz_quic_varint
+        continue-on-error: true
+        run: |
+          cd network_system
+          DURATION=${{ github.event.inputs.fuzz_duration || '300' }}
+          echo "Running fuzz_quic_varint for ${DURATION} seconds..."
+          timeout ${DURATION} ./build/fuzz/fuzz_quic_varint corpus/quic_varint \
+            -max_len=1024 \
+            -print_final_stats=1 \
+            2>&1 | tee fuzz_quic_varint.log || true
+
+          if ls crash-* 1> /dev/null 2>&1; then
+            echo "crash_found=true" >> $GITHUB_OUTPUT
+            echo "::error::Crash found in fuzz_quic_varint"
+          else
+            echo "crash_found=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run QUIC frame fuzzing
+        id: fuzz_quic_frame
+        continue-on-error: true
+        run: |
+          cd network_system
+          DURATION=${{ github.event.inputs.fuzz_duration || '300' }}
+          echo "Running fuzz_quic_frame for ${DURATION} seconds..."
+          timeout ${DURATION} ./build/fuzz/fuzz_quic_frame corpus/quic_frame \
+            -max_len=4096 \
+            -print_final_stats=1 \
+            2>&1 | tee fuzz_quic_frame.log || true
+
+          if ls crash-* 1> /dev/null 2>&1; then
+            echo "crash_found=true" >> $GITHUB_OUTPUT
+            echo "::error::Crash found in fuzz_quic_frame"
+          else
+            echo "crash_found=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run gRPC frame fuzzing
+        id: fuzz_grpc
+        continue-on-error: true
+        run: |
+          cd network_system
+          DURATION=${{ github.event.inputs.fuzz_duration || '300' }}
+          echo "Running fuzz_grpc_frame for ${DURATION} seconds..."
+          timeout ${DURATION} ./build/fuzz/fuzz_grpc_frame corpus/grpc_frame \
+            -max_len=8192 \
+            -print_final_stats=1 \
+            2>&1 | tee fuzz_grpc_frame.log || true
+
+          if ls crash-* 1> /dev/null 2>&1; then
+            echo "crash_found=true" >> $GITHUB_OUTPUT
+            echo "::error::Crash found in fuzz_grpc_frame"
+          else
+            echo "crash_found=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run HPACK decode fuzzing
+        id: fuzz_hpack
+        continue-on-error: true
+        run: |
+          cd network_system
+          DURATION=${{ github.event.inputs.fuzz_duration || '300' }}
+          echo "Running fuzz_hpack_decode for ${DURATION} seconds..."
+          timeout ${DURATION} ./build/fuzz/fuzz_hpack_decode corpus/hpack_decode \
+            -max_len=4096 \
+            -print_final_stats=1 \
+            2>&1 | tee fuzz_hpack_decode.log || true
+
+          if ls crash-* 1> /dev/null 2>&1; then
+            echo "crash_found=true" >> $GITHUB_OUTPUT
+            echo "::error::Crash found in fuzz_hpack_decode"
+          else
+            echo "crash_found=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for crashes
+        run: |
+          cd network_system
+          if ls crash-* 1> /dev/null 2>&1; then
+            echo "Crashes found!"
+            ls -la crash-*
+            for crash in crash-*; do
+              echo "=== $crash ==="
+              xxd "$crash" | head -20
+            done
+            exit 1
+          fi
+          echo "No crashes found - fuzzing completed successfully"
+
+      - name: Generate summary
+        if: always()
+        run: |
+          cd network_system
+          echo "## Fuzzing Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if ls crash-* 1> /dev/null 2>&1; then
+            echo ":x: **Crashes detected**" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| File | Size |" >> $GITHUB_STEP_SUMMARY
+            echo "|------|------|" >> $GITHUB_STEP_SUMMARY
+            for crash in crash-*; do
+              size=$(stat -c%s "$crash" 2>/dev/null || stat -f%z "$crash")
+              echo "| $crash | $size bytes |" >> $GITHUB_STEP_SUMMARY
+            done
+          else
+            echo ":white_check_mark: **No crashes found**" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Fuzz Targets" >> $GITHUB_STEP_SUMMARY
+          echo "| Target | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| HTTP/2 Frame | ${{ steps.fuzz_http2.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| QUIC Varint | ${{ steps.fuzz_quic_varint.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| QUIC Frame | ${{ steps.fuzz_quic_frame.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| gRPC Frame | ${{ steps.fuzz_grpc.outcome }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| HPACK Decode | ${{ steps.fuzz_hpack.outcome }} |" >> $GITHUB_STEP_SUMMARY
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Corpus Statistics" >> $GITHUB_STEP_SUMMARY
+          echo "- HTTP/2 frame: $(ls corpus/http2_frame 2>/dev/null | wc -l) files" >> $GITHUB_STEP_SUMMARY
+          echo "- QUIC varint: $(ls corpus/quic_varint 2>/dev/null | wc -l) files" >> $GITHUB_STEP_SUMMARY
+          echo "- QUIC frame: $(ls corpus/quic_frame 2>/dev/null | wc -l) files" >> $GITHUB_STEP_SUMMARY
+          echo "- gRPC frame: $(ls corpus/grpc_frame 2>/dev/null | wc -l) files" >> $GITHUB_STEP_SUMMARY
+          echo "- HPACK decode: $(ls corpus/hpack_decode 2>/dev/null | wc -l) files" >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload corpus
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-corpus
+          path: network_system/corpus/
+          retention-days: 90
+
+      - name: Upload crashes
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-crashes
+          path: |
+            network_system/crash-*
+            network_system/fuzz_*.log
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-logs
+          path: network_system/fuzz_*.log
+          retention-days: 30

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -866,6 +866,14 @@ if(NETWORK_BUILD_BENCHMARKS AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/benchmarks)
 endif()
 
 ##################################################
+# Fuzzing Targets
+##################################################
+
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/fuzz/CMakeLists.txt)
+    add_subdirectory(fuzz)
+endif()
+
+##################################################
 # Installation
 ##################################################
 

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,0 +1,80 @@
+# Fuzzing targets for Network System protocol parsers
+# Requires Clang with -fsanitize=fuzzer support
+
+# Check if we're using Clang
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    option(BUILD_FUZZING "Build fuzz targets" OFF)
+
+    if(BUILD_FUZZING)
+        message(STATUS "Building fuzz targets with libFuzzer")
+
+        # Add fuzzer and sanitizer flags
+        set(FUZZ_COMPILE_FLAGS "-fsanitize=fuzzer,address,undefined -fno-omit-frame-pointer")
+        set(FUZZ_LINK_FLAGS "-fsanitize=fuzzer,address,undefined")
+
+        # Common include directories for all fuzz targets
+        set(FUZZ_INCLUDE_DIRS
+            ${CMAKE_SOURCE_DIR}/include
+            ${CMAKE_SOURCE_DIR}/src
+        )
+
+        # --- HTTP/2 frame parser fuzz target ---
+        add_executable(fuzz_http2_frame fuzz_http2_frame.cpp)
+        target_link_libraries(fuzz_http2_frame PRIVATE NetworkSystem)
+        target_include_directories(fuzz_http2_frame PRIVATE ${FUZZ_INCLUDE_DIRS})
+        set_target_properties(fuzz_http2_frame PROPERTIES
+            COMPILE_FLAGS "${FUZZ_COMPILE_FLAGS}"
+            LINK_FLAGS "${FUZZ_LINK_FLAGS}"
+        )
+
+        # --- QUIC varint decoder fuzz target ---
+        add_executable(fuzz_quic_varint fuzz_quic_varint.cpp)
+        target_link_libraries(fuzz_quic_varint PRIVATE NetworkSystem)
+        target_include_directories(fuzz_quic_varint PRIVATE ${FUZZ_INCLUDE_DIRS})
+        set_target_properties(fuzz_quic_varint PROPERTIES
+            COMPILE_FLAGS "${FUZZ_COMPILE_FLAGS}"
+            LINK_FLAGS "${FUZZ_LINK_FLAGS}"
+        )
+
+        # --- QUIC frame parser fuzz target ---
+        add_executable(fuzz_quic_frame fuzz_quic_frame.cpp)
+        target_link_libraries(fuzz_quic_frame PRIVATE NetworkSystem)
+        target_include_directories(fuzz_quic_frame PRIVATE ${FUZZ_INCLUDE_DIRS})
+        set_target_properties(fuzz_quic_frame PROPERTIES
+            COMPILE_FLAGS "${FUZZ_COMPILE_FLAGS}"
+            LINK_FLAGS "${FUZZ_LINK_FLAGS}"
+        )
+
+        # --- gRPC message parser fuzz target ---
+        add_executable(fuzz_grpc_frame fuzz_grpc_frame.cpp)
+        target_link_libraries(fuzz_grpc_frame PRIVATE NetworkSystem)
+        target_include_directories(fuzz_grpc_frame PRIVATE ${FUZZ_INCLUDE_DIRS})
+        set_target_properties(fuzz_grpc_frame PROPERTIES
+            COMPILE_FLAGS "${FUZZ_COMPILE_FLAGS}"
+            LINK_FLAGS "${FUZZ_LINK_FLAGS}"
+        )
+
+        # --- HPACK header decoder fuzz target ---
+        add_executable(fuzz_hpack_decode fuzz_hpack_decode.cpp)
+        target_link_libraries(fuzz_hpack_decode PRIVATE NetworkSystem)
+        target_include_directories(fuzz_hpack_decode PRIVATE ${FUZZ_INCLUDE_DIRS})
+        set_target_properties(fuzz_hpack_decode PROPERTIES
+            COMPILE_FLAGS "${FUZZ_COMPILE_FLAGS}"
+            LINK_FLAGS "${FUZZ_LINK_FLAGS}"
+        )
+
+        # Create corpus directories
+        file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/corpus/http2_frame)
+        file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/corpus/quic_varint)
+        file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/corpus/quic_frame)
+        file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/corpus/grpc_frame)
+        file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/corpus/hpack_decode)
+
+        # Copy seed corpus if it exists
+        if(EXISTS ${CMAKE_SOURCE_DIR}/fuzz/corpus)
+            file(COPY ${CMAKE_SOURCE_DIR}/fuzz/corpus DESTINATION ${CMAKE_BINARY_DIR})
+        endif()
+    endif()
+else()
+    message(STATUS "Fuzzing targets require Clang compiler - skipping")
+endif()

--- a/fuzz/fuzz_grpc_frame.cpp
+++ b/fuzz/fuzz_grpc_frame.cpp
@@ -1,0 +1,88 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file fuzz_grpc_frame.cpp
+ * @brief Fuzz target for gRPC message and timeout parsing
+ *
+ * Tests grpc_message::parse() and parse_timeout() with random input
+ * to detect memory safety issues in gRPC protocol parsing.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <string_view>
+
+#include "kcenon/network/detail/protocols/grpc/frame.h"
+
+using namespace kcenon::network::protocols::grpc;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    std::span<const uint8_t> input(data, size);
+
+    // Test grpc_message::parse with raw input
+    auto msg_result = grpc_message::parse(input);
+    if (msg_result.is_ok())
+    {
+        auto& msg = msg_result.value();
+
+        // Exercise accessors
+        (void)msg.compressed;
+        (void)msg.empty();
+        (void)msg.size();
+        (void)msg.serialized_size();
+
+        // Re-serialize to verify round-trip safety
+        auto serialized = msg.serialize();
+        (void)serialized;
+    }
+
+    // Test parse_timeout with input interpreted as string
+    if (size > 0 && size <= 256)
+    {
+        std::string_view timeout_str(reinterpret_cast<const char*>(data), size);
+        auto timeout_ms = parse_timeout(timeout_str);
+        (void)timeout_ms;
+
+        // Test format_timeout round-trip
+        if (timeout_ms > 0)
+        {
+            auto formatted = format_timeout(timeout_ms);
+            (void)formatted;
+        }
+    }
+
+    return 0;
+}

--- a/fuzz/fuzz_hpack_decode.cpp
+++ b/fuzz/fuzz_hpack_decode.cpp
@@ -1,0 +1,84 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file fuzz_hpack_decode.cpp
+ * @brief Fuzz target for HPACK header compression decoding
+ *
+ * Tests hpack_decoder::decode() with random input to detect memory
+ * safety issues in HTTP/2 header compression parsing (RFC 7541).
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+#include "internal/protocols/http2/hpack.h"
+
+using namespace kcenon::network::protocols::http2;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    std::span<const uint8_t> input(data, size);
+
+    // Test HPACK decoding with default table size
+    {
+        hpack_decoder decoder(4096);
+        auto result = decoder.decode(input);
+        if (result.is_ok())
+        {
+            for (const auto& header : result.value())
+            {
+                (void)header.name;
+                (void)header.value;
+                (void)header.size();
+            }
+        }
+    }
+
+    // Test HPACK decoding with small table size (stress eviction)
+    {
+        hpack_decoder decoder(256);
+        auto result = decoder.decode(input);
+        (void)result;
+    }
+
+    // Test static table lookups with first byte as index
+    if (size > 0)
+    {
+        size_t index = static_cast<size_t>(data[0]) % 70;
+        auto entry = static_table::get(index);
+        (void)entry;
+    }
+
+    return 0;
+}

--- a/fuzz/fuzz_http2_frame.cpp
+++ b/fuzz/fuzz_http2_frame.cpp
@@ -1,0 +1,84 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file fuzz_http2_frame.cpp
+ * @brief Fuzz target for HTTP/2 frame parsing
+ *
+ * Tests frame_header::parse() and frame::parse() with random input
+ * to detect memory safety issues in HTTP/2 frame deserialization.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+#include "internal/protocols/http2/frame.h"
+
+using namespace kcenon::network::protocols::http2;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    std::span<const uint8_t> input(data, size);
+
+    // Test frame_header::parse with raw input
+    auto header_result = frame_header::parse(input);
+    if (header_result.is_ok())
+    {
+        auto& hdr = header_result.value();
+        // Exercise accessors
+        (void)hdr.length;
+        (void)hdr.type;
+        (void)hdr.flags;
+        (void)hdr.stream_id;
+
+        // Re-serialize to verify round-trip safety
+        auto serialized = hdr.serialize();
+        (void)serialized;
+    }
+
+    // Test full frame::parse with raw input
+    auto frame_result = frame::parse(input);
+    if (frame_result.is_ok())
+    {
+        auto& f = frame_result.value();
+        // Exercise accessors
+        (void)f->header();
+        (void)f->payload();
+
+        // Re-serialize to verify round-trip safety
+        auto serialized = f->serialize();
+        (void)serialized;
+    }
+
+    return 0;
+}

--- a/fuzz/fuzz_quic_frame.cpp
+++ b/fuzz/fuzz_quic_frame.cpp
@@ -1,0 +1,77 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file fuzz_quic_frame.cpp
+ * @brief Fuzz target for QUIC frame parsing
+ *
+ * Tests frame_parser::parse() and frame_parser::parse_all() with
+ * random input to detect memory safety issues in QUIC frame
+ * deserialization (RFC 9000 Section 12/19).
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+#include "internal/protocols/quic/frame.h"
+
+using namespace kcenon::network::protocols::quic;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    std::span<const uint8_t> input(data, size);
+
+    // Test single frame parsing
+    auto single_result = frame_parser::parse(input);
+    if (single_result.is_ok())
+    {
+        auto& [parsed_frame, bytes_consumed] = single_result.value();
+        (void)get_frame_type(parsed_frame);
+    }
+
+    // Test peek_type (lightweight type check without full parsing)
+    auto peek_result = frame_parser::peek_type(input);
+    (void)peek_result;
+
+    // Test parsing all frames from buffer
+    auto all_result = frame_parser::parse_all(input);
+    if (all_result.is_ok())
+    {
+        for (const auto& f : all_result.value())
+        {
+            (void)get_frame_type(f);
+        }
+    }
+
+    return 0;
+}

--- a/fuzz/fuzz_quic_varint.cpp
+++ b/fuzz/fuzz_quic_varint.cpp
@@ -1,0 +1,84 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2024, kcenon
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+/**
+ * @file fuzz_quic_varint.cpp
+ * @brief Fuzz target for QUIC variable-length integer decoding
+ *
+ * Tests varint::decode() with random input to detect memory safety
+ * issues in RFC 9000 Section 16 variable-length integer parsing.
+ */
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+#include "internal/protocols/quic/varint.h"
+
+using namespace kcenon::network::protocols::quic;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    std::span<const uint8_t> input(data, size);
+
+    // Test varint::decode with raw input
+    auto result = varint::decode(input);
+    if (result.is_ok())
+    {
+        auto [value, bytes_consumed] = result.value();
+
+        // Verify encode round-trip does not crash
+        auto encoded = varint::encode(value);
+        (void)encoded;
+
+        // Test encode_with_length with decoded value
+        for (size_t len : {1UL, 2UL, 4UL, 8UL})
+        {
+            auto ewl_result = varint::encode_with_length(value, len);
+            (void)ewl_result;
+        }
+
+        // Test length computations
+        (void)varint::encoded_length(value);
+        (void)varint::is_valid(value);
+
+        // If there is remaining data after first varint, try decoding more
+        if (bytes_consumed < size)
+        {
+            auto remaining = input.subspan(bytes_consumed);
+            auto next = varint::decode(remaining);
+            (void)next;
+        }
+    }
+
+    return 0;
+}

--- a/fuzz/generate_corpus.py
+++ b/fuzz/generate_corpus.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""
+Generate seed corpus for network protocol fuzzing.
+
+Creates valid and edge-case serialized data to seed the fuzzer
+for better coverage of the protocol parsing code.
+"""
+
+import os
+import struct
+from pathlib import Path
+
+
+def generate_http2_frame_corpus(output_dir: Path):
+    """Generate seed corpus for HTTP/2 frame parsing."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    def make_frame_header(length, frame_type, flags, stream_id):
+        """Create a 9-byte HTTP/2 frame header."""
+        # Length: 24 bits (3 bytes, big-endian)
+        # Type: 8 bits
+        # Flags: 8 bits
+        # Stream ID: 32 bits (MSB reserved, big-endian)
+        return (
+            struct.pack(">I", length)[1:]  # 3 bytes of big-endian uint32
+            + bytes([frame_type, flags])
+            + struct.pack(">I", stream_id & 0x7FFFFFFF)
+        )
+
+    # DATA frame (type 0x0)
+    payload = b"Hello, World!"
+    header = make_frame_header(len(payload), 0x0, 0x01, 1)  # END_STREAM
+    with open(output_dir / "data_frame", "wb") as f:
+        f.write(header + payload)
+
+    # HEADERS frame (type 0x1)
+    hpack_block = bytes([0x82, 0x86])  # :method GET, :path /
+    header = make_frame_header(len(hpack_block), 0x1, 0x05, 1)  # END_STREAM | END_HEADERS
+    with open(output_dir / "headers_frame", "wb") as f:
+        f.write(header + hpack_block)
+
+    # SETTINGS frame (type 0x4) with parameters
+    settings_payload = struct.pack(">HI", 0x3, 100)  # MAX_CONCURRENT_STREAMS = 100
+    header = make_frame_header(len(settings_payload), 0x4, 0x0, 0)
+    with open(output_dir / "settings_frame", "wb") as f:
+        f.write(header + settings_payload)
+
+    # SETTINGS ACK (empty)
+    header = make_frame_header(0, 0x4, 0x01, 0)  # ACK flag
+    with open(output_dir / "settings_ack", "wb") as f:
+        f.write(header)
+
+    # RST_STREAM frame (type 0x3)
+    rst_payload = struct.pack(">I", 0x0)  # NO_ERROR
+    header = make_frame_header(len(rst_payload), 0x3, 0x0, 1)
+    with open(output_dir / "rst_stream", "wb") as f:
+        f.write(header + rst_payload)
+
+    # PING frame (type 0x6)
+    ping_data = b"\x00\x01\x02\x03\x04\x05\x06\x07"
+    header = make_frame_header(8, 0x6, 0x0, 0)
+    with open(output_dir / "ping_frame", "wb") as f:
+        f.write(header + ping_data)
+
+    # GOAWAY frame (type 0x7)
+    goaway_payload = struct.pack(">II", 0, 0x0)  # last_stream_id=0, NO_ERROR
+    header = make_frame_header(len(goaway_payload), 0x7, 0x0, 0)
+    with open(output_dir / "goaway_frame", "wb") as f:
+        f.write(header + goaway_payload)
+
+    # WINDOW_UPDATE frame (type 0x8)
+    wu_payload = struct.pack(">I", 65535)
+    header = make_frame_header(len(wu_payload), 0x8, 0x0, 0)
+    with open(output_dir / "window_update", "wb") as f:
+        f.write(header + wu_payload)
+
+    # Edge cases
+    with open(output_dir / "empty", "wb") as f:
+        f.write(b"")
+
+    with open(output_dir / "truncated_header", "wb") as f:
+        f.write(b"\x00\x00\x04")  # Only 3 bytes of 9-byte header
+
+    with open(output_dir / "oversized_length", "wb") as f:
+        f.write(make_frame_header(0xFFFFFF, 0x0, 0x0, 1))  # Max length, no payload
+
+    with open(output_dir / "invalid_type", "wb") as f:
+        f.write(make_frame_header(0, 0xFF, 0x0, 0))
+
+    with open(output_dir / "all_flags_set", "wb") as f:
+        f.write(make_frame_header(0, 0x0, 0xFF, 1))
+
+    print(f"Generated {len(list(output_dir.iterdir()))} HTTP/2 frame seeds in {output_dir}")
+
+
+def generate_quic_varint_corpus(output_dir: Path):
+    """Generate seed corpus for QUIC varint decoding."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # 1-byte encoding (6-bit, prefix 0b00)
+    with open(output_dir / "varint_0", "wb") as f:
+        f.write(bytes([0x00]))  # value = 0
+
+    with open(output_dir / "varint_63", "wb") as f:
+        f.write(bytes([0x3F]))  # value = 63 (max 1-byte)
+
+    # 2-byte encoding (14-bit, prefix 0b01)
+    with open(output_dir / "varint_64", "wb") as f:
+        f.write(bytes([0x40, 0x40]))  # value = 64
+
+    with open(output_dir / "varint_16383", "wb") as f:
+        f.write(bytes([0x7F, 0xFF]))  # value = 16383 (max 2-byte)
+
+    # 4-byte encoding (30-bit, prefix 0b10)
+    with open(output_dir / "varint_16384", "wb") as f:
+        f.write(bytes([0x80, 0x00, 0x40, 0x00]))  # value = 16384
+
+    with open(output_dir / "varint_1073741823", "wb") as f:
+        f.write(bytes([0xBF, 0xFF, 0xFF, 0xFF]))  # value = 1073741823 (max 4-byte)
+
+    # 8-byte encoding (62-bit, prefix 0b11)
+    with open(output_dir / "varint_8byte", "wb") as f:
+        f.write(bytes([0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00]))
+
+    with open(output_dir / "varint_max", "wb") as f:
+        f.write(bytes([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]))  # max 62-bit
+
+    # Multiple varints concatenated
+    with open(output_dir / "multi_varint", "wb") as f:
+        f.write(bytes([0x00, 0x3F, 0x40, 0x40]))  # 0, 63, 64
+
+    # Edge cases
+    with open(output_dir / "empty", "wb") as f:
+        f.write(b"")
+
+    with open(output_dir / "truncated_2byte", "wb") as f:
+        f.write(bytes([0x40]))  # 2-byte prefix but only 1 byte
+
+    with open(output_dir / "truncated_4byte", "wb") as f:
+        f.write(bytes([0x80, 0x00]))  # 4-byte prefix but only 2 bytes
+
+    with open(output_dir / "truncated_8byte", "wb") as f:
+        f.write(bytes([0xC0, 0x00, 0x00]))  # 8-byte prefix but only 3 bytes
+
+    print(f"Generated {len(list(output_dir.iterdir()))} QUIC varint seeds in {output_dir}")
+
+
+def generate_quic_frame_corpus(output_dir: Path):
+    """Generate seed corpus for QUIC frame parsing."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    def varint_encode(value):
+        """Encode a value as a QUIC varint."""
+        if value <= 63:
+            return bytes([value])
+        elif value <= 16383:
+            return bytes([0x40 | (value >> 8), value & 0xFF])
+        elif value <= 1073741823:
+            return bytes([
+                0x80 | ((value >> 24) & 0x3F),
+                (value >> 16) & 0xFF,
+                (value >> 8) & 0xFF,
+                value & 0xFF,
+            ])
+        else:
+            return bytes([
+                0xC0 | ((value >> 56) & 0x3F),
+                (value >> 48) & 0xFF,
+                (value >> 40) & 0xFF,
+                (value >> 32) & 0xFF,
+                (value >> 24) & 0xFF,
+                (value >> 16) & 0xFF,
+                (value >> 8) & 0xFF,
+                value & 0xFF,
+            ])
+
+    # PADDING frame (type 0x00) - just zero bytes
+    with open(output_dir / "padding_frame", "wb") as f:
+        f.write(bytes([0x00, 0x00, 0x00]))
+
+    # PING frame (type 0x01) - single byte
+    with open(output_dir / "ping_frame", "wb") as f:
+        f.write(varint_encode(0x01))
+
+    # ACK frame (type 0x02)
+    with open(output_dir / "ack_frame", "wb") as f:
+        data = varint_encode(0x02)  # type
+        data += varint_encode(100)  # largest_acked
+        data += varint_encode(0)    # ack_delay
+        data += varint_encode(0)    # ack_range_count
+        data += varint_encode(0)    # first_ack_range
+        f.write(data)
+
+    # RESET_STREAM frame (type 0x04)
+    with open(output_dir / "reset_stream", "wb") as f:
+        data = varint_encode(0x04)  # type
+        data += varint_encode(1)    # stream_id
+        data += varint_encode(0)    # app_error_code
+        data += varint_encode(100)  # final_size
+        f.write(data)
+
+    # CRYPTO frame (type 0x06)
+    with open(output_dir / "crypto_frame", "wb") as f:
+        crypto_data = b"TLS handshake data"
+        data = varint_encode(0x06)              # type
+        data += varint_encode(0)                # offset
+        data += varint_encode(len(crypto_data)) # length
+        data += crypto_data
+        f.write(data)
+
+    # STREAM frame (type 0x08)
+    with open(output_dir / "stream_frame", "wb") as f:
+        stream_data = b"Hello stream"
+        data = varint_encode(0x08)               # type (stream_base)
+        data += varint_encode(4)                 # stream_id
+        data += stream_data
+        f.write(data)
+
+    # CONNECTION_CLOSE frame (type 0x1c)
+    with open(output_dir / "connection_close", "wb") as f:
+        reason = b"no error"
+        data = varint_encode(0x1c)           # type
+        data += varint_encode(0)             # error_code
+        data += varint_encode(0)             # frame_type
+        data += varint_encode(len(reason))   # reason_phrase_length
+        data += reason
+        f.write(data)
+
+    # Edge cases
+    with open(output_dir / "empty", "wb") as f:
+        f.write(b"")
+
+    with open(output_dir / "unknown_type", "wb") as f:
+        f.write(varint_encode(0xFF))  # Unknown frame type
+
+    with open(output_dir / "truncated", "wb") as f:
+        f.write(varint_encode(0x04) + varint_encode(1))  # Incomplete RESET_STREAM
+
+    print(f"Generated {len(list(output_dir.iterdir()))} QUIC frame seeds in {output_dir}")
+
+
+def generate_grpc_frame_corpus(output_dir: Path):
+    """Generate seed corpus for gRPC message parsing."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    def make_grpc_message(compressed, payload):
+        """Create a gRPC length-prefixed message."""
+        header = bytes([1 if compressed else 0])
+        header += struct.pack(">I", len(payload))
+        return header + payload
+
+    # Simple uncompressed message
+    with open(output_dir / "simple_msg", "wb") as f:
+        f.write(make_grpc_message(False, b"\x0a\x05Hello"))
+
+    # Compressed flag set
+    with open(output_dir / "compressed_msg", "wb") as f:
+        f.write(make_grpc_message(True, b"\x0a\x05Hello"))
+
+    # Empty message
+    with open(output_dir / "empty_msg", "wb") as f:
+        f.write(make_grpc_message(False, b""))
+
+    # Larger payload
+    with open(output_dir / "large_msg", "wb") as f:
+        f.write(make_grpc_message(False, b"\x00" * 1024))
+
+    # Timeout strings
+    for name, value in [
+        ("timeout_seconds", b"10S"),
+        ("timeout_millis", b"500m"),
+        ("timeout_hours", b"1H"),
+        ("timeout_minutes", b"30M"),
+        ("timeout_micros", b"1000u"),
+        ("timeout_nanos", b"999999n"),
+    ]:
+        with open(output_dir / name, "wb") as f:
+            f.write(value)
+
+    # Edge cases
+    with open(output_dir / "empty", "wb") as f:
+        f.write(b"")
+
+    with open(output_dir / "truncated_header", "wb") as f:
+        f.write(b"\x00\x00\x00")  # Only 3 of 5 header bytes
+
+    with open(output_dir / "oversized_length", "wb") as f:
+        f.write(b"\x00" + struct.pack(">I", 0x00FFFFFF))  # Large length, no payload
+
+    with open(output_dir / "invalid_compressed_flag", "wb") as f:
+        f.write(b"\xFF" + struct.pack(">I", 0) + b"")  # Non-standard compressed flag
+
+    print(f"Generated {len(list(output_dir.iterdir()))} gRPC frame seeds in {output_dir}")
+
+
+def generate_hpack_corpus(output_dir: Path):
+    """Generate seed corpus for HPACK decoding."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Indexed header field (prefix 1xxxxxxx)
+    # Static table index 2 = :method GET
+    with open(output_dir / "indexed_get", "wb") as f:
+        f.write(bytes([0x82]))
+
+    # Indexed header field - :path /
+    with open(output_dir / "indexed_path", "wb") as f:
+        f.write(bytes([0x84]))
+
+    # Multiple indexed headers
+    with open(output_dir / "multi_indexed", "wb") as f:
+        f.write(bytes([0x82, 0x86, 0x84]))  # GET, scheme https, /
+
+    # Literal header with incremental indexing (prefix 01xxxxxx)
+    # New name and value
+    with open(output_dir / "literal_new", "wb") as f:
+        name = b"x-custom"
+        value = b"test-value"
+        data = bytes([0x40])  # Literal with incremental indexing, new name
+        data += bytes([len(name)]) + name
+        data += bytes([len(value)]) + value
+        f.write(data)
+
+    # Literal header with indexed name (prefix 01xxxxxx, name index > 0)
+    with open(output_dir / "literal_indexed_name", "wb") as f:
+        value = b"bar"
+        data = bytes([0x41])  # Incremental indexing, name index 1 (:authority)
+        data += bytes([len(value)]) + value
+        f.write(data)
+
+    # Literal header without indexing (prefix 0000xxxx)
+    with open(output_dir / "literal_no_index", "wb") as f:
+        name = b"cache-control"
+        value = b"no-cache"
+        data = bytes([0x00])  # No indexing, new name
+        data += bytes([len(name)]) + name
+        data += bytes([len(value)]) + value
+        f.write(data)
+
+    # Dynamic table size update (prefix 001xxxxx)
+    with open(output_dir / "table_size_update", "wb") as f:
+        f.write(bytes([0x20 | 0x1F, 0x00]))  # Update to size 31
+
+    # Edge cases
+    with open(output_dir / "empty", "wb") as f:
+        f.write(b"")
+
+    with open(output_dir / "max_index", "wb") as f:
+        f.write(bytes([0xFF, 0x00]))  # Index 127 (static table only has 61)
+
+    with open(output_dir / "truncated_string", "wb") as f:
+        f.write(bytes([0x40, 0x05, 0x41]))  # Claims 5-byte name but only 1 byte
+
+    with open(output_dir / "huffman_encoded", "wb") as f:
+        # Huffman flag set (bit 7 of string length byte)
+        f.write(bytes([0x82]))  # Indexed, then some huffman data
+        f.write(bytes([0x40, 0x85, 0xF2, 0xB2, 0x4A, 0x84, 0xFF]))  # Huffman-encoded name
+
+    print(f"Generated {len(list(output_dir.iterdir()))} HPACK decode seeds in {output_dir}")
+
+
+def main():
+    base_dir = Path("corpus")
+
+    generate_http2_frame_corpus(base_dir / "http2_frame")
+    generate_quic_varint_corpus(base_dir / "quic_varint")
+    generate_quic_frame_corpus(base_dir / "quic_frame")
+    generate_grpc_frame_corpus(base_dir / "grpc_frame")
+    generate_hpack_corpus(base_dir / "hpack_decode")
+
+    print(f"\nCorpus generation complete!")
+    print(f"Total files: {sum(1 for _ in base_dir.rglob('*') if _.is_file())}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #909

## Summary
- Add libFuzzer-based fuzz testing for 5 protocol parsers: HTTP/2 frame, QUIC varint, QUIC frame, gRPC message, and HPACK header decoding
- Create `fuzzing.yml` CI workflow running weekly (Monday 02:00 UTC) and on PRs that touch protocol code
- Include seed corpus generator (`fuzz/generate_corpus.py`) with valid and edge-case inputs for each parser
- Build fuzz targets with AddressSanitizer and UndefinedBehaviorSanitizer alongside libFuzzer
- Follow existing ecosystem pattern from container_system's fuzzing workflow

## Fuzz Targets
| Target | Parser | Protocol |
|--------|--------|----------|
| `fuzz_http2_frame` | `frame_header::parse()`, `frame::parse()` | HTTP/2 (RFC 7540) |
| `fuzz_quic_varint` | `varint::decode()` | QUIC (RFC 9000 Section 16) |
| `fuzz_quic_frame` | `frame_parser::parse()`, `frame_parser::parse_all()` | QUIC (RFC 9000 Section 12/19) |
| `fuzz_grpc_frame` | `grpc_message::parse()`, `parse_timeout()` | gRPC |
| `fuzz_hpack_decode` | `hpack_decoder::decode()` | HPACK (RFC 7541) |

## Test Plan
- [ ] Fuzzing workflow triggers correctly on PR and manual dispatch
- [ ] All 5 fuzz targets compile successfully with Clang + libFuzzer
- [ ] Seed corpus generation completes without errors
- [ ] No crashes found during initial 300-second fuzzing runs
- [ ] Crash artifacts are uploaded when issues are detected