### PR TITLE
refactor: rename CMake project from NetworkSystem to network_system

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,7 @@ jobs:
         echo "" >> release-notes.md
         echo "# Include in your CMake project" >> release-notes.md
         echo "find_package(network_system REQUIRED)" >> release-notes.md
-        echo "target_link_libraries(your_app NetworkSystem::NetworkSystem)" >> release-notes.md
+        echo "target_link_libraries(your_app network_system::network_system)" >> release-notes.md
         echo '```' >> release-notes.md
         echo "" >> release-notes.md
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 # Independent high-performance network system
 ##################################################
 
-project(NetworkSystem
+project(network_system
     VERSION 0.1.1
     DESCRIPTION "Independent High-Performance Network System"
     LANGUAGES CXX
@@ -271,10 +271,10 @@ endfunction()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-include(NetworkSystemFeatures)
-include(NetworkSystemDependencies)
-include(NetworkSystemIntegration)
-include(NetworkSystemInstall)
+include(network_system_features)
+include(network_system_dependencies)
+include(network_system_integration)
+include(network_system_install)
 
 ##################################################
 # Dependency Detection
@@ -305,7 +305,7 @@ endif()
 ##################################################
 # Shared Integration Objects (ODR Fix - Issue #555)
 #
-# These sources are shared between NetworkSystem and network-tcp.
+# These sources are shared between network_system and network-tcp.
 # Using an OBJECT library ensures symbols are defined exactly once,
 # preventing ODR (One Definition Rule) violations that cause SEGV
 # in sanitizer tests.
@@ -414,7 +414,7 @@ endif()
 # Create Main Library
 ##################################################
 
-add_library(NetworkSystem
+add_library(network_system
     # Main API implementation
     src/network_system.cpp
 
@@ -537,7 +537,7 @@ add_library(NetworkSystem
 # WARNING: Suppressions removed for strict code quality check. 
 # Fix the code instead of suppressing warnings!
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    # target_compile_options(NetworkSystem PRIVATE
+    # target_compile_options(network_system PRIVATE
     #     -Wno-sign-conversion
     #     -Wno-conversion
     #     -Wno-implicit-fallthrough
@@ -547,7 +547,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     #     -Wno-unused-variable
     # )
 elseif(MSVC)
-    # target_compile_options(NetworkSystem PRIVATE
+    # target_compile_options(network_system PRIVATE
     #     /wd4244  # conversion from 'type1' to 'type2', possible loss of data
     #     /wd4267  # conversion from 'size_t' to 'type', possible loss of data
     #     /wd4100  # unreferenced formal parameter
@@ -562,7 +562,7 @@ option(BUILD_TLS_SUPPORT "Build with TLS/SSL support for secure messaging" ON)
 option(BUILD_LZ4_COMPRESSION "Build with LZ4 compression support" ON)
 
 if(BUILD_TLS_SUPPORT)
-    target_sources(NetworkSystem PRIVATE
+    target_sources(network_system PRIVATE
         # secure_tcp_socket moved to libs/network-tcp (Issue #554)
         # secure_messaging_udp moved to libs/network-udp (Issue #561)
         src/internal/dtls_socket.cpp
@@ -575,13 +575,13 @@ if(BUILD_TLS_SUPPORT)
         src/protocols/http2/http2_server.cpp
         src/protocols/http2/http2_server_stream.cpp
     )
-    target_compile_definitions(NetworkSystem PUBLIC BUILD_TLS_SUPPORT)
+    target_compile_definitions(network_system PUBLIC BUILD_TLS_SUPPORT)
 
     # Find OpenSSL for TLS/SSL
     # Minimum requirement: OpenSSL 3.0.0
     # OpenSSL 1.1.x reached EOL on September 11, 2023 and is no longer supported
     find_package(OpenSSL 3.0.0 REQUIRED)
-    target_link_libraries(NetworkSystem PUBLIC OpenSSL::SSL OpenSSL::Crypto)
+    target_link_libraries(network_system PUBLIC OpenSSL::SSL OpenSSL::Crypto)
 
     message(STATUS "TLS/SSL support enabled (TLS 1.2/1.3)")
     message(STATUS "  OpenSSL version: ${OPENSSL_VERSION}")
@@ -589,7 +589,7 @@ endif()
 
 # WebSocket support (conditional) - part of HTTP layer
 if(BUILD_WEBSOCKET_SUPPORT)
-    target_sources(NetworkSystem PRIVATE
+    target_sources(network_system PRIVATE
         src/internal/websocket_frame.cpp
         src/internal/websocket_handshake.cpp
         src/internal/websocket_protocol.cpp
@@ -597,12 +597,12 @@ if(BUILD_WEBSOCKET_SUPPORT)
         src/http/websocket_client.cpp
         src/http/websocket_server.cpp
     )
-    target_compile_definitions(NetworkSystem PUBLIC BUILD_WEBSOCKET_SUPPORT)
+    target_compile_definitions(network_system PUBLIC BUILD_WEBSOCKET_SUPPORT)
 
     # Find OpenSSL for SHA-1 hashing in handshake (if not already found)
     if(NOT BUILD_TLS_SUPPORT)
         find_package(OpenSSL 3.0.0 REQUIRED)
-        target_link_libraries(NetworkSystem PRIVATE OpenSSL::Crypto)
+        target_link_libraries(network_system PRIVATE OpenSSL::Crypto)
         message(STATUS "  OpenSSL version: ${OPENSSL_VERSION}")
     endif()
 
@@ -616,9 +616,9 @@ if(BUILD_LZ4_COMPRESSION)
     find_path(LZ4_INCLUDE_DIR NAMES lz4.h)
 
     if(LZ4_LIBRARY AND LZ4_INCLUDE_DIR)
-        target_compile_definitions(NetworkSystem PUBLIC BUILD_LZ4_COMPRESSION)
-        target_include_directories(NetworkSystem PRIVATE ${LZ4_INCLUDE_DIR})
-        target_link_libraries(NetworkSystem PRIVATE ${LZ4_LIBRARY})
+        target_compile_definitions(network_system PUBLIC BUILD_LZ4_COMPRESSION)
+        target_include_directories(network_system PRIVATE ${LZ4_INCLUDE_DIR})
+        target_link_libraries(network_system PRIVATE ${LZ4_LIBRARY})
         message(STATUS "LZ4 compression enabled")
         message(STATUS "  LZ4 library: ${LZ4_LIBRARY}")
         message(STATUS "  LZ4 include: ${LZ4_INCLUDE_DIR}")
@@ -628,9 +628,9 @@ if(BUILD_LZ4_COMPRESSION)
         if(PkgConfig_FOUND)
             pkg_check_modules(LZ4 QUIET liblz4)
             if(LZ4_FOUND)
-                target_compile_definitions(NetworkSystem PUBLIC BUILD_LZ4_COMPRESSION)
-                target_include_directories(NetworkSystem PRIVATE ${LZ4_INCLUDE_DIRS})
-                target_link_libraries(NetworkSystem PRIVATE ${LZ4_LIBRARIES})
+                target_compile_definitions(network_system PUBLIC BUILD_LZ4_COMPRESSION)
+                target_include_directories(network_system PRIVATE ${LZ4_INCLUDE_DIRS})
+                target_link_libraries(network_system PRIVATE ${LZ4_LIBRARIES})
                 message(STATUS "LZ4 compression enabled (via pkg-config)")
                 message(STATUS "  LZ4 version: ${LZ4_VERSION}")
             else()
@@ -651,8 +651,8 @@ if(BUILD_ZLIB_COMPRESSION)
     find_package(ZLIB QUIET)
 
     if(ZLIB_FOUND)
-        target_compile_definitions(NetworkSystem PUBLIC BUILD_ZLIB_COMPRESSION)
-        target_link_libraries(NetworkSystem PRIVATE ZLIB::ZLIB)
+        target_compile_definitions(network_system PUBLIC BUILD_ZLIB_COMPRESSION)
+        target_link_libraries(network_system PRIVATE ZLIB::ZLIB)
         message(STATUS "ZLIB compression enabled (gzip/deflate)")
         message(STATUS "  ZLIB version: ${ZLIB_VERSION_STRING}")
     else()
@@ -671,13 +671,13 @@ if(NETWORK_ENABLE_GRPC_OFFICIAL AND GRPC_FOUND)
     message(STATUS "========================================")
 
     # Add gRPC wrapper sources
-    target_sources(NetworkSystem PRIVATE
+    target_sources(network_system PRIVATE
         src/protocols/grpc/grpc_official_wrapper.cpp
     )
 
     if(GRPC_CMAKE_CONFIG)
         # Use CMake config targets (preferred)
-        target_link_libraries(NetworkSystem PRIVATE
+        target_link_libraries(network_system PRIVATE
             gRPC::grpc++
             gRPC::grpc++_reflection
             protobuf::libprotobuf
@@ -697,12 +697,12 @@ if(NETWORK_ENABLE_GRPC_OFFICIAL AND GRPC_FOUND)
         endif()
     elseif(GRPC_PKGCONFIG)
         # Use pkg-config libraries
-        target_include_directories(NetworkSystem PRIVATE
+        target_include_directories(network_system PRIVATE
             ${GRPCPP_INCLUDE_DIRS}
             ${PROTOBUF_INCLUDE_DIRS}
         )
 
-        target_link_libraries(NetworkSystem PRIVATE
+        target_link_libraries(network_system PRIVATE
             ${GRPCPP_LIBRARIES}
             ${PROTOBUF_LIBRARIES}
         )
@@ -712,7 +712,7 @@ if(NETWORK_ENABLE_GRPC_OFFICIAL AND GRPC_FOUND)
     endif()
 
     # Define compile-time flag
-    target_compile_definitions(NetworkSystem PUBLIC NETWORK_GRPC_OFFICIAL=1)
+    target_compile_definitions(network_system PUBLIC NETWORK_GRPC_OFFICIAL=1)
 
     message(STATUS "")
     message(STATUS "Note: Existing gRPC API (grpc_server, grpc_client) remains unchanged.")
@@ -726,13 +726,13 @@ else()
 endif()
 
 # Set target properties
-set_target_properties(NetworkSystem PROPERTIES
+set_target_properties(network_system PROPERTIES
     CXX_STANDARD 20
     CXX_STANDARD_REQUIRED ON
 )
 
 # Include directories
-target_include_directories(NetworkSystem
+target_include_directories(network_system
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
@@ -742,34 +742,34 @@ target_include_directories(NetworkSystem
 
 # Link to network-core for shared interfaces (Issue #538, #539)
 if(TARGET network-core)
-    target_link_libraries(NetworkSystem PUBLIC network-core)
+    target_link_libraries(network_system PUBLIC network-core)
 endif()
 
 # Link to network-tcp for TCP protocol support (Issue #554)
 if(TARGET network-tcp)
-    target_link_libraries(NetworkSystem PUBLIC network-tcp)
+    target_link_libraries(network_system PUBLIC network-tcp)
 endif()
 
 # Link to network-udp for UDP protocol support (Issue #618)
 if(TARGET network-udp)
-    target_link_libraries(NetworkSystem PUBLIC network-udp)
+    target_link_libraries(network_system PUBLIC network-udp)
 endif()
 
 # Note: Integration objects are provided by network-tcp (ODR fix - Issue #555)
-# NetworkSystem gets these symbols through linking with network-tcp
+# network_system gets these symbols through linking with network-tcp
 
 ##################################################
 # Configure Integrations
 ##################################################
 
-setup_network_system_integrations(NetworkSystem)
+setup_network_system_integrations(network_system)
 
 # Messaging bridge (optional - requires external systems)
 if(BUILD_MESSAGING_BRIDGE)
-    target_sources(NetworkSystem PRIVATE
+    target_sources(network_system PRIVATE
         src/integration/messaging_bridge.cpp
     )
-    target_compile_definitions(NetworkSystem PRIVATE BUILD_MESSAGING_BRIDGE)
+    target_compile_definitions(network_system PRIVATE BUILD_MESSAGING_BRIDGE)
 endif()
 
 ##################################################
@@ -782,7 +782,7 @@ option(BUILD_VERIFY_BUILD "Build verify_build executable" OFF)
 
 if(BUILD_VERIFY_BUILD)
     add_executable(verify_build verify_build.cpp)
-    target_link_libraries(verify_build PRIVATE NetworkSystem)
+    target_link_libraries(verify_build PRIVATE network_system)
 
     # Add system include paths to verify_build
     if(CONTAINER_SYSTEM_INCLUDE_DIR)
@@ -890,7 +890,7 @@ endif()
 
 # CPack only applies to standalone builds (not as a subdirectory)
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-    include(cmake/NetworkSystemCPack.cmake)
+    include(cmake/network_system_cpack.cmake)
 endif()
 
 ##################################################
@@ -973,7 +973,7 @@ endif()
 ##################################################
 
 message(STATUS "========================================")
-message(STATUS "NetworkSystem Build Configuration:")
+message(STATUS "network_system Build Configuration:")
 message(STATUS "========================================")
 message(STATUS "")
 message(STATUS "Dependency Chain (Tier 4):")

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -28,7 +28,7 @@ if(benchmark_FOUND OR BENCHMARK_FOUND)
 
     target_link_libraries(network_benchmarks
         PRIVATE
-            NetworkSystem
+            network_system
             benchmark::benchmark
             benchmark::benchmark_main
     )
@@ -40,7 +40,7 @@ if(benchmark_FOUND OR BENCHMARK_FOUND)
             ${CMAKE_CURRENT_SOURCE_DIR}/../src
     )
 
-    # Setup integrations for benchmarks (same as NetworkSystem target)
+    # Setup integrations for benchmarks (same as network_system target)
     setup_asio_integration(network_benchmarks)
 
     # Add system integration paths and definitions

--- a/cmake/network_system-config.cmake.in
+++ b/cmake/network_system-config.cmake.in
@@ -43,16 +43,6 @@ set(network_system_FOUND TRUE)
 # Provide information about the package
 set(network_system_VERSION @PROJECT_VERSION@)
 set(network_system_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@/network_system")
-set(network_system_LIBRARIES network_system::NetworkSystem)
-
-# Legacy variables for backward compatibility
-set(NetworkSystem_FOUND TRUE)
-set(NETWORKSYSTEM_FOUND TRUE)
-set(NetworkSystem_VERSION ${network_system_VERSION})
-set(NetworkSystem_INCLUDE_DIRS ${network_system_INCLUDE_DIRS})
-set(NetworkSystem_LIBRARIES ${network_system_LIBRARIES})
-set(NETWORKSYSTEM_VERSION ${network_system_VERSION})
-set(NETWORKSYSTEM_INCLUDE_DIRS ${network_system_INCLUDE_DIRS})
-set(NETWORKSYSTEM_LIBRARIES ${network_system_LIBRARIES})
+set(network_system_LIBRARIES network_system::network_system)
 
 message(STATUS "Found network_system: ${network_system_VERSION}")

--- a/cmake/network_system_cpack.cmake
+++ b/cmake/network_system_cpack.cmake
@@ -1,6 +1,6 @@
 # CPack Configuration for Network System
 
-set(CPACK_PACKAGE_NAME "NetworkSystem")
+set(CPACK_PACKAGE_NAME "network_system")
 set(CPACK_PACKAGE_VENDOR "Network System Team")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "High-performance asynchronous network communication library")
 set(CPACK_PACKAGE_VERSION_MAJOR "${PROJECT_VERSION_MAJOR}")
@@ -35,7 +35,7 @@ if(WIN32)
 
     # Start menu shortcuts
     set(CPACK_NSIS_CREATE_ICONS_EXTRA
-        "CreateShortCut '$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\Documentation.lnk' '$INSTDIR\\\\share\\\\doc\\\\NetworkSystem\\\\API_REFERENCE.md'"
+        "CreateShortCut '$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\Documentation.lnk' '$INSTDIR\\\\share\\\\doc\\\\network_system\\\\API_REFERENCE.md'"
     )
     set(CPACK_NSIS_DELETE_ICONS_EXTRA
         "Delete '$SMPROGRAMS\\\\$START_MENU\\\\Documentation.lnk'"
@@ -43,7 +43,7 @@ if(WIN32)
 
 elseif(APPLE)
     set(CPACK_GENERATOR "TGZ;DragNDrop")
-    set(CPACK_DMG_VOLUME_NAME "NetworkSystem-${CPACK_PACKAGE_VERSION}")
+    set(CPACK_DMG_VOLUME_NAME "network_system-${CPACK_PACKAGE_VERSION}")
     set(CPACK_DMG_FORMAT "UDZO")  # Compressed
     set(CPACK_PACKAGE_FILE_NAME "network_system-${CPACK_PACKAGE_VERSION}-macos")
 

--- a/cmake/network_system_dependencies.cmake
+++ b/cmake/network_system_dependencies.cmake
@@ -1,7 +1,7 @@
 ##################################################
 # NetworkSystemDependencies.cmake
 #
-# Dependency finding module for NetworkSystem
+# Dependency finding module for network_system
 # Handles ASIO and system integrations
 ##################################################
 
@@ -684,7 +684,7 @@ endfunction()
 # Main dependency finding function
 ##################################################
 function(find_network_system_dependencies)
-    message(STATUS "Finding NetworkSystem dependencies...")
+    message(STATUS "Finding network_system dependencies...")
 
     find_asio_library()
     find_container_system()

--- a/cmake/network_system_features.cmake
+++ b/cmake/network_system_features.cmake
@@ -1,7 +1,7 @@
 ##################################################
 # NetworkSystemFeatures.cmake
 #
-# Feature detection module for NetworkSystem
+# Feature detection module for network_system
 # Checks ASIO and coroutine support
 ##################################################
 
@@ -98,7 +98,7 @@ endfunction()
 # Main feature check function
 ##################################################
 function(check_network_system_features)
-    message(STATUS "Checking NetworkSystem feature support...")
+    message(STATUS "Checking network_system feature support...")
 
     check_asio_support()
     check_coroutine_support()

--- a/cmake/network_system_install.cmake
+++ b/cmake/network_system_install.cmake
@@ -1,7 +1,7 @@
 ##################################################
 # NetworkSystemInstall.cmake
 #
-# Installation configuration for NetworkSystem
+# Installation configuration for network_system
 ##################################################
 
 include(GNUInstallDirs)
@@ -12,7 +12,7 @@ include(CMakePackageConfigHelpers)
 ##################################################
 function(install_network_system_library)
     # Build list of targets to install
-    set(_INSTALL_TARGETS NetworkSystem)
+    set(_INSTALL_TARGETS network_system)
 
     # Include network-core if it exists (Issue #538, #539)
     if(TARGET network-core)

--- a/cmake/network_system_integration.cmake
+++ b/cmake/network_system_integration.cmake
@@ -1,7 +1,7 @@
 ##################################################
 # NetworkSystemIntegration.cmake
 #
-# Integration configuration for NetworkSystem
+# Integration configuration for network_system
 # Handles linking with external systems
 ##################################################
 
@@ -21,8 +21,8 @@ function(setup_asio_integration target)
     elseif(ASIO_INCLUDE_DIR)
         # Standalone ASIO via include directory
         # Use PUBLIC because:
-        # 1. NetworkSystem's source files (network_system.cpp) include headers that use <asio.hpp>
-        # 2. NetworkSystem's public headers include <asio.hpp>
+        # 1. network_system's source files (network_system.cpp) include headers that use <asio.hpp>
+        # 2. network_system's public headers include <asio.hpp>
         # 3. Dependent systems (like database_system) need access to ASIO headers
         target_include_directories(${target}
             PUBLIC

--- a/docs/advanced/MIGRATION.md
+++ b/docs/advanced/MIGRATION.md
@@ -56,7 +56,7 @@ The network module has been separated from `messaging_system` into an independen
 |--------|---------------------------|------------------------|
 | **Namespace** | `messaging::network` | `kcenon::network::core` |
 | **Header Path** | `<messaging/network/*>` | `<network_system/*>` |
-| **CMake Target** | `messaging_system` | `NetworkSystem::NetworkSystem` |
+| **CMake Target** | `messaging_system` | `network_system::network_system` |
 | **Repository** | Part of messaging_system | Independent repository |
 | **Dependencies** | Tightly coupled | Optional integration |
 
@@ -107,7 +107,7 @@ Use this checklist for a high-level overview of migration tasks:
 - [ ] **Choose migration path** (compatibility mode vs. full migration)
 
 ### Build System Migration
-- [ ] **Update CMakeLists.txt** (replace MessagingSystem with NetworkSystem)
+- [ ] **Update CMakeLists.txt** (replace MessagingSystem with network_system)
 - [ ] **Configure package dependencies** (add network_system to vcpkg.json or equivalent)
 - [ ] **Set C++ standard** (ensure C++20 is enabled)
 - [ ] **Test build** (verify clean compilation)
@@ -249,18 +249,18 @@ project(YourApplication)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Find NetworkSystem
-find_package(NetworkSystem REQUIRED
+# Find network_system
+find_package(network_system REQUIRED
     PATHS /path/to/network_system/build
 )
 
 # Create executable
 add_executable(your_app main.cpp network_client.cpp)
 
-# Link NetworkSystem
+# Link network_system
 target_link_libraries(your_app
     PRIVATE
-    NetworkSystem::NetworkSystem
+    network_system::network_system
 )
 
 # Platform-specific dependencies
@@ -569,7 +569,7 @@ Compile and run:
 g++ -std=c++20 migration_verify.cpp \
     -I/path/to/network_system/include \
     -L/path/to/network_system/build \
-    -lNetworkSystem -lpthread \
+    -lnetwork_system -lpthread \
     -o migration_verify
 
 ./migration_verify
@@ -615,10 +615,10 @@ cmake_minimum_required(VERSION 3.16)
 project(MyNetworkApp CXX)
 
 set(CMAKE_CXX_STANDARD 20)  # Upgraded to C++20
-find_package(NetworkSystem REQUIRED)
+find_package(network_system REQUIRED)
 
 add_executable(app main.cpp)
-target_link_libraries(app NetworkSystem::NetworkSystem)
+target_link_libraries(app network_system::network_system)
 
 # Platform-specific libraries
 if(WIN32)
@@ -829,13 +829,13 @@ This section addresses frequently encountered problems during migration.
 undefined reference to `network_system::core::messaging_server::start_server(unsigned short)'
 ```
 
-**Cause:** NetworkSystem library not properly linked.
+**Cause:** network_system library not properly linked.
 
 **Solution:**
 ```cmake
-# Ensure NetworkSystem is found and linked
-find_package(NetworkSystem REQUIRED)
-target_link_libraries(your_app PRIVATE NetworkSystem::NetworkSystem)
+# Ensure network_system is found and linked
+find_package(network_system REQUIRED)
+target_link_libraries(your_app PRIVATE network_system::network_system)
 
 # Also ensure threading support
 find_package(Threads REQUIRED)
@@ -1396,7 +1396,7 @@ Components reverted:
   - src/network/session_manager.cpp
 
 Files kept:
-  - CMakeLists.txt (using NetworkSystem)
+  - CMakeLists.txt (using network_system)
   - Basic client/server code (compatibility mode)
 
 Next steps:

--- a/docs/advanced/OPERATIONS.kr.md
+++ b/docs/advanced/OPERATIONS.kr.md
@@ -71,7 +71,7 @@ CMD ["/usr/local/bin/network_server"]
 #### Windows 서비스
 ```powershell
 # Windows 서비스로 설치
-sc create NetworkService binPath= "C:\Program Files\NetworkSystem\network_server.exe"
+sc create NetworkService binPath= "C:\Program Files\network_system\network_server.exe"
 sc config NetworkService start= auto
 sc start NetworkService
 ```

--- a/docs/advanced/OPERATIONS.md
+++ b/docs/advanced/OPERATIONS.md
@@ -71,7 +71,7 @@ CMD ["/usr/local/bin/network_server"]
 #### Windows Service
 ```powershell
 # Install as Windows service
-sc create NetworkService binPath= "C:\Program Files\NetworkSystem\network_server.exe"
+sc create NetworkService binPath= "C:\Program Files\network_system\network_server.exe"
 sc config NetworkService start= auto
 sc start NetworkService
 ```

--- a/docs/guides/BUILD.kr.md
+++ b/docs/guides/BUILD.kr.md
@@ -318,17 +318,17 @@ chmod +x .git/hooks/pre-commit
 
 ## 통합
 
-### 프로젝트에서 NetworkSystem 사용
+### 프로젝트에서 network_system 사용
 
 #### CMake 통합
 ```cmake
 # 패키지 찾기
-find_package(NetworkSystem REQUIRED)
+find_package(network_system REQUIRED)
 
 # 타겟에 링크
 target_link_libraries(your_target
   PRIVATE
-    NetworkSystem::NetworkSystem
+    network_system::network_system
 )
 ```
 
@@ -343,7 +343,7 @@ target_include_directories(your_target
 # 라이브러리 링크
 target_link_libraries(your_target
   PRIVATE
-    /path/to/network_system/build/libNetworkSystem.a
+    /path/to/network_system/build/libnetwork_system.a
 )
 ```
 

--- a/docs/guides/BUILD.md
+++ b/docs/guides/BUILD.md
@@ -353,17 +353,17 @@ chmod +x .git/hooks/pre-commit
 
 ## Integration
 
-### Using NetworkSystem in Your Project
+### Using network_system in Your Project
 
 #### CMake Integration
 ```cmake
 # Find the package
-find_package(NetworkSystem REQUIRED)
+find_package(network_system REQUIRED)
 
 # Link to your target
 target_link_libraries(your_target
   PRIVATE
-    NetworkSystem::NetworkSystem
+    network_system::network_system
 )
 ```
 
@@ -378,7 +378,7 @@ target_include_directories(your_target
 # Link library
 target_link_libraries(your_target
   PRIVATE
-    /path/to/network_system/build/libNetworkSystem.a
+    /path/to/network_system/build/libnetwork_system.a
 )
 ```
 

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -166,10 +166,10 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # network_system 찾기
-find_package(NetworkSystem REQUIRED)
+find_package(network_system REQUIRED)
 
 add_executable(my_app main.cpp)
-target_link_libraries(my_app PRIVATE NetworkSystem::network)
+target_link_libraries(my_app PRIVATE network_system::network)
 ```
 
 ---

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -166,10 +166,10 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find network_system
-find_package(NetworkSystem REQUIRED)
+find_package(network_system REQUIRED)
 
 add_executable(my_app main.cpp)
-target_link_libraries(my_app PRIVATE NetworkSystem::network)
+target_link_libraries(my_app PRIVATE network_system::network)
 ```
 
 Or using FetchContent:

--- a/docs/guides/TROUBLESHOOTING.kr.md
+++ b/docs/guides/TROUBLESHOOTING.kr.md
@@ -801,8 +801,8 @@ grep -r "KCENON_WITH_COMMON_SYSTEM" build/compile_commands.json
 2. 소비 프로젝트가 정의를 받는지 확인:
 ```cmake
 # 소비 프로젝트의 CMakeLists.txt에서
-get_target_property(DEFS NetworkSystem INTERFACE_COMPILE_DEFINITIONS)
-message(STATUS "NetworkSystem definitions: ${DEFS}")
+get_target_property(DEFS network_system INTERFACE_COMPILE_DEFINITIONS)
+message(STATUS "network_system definitions: ${DEFS}")
 ```
 
 > **참고:** [GitHub Issue #338](https://github.com/kcenon/network_system/issues/338)

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -801,8 +801,8 @@ grep -r "KCENON_WITH_COMMON_SYSTEM" build/compile_commands.json
 2. Ensure consuming project receives the definition:
 ```cmake
 # In consuming project's CMakeLists.txt
-get_target_property(DEFS NetworkSystem INTERFACE_COMPILE_DEFINITIONS)
-message(STATUS "NetworkSystem definitions: ${DEFS}")
+get_target_property(DEFS network_system INTERFACE_COMPILE_DEFINITIONS)
+message(STATUS "network_system definitions: ${DEFS}")
 ```
 
 > **See also:** [GitHub Issue #338](https://github.com/kcenon/network_system/issues/338)

--- a/docs/implementation/02-dependency-and-testing.md
+++ b/docs/implementation/02-dependency-and-testing.md
@@ -13,19 +13,19 @@ This document covers dependency management (CMake, pkg-config) and testing strat
 ### 1. CMake Module Files
 
 ```cmake
-# cmake/FindNetworkSystem.cmake
+# cmake/Findnetwork_system.cmake
 find_package(PkgConfig QUIET)
 
 # ASIO dependency
 find_package(asio CONFIG REQUIRED)
 if(NOT asio_FOUND)
-    message(FATAL_ERROR "ASIO library is required for NetworkSystem")
+    message(FATAL_ERROR "ASIO library is required for network_system")
 endif()
 
 # fmt dependency
 find_package(fmt CONFIG REQUIRED)
 if(NOT fmt_FOUND)
-    message(FATAL_ERROR "fmt library is required for NetworkSystem")
+    message(FATAL_ERROR "fmt library is required for network_system")
 endif()
 
 # Check conditional dependencies
@@ -46,39 +46,39 @@ if(BUILD_WITH_THREAD_SYSTEM)
 endif()
 
 # Define library target
-if(NOT TARGET NetworkSystem::Core)
-    add_library(NetworkSystem::Core INTERFACE)
-    target_include_directories(NetworkSystem::Core INTERFACE
+if(NOT TARGET network_system::Core)
+    add_library(network_system::Core INTERFACE)
+    target_include_directories(network_system::Core INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/../include
     )
-    target_link_libraries(NetworkSystem::Core INTERFACE
+    target_link_libraries(network_system::Core INTERFACE
         asio::asio
         fmt::fmt
     )
 
     if(BUILD_WITH_CONTAINER_SYSTEM)
-        target_link_libraries(NetworkSystem::Core INTERFACE
+        target_link_libraries(network_system::Core INTERFACE
             ContainerSystem::Core
         )
-        target_compile_definitions(NetworkSystem::Core INTERFACE
+        target_compile_definitions(network_system::Core INTERFACE
             BUILD_WITH_CONTAINER_SYSTEM
         )
     endif()
 
     if(BUILD_WITH_THREAD_SYSTEM)
-        target_link_libraries(NetworkSystem::Core INTERFACE
+        target_link_libraries(network_system::Core INTERFACE
             ThreadSystem::Core
         )
-        target_compile_definitions(NetworkSystem::Core INTERFACE
+        target_compile_definitions(network_system::Core INTERFACE
             BUILD_WITH_THREAD_SYSTEM
         )
     endif()
 endif()
 
 # Set variables
-set(NetworkSystem_FOUND TRUE)
-set(NetworkSystem_VERSION "2.0.0")
-set(NetworkSystem_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/../include)
+set(network_system_FOUND TRUE)
+set(network_system_VERSION "2.0.0")
+set(network_system_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/../include)
 ```
 
 ### 2. pkg-config File
@@ -90,12 +90,12 @@ exec_prefix=${prefix}
 libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
-Name: NetworkSystem
+Name: network_system
 Description: High-performance modular network system
 Version: @PROJECT_VERSION@
 Requires: asio fmt
 Requires.private: @PRIVATE_DEPENDENCIES@
-Libs: -L${libdir} -lNetworkSystem
+Libs: -L${libdir} -lnetwork_system
 Libs.private: @PRIVATE_LIBS@
 Cflags: -I${includedir}
 ```

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Include integration module for ASIO setup
-include(NetworkSystemIntegration)
+include(network_system_integration)
 
 # Find required packages
 find_package(Threads REQUIRED)
@@ -62,7 +62,7 @@ foreach(EXAMPLE ${EXAMPLE_PROGRAMS})
     )
 
     target_link_libraries(example_${EXAMPLE} PRIVATE
-        NetworkSystem
+        network_system
         Threads::Threads
     )
 

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -20,7 +20,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 
         # --- HTTP/2 frame parser fuzz target ---
         add_executable(fuzz_http2_frame fuzz_http2_frame.cpp)
-        target_link_libraries(fuzz_http2_frame PRIVATE NetworkSystem)
+        target_link_libraries(fuzz_http2_frame PRIVATE network_system)
         target_include_directories(fuzz_http2_frame PRIVATE ${FUZZ_INCLUDE_DIRS})
         set_target_properties(fuzz_http2_frame PROPERTIES
             COMPILE_FLAGS "${FUZZ_COMPILE_FLAGS}"
@@ -29,7 +29,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 
         # --- QUIC varint decoder fuzz target ---
         add_executable(fuzz_quic_varint fuzz_quic_varint.cpp)
-        target_link_libraries(fuzz_quic_varint PRIVATE NetworkSystem)
+        target_link_libraries(fuzz_quic_varint PRIVATE network_system)
         target_include_directories(fuzz_quic_varint PRIVATE ${FUZZ_INCLUDE_DIRS})
         set_target_properties(fuzz_quic_varint PROPERTIES
             COMPILE_FLAGS "${FUZZ_COMPILE_FLAGS}"
@@ -38,7 +38,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 
         # --- QUIC frame parser fuzz target ---
         add_executable(fuzz_quic_frame fuzz_quic_frame.cpp)
-        target_link_libraries(fuzz_quic_frame PRIVATE NetworkSystem)
+        target_link_libraries(fuzz_quic_frame PRIVATE network_system)
         target_include_directories(fuzz_quic_frame PRIVATE ${FUZZ_INCLUDE_DIRS})
         set_target_properties(fuzz_quic_frame PROPERTIES
             COMPILE_FLAGS "${FUZZ_COMPILE_FLAGS}"
@@ -47,7 +47,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 
         # --- gRPC message parser fuzz target ---
         add_executable(fuzz_grpc_frame fuzz_grpc_frame.cpp)
-        target_link_libraries(fuzz_grpc_frame PRIVATE NetworkSystem)
+        target_link_libraries(fuzz_grpc_frame PRIVATE network_system)
         target_include_directories(fuzz_grpc_frame PRIVATE ${FUZZ_INCLUDE_DIRS})
         set_target_properties(fuzz_grpc_frame PROPERTIES
             COMPILE_FLAGS "${FUZZ_COMPILE_FLAGS}"
@@ -56,7 +56,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 
         # --- HPACK header decoder fuzz target ---
         add_executable(fuzz_hpack_decode fuzz_hpack_decode.cpp)
-        target_link_libraries(fuzz_hpack_decode PRIVATE NetworkSystem)
+        target_link_libraries(fuzz_hpack_decode PRIVATE network_system)
         target_include_directories(fuzz_hpack_decode PRIVATE ${FUZZ_INCLUDE_DIRS})
         set_target_properties(fuzz_hpack_decode PROPERTIES
             COMPILE_FLAGS "${FUZZ_COMPILE_FLAGS}"

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -82,7 +82,7 @@ target_include_directories(connection_lifecycle_test PRIVATE
 )
 
 target_link_libraries(connection_lifecycle_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -143,7 +143,7 @@ target_include_directories(protocol_integration_test PRIVATE
 )
 
 target_link_libraries(protocol_integration_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -203,7 +203,7 @@ target_include_directories(network_performance_test PRIVATE
 )
 
 target_link_libraries(network_performance_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -263,7 +263,7 @@ target_include_directories(error_handling_test PRIVATE
 )
 
 target_link_libraries(error_handling_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -364,7 +364,7 @@ target_include_directories(tcp_load_test PRIVATE
 )
 
 target_link_libraries(tcp_load_test PRIVATE
-    NetworkSystem
+    network_system
     network_integration_test_framework
     GTest::gtest
     GTest::gtest_main
@@ -418,7 +418,7 @@ target_include_directories(udp_load_test PRIVATE
 )
 
 target_link_libraries(udp_load_test PRIVATE
-    NetworkSystem
+    network_system
     network-udp
     network_integration_test_framework
     GTest::gtest
@@ -473,7 +473,7 @@ target_include_directories(websocket_load_test PRIVATE
 )
 
 target_link_libraries(websocket_load_test PRIVATE
-    NetworkSystem
+    network_system
     network_integration_test_framework
     GTest::gtest
     GTest::gtest_main

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -167,7 +167,7 @@ xdg-open coverage_html/index.html  # Linux
 
 ## Test Framework
 
-### NetworkSystemFixture
+### network_system_fixture
 
 Base fixture providing:
 - `StartServer()` - Start test server

--- a/integration_tests/README_KO.md
+++ b/integration_tests/README_KO.md
@@ -167,7 +167,7 @@ xdg-open coverage_html/index.html  # Linux
 
 ## 테스트 프레임워크
 
-### NetworkSystemFixture
+### network_system_fixture
 
 다음을 제공하는 기본 픽스처:
 - `StartServer()` - 테스트 서버 시작

--- a/libs/network-http2/README.md
+++ b/libs/network-http2/README.md
@@ -37,7 +37,7 @@ When building as part of the main network_system project, the library is automat
 
 ```cmake
 # In your CMakeLists.txt
-find_package(NetworkSystem REQUIRED)
+find_package(network_system REQUIRED)
 target_link_libraries(your_target PRIVATE kcenon::network-http2)
 ```
 

--- a/libs/network-quic/README.md
+++ b/libs/network-quic/README.md
@@ -37,7 +37,7 @@ When building as part of the main network_system project, the library is automat
 
 ```cmake
 # In your CMakeLists.txt
-find_package(NetworkSystem REQUIRED)
+find_package(network_system REQUIRED)
 target_link_libraries(your_target PRIVATE kcenon::network-quic)
 ```
 

--- a/libs/network-websocket/README.md
+++ b/libs/network-websocket/README.md
@@ -34,7 +34,7 @@ When building as part of the main network_system project, the library is automat
 
 ```cmake
 # In your CMakeLists.txt
-find_package(NetworkSystem REQUIRED)
+find_package(network_system REQUIRED)
 target_link_libraries(your_target PRIVATE kcenon::network-websocket)
 ```
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Include integration module for ASIO setup
-include(NetworkSystemIntegration)
+include(network_system_integration)
 
 # Find required packages
 find_package(Threads REQUIRED)
@@ -67,11 +67,11 @@ foreach(SAMPLE ${SAMPLE_PROGRAMS})
         CXX_EXTENSIONS OFF
     )
 
-    # Include directories are provided by NetworkSystem target linkage
+    # Include directories are provided by network_system target linkage
 
     # Link libraries
     target_link_libraries(network_${SAMPLE} PRIVATE
-        NetworkSystem
+        network_system
         Threads::Threads
     )
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -141,7 +141,7 @@ The samples use the following default configuration:
 - **Timeout**: `5000` ms (5 seconds)
 
 ### HTTP Client Configuration
-- **User-Agent**: `NetworkSystem/1.0`
+- **User-Agent**: `network_system/1.0`
 - **Timeout**: `30000` ms (30 seconds)
 - **Maximum Redirects**: `5`
 - **Default Headers**: Accept, Accept-Language, Accept-Encoding

--- a/samples/README_KO.md
+++ b/samples/README_KO.md
@@ -141,7 +141,7 @@ make
 - **타임아웃**: `5000` ms (5초)
 
 ### HTTP 클라이언트 구성
-- **User-Agent**: `NetworkSystem/1.0`
+- **User-Agent**: `network_system/1.0`
 - **타임아웃**: `30000` ms (30초)
 - **최대 리다이렉트**: `5`
 - **기본 헤더**: Accept, Accept-Language, Accept-Encoding

--- a/samples/messaging_system_integration/CMakeLists.txt
+++ b/samples/messaging_system_integration/CMakeLists.txt
@@ -6,20 +6,20 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Find network_system (assuming it's built in ../../build)
-set(NetworkSystem_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
-set(NetworkSystem_BUILD_DIR "${NetworkSystem_DIR}/build")
+set(network_system_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+set(network_system_BUILD_DIR "${network_system_DIR}/build")
 
 # Add include directories
-include_directories(${NetworkSystem_DIR}/include)
+include_directories(${network_system_DIR}/include)
 
 # Link to network_system library
-link_directories(${NetworkSystem_BUILD_DIR})
+link_directories(${network_system_BUILD_DIR})
 
 # Legacy compatibility example
 add_executable(legacy_compatibility legacy_compatibility.cpp)
 target_link_libraries(legacy_compatibility
     PRIVATE
-    ${NetworkSystem_BUILD_DIR}/libNetworkSystem.a
+    ${network_system_BUILD_DIR}/libnetwork_system.a
     pthread
 )
 
@@ -27,7 +27,7 @@ target_link_libraries(legacy_compatibility
 add_executable(modern_usage modern_usage.cpp)
 target_link_libraries(modern_usage
     PRIVATE
-    ${NetworkSystem_BUILD_DIR}/libNetworkSystem.a
+    ${network_system_BUILD_DIR}/libnetwork_system.a
     pthread
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,7 +47,7 @@ if(GTest_FOUND OR GTEST_FOUND)
 
     # Link dependencies
     target_link_libraries(network_unit_tests PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -99,7 +99,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_thread_safety_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -148,7 +148,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_tls_config_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -186,7 +186,7 @@ if(GTest_FOUND OR GTEST_FOUND)
         )
 
         target_link_libraries(network_thread_system_adapter_test PRIVATE
-            NetworkSystem
+            network_system
             GTest::gtest
             GTest::gtest_main
             Threads::Threads
@@ -237,7 +237,7 @@ if(GTest_FOUND OR GTEST_FOUND)
         )
 
         target_link_libraries(network_thread_pool_adapters_test PRIVATE
-            NetworkSystem
+            network_system
             GTest::gtest
             GTest::gtest_main
             Threads::Threads
@@ -278,7 +278,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_thread_pool_bridge_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -293,7 +293,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_system_bridge_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -362,7 +362,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_observability_bridge_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -404,7 +404,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_messaging_bridge_interface_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -446,7 +446,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_tcp_socket_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -478,7 +478,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_socket_concepts_test PRIVATE
-        NetworkSystem
+        network_system
         network-udp
         GTest::gtest
         GTest::gtest_main
@@ -511,7 +511,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_session_manager_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -543,7 +543,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_session_manager_base_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -573,7 +573,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_ws_session_manager_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -603,7 +603,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_session_manager_integration_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -636,7 +636,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_composition_utilities_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -668,7 +668,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_interfaces_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -700,7 +700,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_policy_protocol_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -732,7 +732,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_unified_messaging_client_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -774,7 +774,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_unified_messaging_server_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -816,7 +816,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_udp_composition_test PRIVATE
-        NetworkSystem
+        network_system
         network-udp
         GTest::gtest
         GTest::gtest_main
@@ -859,7 +859,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_udp_socket_test PRIVATE
-        NetworkSystem
+        network_system
         network-udp
         GTest::gtest
         GTest::gtest_main
@@ -901,7 +901,7 @@ if(GTest_FOUND OR GTEST_FOUND)
         )
 
         target_link_libraries(network_websocket_frame_test PRIVATE
-            NetworkSystem
+            network_system
             GTest::gtest
             GTest::gtest_main
             Threads::Threads
@@ -927,7 +927,7 @@ if(GTest_FOUND OR GTEST_FOUND)
         )
 
         target_link_libraries(network_websocket_handshake_test PRIVATE
-            NetworkSystem
+            network_system
             GTest::gtest
             GTest::gtest_main
             Threads::Threads
@@ -953,7 +953,7 @@ if(GTest_FOUND OR GTEST_FOUND)
         )
 
         target_link_libraries(network_websocket_protocol_test PRIVATE
-            NetworkSystem
+            network_system
             GTest::gtest
             GTest::gtest_main
             Threads::Threads
@@ -979,7 +979,7 @@ if(GTest_FOUND OR GTEST_FOUND)
         )
 
         target_link_libraries(network_messaging_ws_client_test PRIVATE
-            NetworkSystem
+            network_system
             GTest::gtest
             GTest::gtest_main
             Threads::Threads
@@ -1011,7 +1011,7 @@ if(GTest_FOUND OR GTEST_FOUND)
         )
 
         target_link_libraries(network_messaging_ws_server_test PRIVATE
-            NetworkSystem
+            network_system
             GTest::gtest
             GTest::gtest_main
             Threads::Threads
@@ -1048,7 +1048,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_http2_frame_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1080,7 +1080,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_http2_hpack_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1113,7 +1113,7 @@ if(GTest_FOUND OR GTEST_FOUND)
         )
 
         target_link_libraries(network_http2_client_test PRIVATE
-            NetworkSystem
+            network_system
             GTest::gtest
             GTest::gtest_main
             Threads::Threads
@@ -1147,7 +1147,7 @@ if(GTest_FOUND OR GTEST_FOUND)
         )
 
         target_link_libraries(network_http2_server_test PRIVATE
-            NetworkSystem
+            network_system
             GTest::gtest
             GTest::gtest_main
             Threads::Threads
@@ -1185,7 +1185,7 @@ if(GTest_FOUND OR GTEST_FOUND)
         )
 
         target_link_libraries(network_dtls_socket_test PRIVATE
-            NetworkSystem
+            network_system
             GTest::gtest
             GTest::gtest_main
             Threads::Threads
@@ -1229,7 +1229,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_metrics_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1280,7 +1280,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_histogram_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1331,7 +1331,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_tracing_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1382,7 +1382,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_grpc_frame_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1414,7 +1414,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_grpc_client_server_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1446,7 +1446,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_grpc_service_registry_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1478,7 +1478,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_grpc_official_wrapper_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1510,7 +1510,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_grpc_integration_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1546,7 +1546,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_quic_varint_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1578,7 +1578,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_quic_frame_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1610,7 +1610,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_quic_packet_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1643,7 +1643,7 @@ if(GTest_FOUND OR GTEST_FOUND)
         )
 
         target_link_libraries(network_quic_crypto_test PRIVATE
-            NetworkSystem
+            network_system
             GTest::gtest
             GTest::gtest_main
             Threads::Threads
@@ -1677,7 +1677,7 @@ if(GTest_FOUND OR GTEST_FOUND)
         )
 
         target_link_libraries(network_quic_socket_test PRIVATE
-            NetworkSystem
+            network_system
             GTest::gtest
             GTest::gtest_main
             Threads::Threads
@@ -1712,7 +1712,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_quic_stream_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1744,7 +1744,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_quic_connection_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1776,7 +1776,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_quic_loss_detection_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1808,7 +1808,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_quic_pmtud_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1840,7 +1840,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_quic_ecn_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1872,7 +1872,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_quic_session_ticket_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1904,7 +1904,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_quic_flow_congestion_rtt_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1936,7 +1936,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_messaging_quic_client_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -1968,7 +1968,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_messaging_quic_server_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -2002,7 +2002,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_unified_interfaces_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -2036,7 +2036,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_session_type_erasure_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -2066,7 +2066,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_unified_session_manager_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -2099,7 +2099,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_connection_pool_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -2142,7 +2142,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_buffer_pool_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -2185,7 +2185,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_compression_pipeline_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -2228,7 +2228,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_resilient_client_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -2272,7 +2272,7 @@ if(GTest_FOUND OR GTEST_FOUND)
         )
 
         target_link_libraries(network_secure_messaging_client_test PRIVATE
-            NetworkSystem
+            network_system
             GTest::gtest
             GTest::gtest_main
             Threads::Threads
@@ -2317,7 +2317,7 @@ if(GTest_FOUND OR GTEST_FOUND)
         )
 
         target_link_libraries(network_secure_messaging_server_test PRIVATE
-            NetworkSystem
+            network_system
             GTest::gtest
             GTest::gtest_main
             Threads::Threads
@@ -2367,7 +2367,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_udp_basic_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -2410,7 +2410,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_http_client_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -2449,7 +2449,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_http_server_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -2492,7 +2492,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_http_parser_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -2544,7 +2544,7 @@ if(FALSE AND benchmark_FOUND)
 
     # Link dependencies
     target_link_libraries(network_benchmark_tests PRIVATE
-        NetworkSystem
+        network_system
         benchmark::benchmark
         benchmark::benchmark_main
         Threads::Threads
@@ -2607,7 +2607,7 @@ if(benchmark_FOUND)
     )
 
     target_link_libraries(network_grpc_benchmarks PRIVATE
-        NetworkSystem
+        network_system
         benchmark::benchmark
         benchmark::benchmark_main
         Threads::Threads
@@ -2657,7 +2657,7 @@ add_executable(network_tcp_facade_test
 )
 
 target_link_libraries(network_tcp_facade_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -2690,7 +2690,7 @@ add_executable(network_udp_facade_test
 )
 
 target_link_libraries(network_udp_facade_test PRIVATE
-    NetworkSystem
+    network_system
     network-udp
     GTest::gtest
     GTest::gtest_main
@@ -2724,7 +2724,7 @@ add_executable(network_http_facade_test
 )
 
 target_link_libraries(network_http_facade_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -2758,7 +2758,7 @@ if(BUILD_WEBSOCKET_SUPPORT)
     )
 
     target_link_libraries(network_websocket_facade_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -2793,7 +2793,7 @@ add_executable(network_memory_profiler_session_timeout_test
 )
 
 target_link_libraries(network_memory_profiler_session_timeout_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -2825,7 +2825,7 @@ add_executable(network_facade_validation_test
 )
 
 target_link_libraries(network_facade_validation_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -2857,7 +2857,7 @@ add_executable(network_config_http_error_test
 )
 
 target_link_libraries(network_config_http_error_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -2892,7 +2892,7 @@ add_executable(network_socket_metrics_test
 )
 
 target_link_libraries(network_socket_metrics_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -2925,7 +2925,7 @@ add_executable(network_callback_indices_test
 )
 
 target_link_libraries(network_callback_indices_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -2958,7 +2958,7 @@ add_executable(network_http2_request_test
 )
 
 target_link_libraries(network_http2_request_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -2991,7 +2991,7 @@ add_executable(network_quic_varint_unit_test
 )
 
 target_link_libraries(network_quic_varint_unit_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -3024,7 +3024,7 @@ add_executable(network_quic_frame_types_unit_test
 )
 
 target_link_libraries(network_quic_frame_types_unit_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -3057,7 +3057,7 @@ add_executable(network_openssl_compat_test
 )
 
 target_link_libraries(network_openssl_compat_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -3090,7 +3090,7 @@ add_executable(network_context_test
 )
 
 target_link_libraries(network_context_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -3123,7 +3123,7 @@ add_executable(network_metric_event_test
 )
 
 target_link_libraries(network_metric_event_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -3156,7 +3156,7 @@ add_executable(network_concepts_test
 )
 
 target_link_libraries(network_concepts_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -3185,7 +3185,7 @@ add_executable(network_http_types_test
 )
 
 target_link_libraries(network_http_types_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -3218,7 +3218,7 @@ add_executable(network_quic_connection_id_test
 )
 
 target_link_libraries(network_quic_connection_id_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -3251,7 +3251,7 @@ add_executable(network_quic_keys_test
 )
 
 target_link_libraries(network_quic_keys_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -3284,7 +3284,7 @@ add_executable(network_startable_base_test
 )
 
 target_link_libraries(network_startable_base_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -3317,7 +3317,7 @@ add_executable(network_session_info_traits_test
 )
 
 target_link_libraries(network_session_info_traits_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -3350,7 +3350,7 @@ add_executable(network_result_types_test
 )
 
 target_link_libraries(network_result_types_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -3379,7 +3379,7 @@ add_executable(network_common_defs_test
 )
 
 target_link_libraries(network_common_defs_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -3408,7 +3408,7 @@ add_executable(network_quic_transport_params_test
 )
 
 target_link_libraries(network_quic_transport_params_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -3441,7 +3441,7 @@ add_executable(network_sliding_histogram_test
 )
 
 target_link_libraries(network_sliding_histogram_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -3474,7 +3474,7 @@ add_executable(network_system_lifecycle_test
 )
 
 target_link_libraries(network_system_lifecycle_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -3522,7 +3522,7 @@ add_executable(network_message_validator_extended_test
 )
 
 target_link_libraries(network_message_validator_extended_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -3552,7 +3552,7 @@ add_executable(network_metrics_histogram_test
 )
 
 target_link_libraries(network_metrics_histogram_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads
@@ -3582,7 +3582,7 @@ add_executable(network_facade_extended_test
 )
 
 target_link_libraries(network_facade_extended_test PRIVATE
-    NetworkSystem
+    network_system
     GTest::gtest
     GTest::gtest_main
     Threads::Threads

--- a/tests/failure/CMakeLists.txt
+++ b/tests/failure/CMakeLists.txt
@@ -9,7 +9,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_failure_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -53,7 +53,7 @@ if(GTest_FOUND OR GTEST_FOUND)
     )
 
     target_link_libraries(network_boundary_test PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -21,7 +21,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test_e2e.cpp)
     add_executable(test_e2e test_e2e.cpp)
 
     target_link_libraries(test_e2e PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -68,7 +68,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test_integration.cpp)
     add_executable(stress_test test_integration.cpp)
 
     target_link_libraries(stress_test PRIVATE
-        NetworkSystem
+        network_system
         Threads::Threads
     )
 
@@ -114,7 +114,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test_websocket_e2e.cpp)
     add_executable(test_websocket_e2e test_websocket_e2e.cpp)
 
     target_link_libraries(test_websocket_e2e PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -168,7 +168,7 @@ if(BUILD_QUIC_SUPPORT AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test_quic_e2e.cpp)
     add_executable(test_quic_e2e test_quic_e2e.cpp)
 
     target_link_libraries(test_quic_e2e PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -222,7 +222,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test_metrics_integration.cpp)
     add_executable(test_metrics_integration test_metrics_integration.cpp)
 
     target_link_libraries(test_metrics_integration PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads
@@ -274,7 +274,7 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test_tracing_integration.cpp)
     add_executable(test_tracing_integration test_tracing_integration.cpp)
 
     target_link_libraries(test_tracing_integration PRIVATE
-        NetworkSystem
+        network_system
         GTest::gtest
         GTest::gtest_main
         Threads::Threads

--- a/vcpkg-ports/kcenon-network-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-network-system/portfile.cmake
@@ -32,8 +32,8 @@ vcpkg_cmake_configure(
 vcpkg_cmake_install()
 
 vcpkg_cmake_config_fixup(
-    PACKAGE_NAME NetworkSystem
-    CONFIG_PATH lib/cmake/NetworkSystem
+    PACKAGE_NAME network_system
+    CONFIG_PATH lib/cmake/network_system
 )
 
 # Remove empty directories that cause vcpkg post-build validation warnings

--- a/vcpkg-ports/kcenon-network-system/usage
+++ b/vcpkg-ports/kcenon-network-system/usage
@@ -1,6 +1,6 @@
 The package kcenon-network-system provides CMake targets:
 
     find_package(network_system CONFIG REQUIRED)
-    target_link_libraries(main PRIVATE network_system::NetworkSystem)
+    target_link_libraries(main PRIVATE network_system::network_system)
 
 Available features: logging


### PR DESCRIPTION
## Summary

Renames the CMake project from PascalCase (`NetworkSystem`) to snake_case (`network_system`) across the entire build system and documentation.

- Rename `project(NetworkSystem)` to `project(network_system)` and all CMake targets
- Rename 5 cmake module files from PascalCase to snake_case
- Update `config.cmake.in` namespace to `network_system::network_system`
- Remove legacy backward-compatibility variables (no aliases)
- Update all test/sample/benchmark/integration CMakeLists.txt references
- Update vcpkg port usage file and portfile
- Update CMake examples in 18 documentation files
- Update release workflow

Closes #914

## What

| Aspect | Before | After |
|--------|--------|-------|
| Project name | `NetworkSystem` | `network_system` |
| Library target | `NetworkSystem` | `network_system` |
| CMake namespace | `network_system::NetworkSystem` | `network_system::network_system` |
| Module files | `NetworkSystemFeatures.cmake` etc. | `network_system_features.cmake` etc. |

## Why

Part of the kcenon ecosystem standardization (Phase 2). All CMake project names are being unified to snake_case. No backward-compatible aliases are provided - this is a clean break.

## Where

- Root `CMakeLists.txt` and 5 cmake module files (renamed)
- `cmake/network_system-config.cmake.in`
- 10 subdirectory `CMakeLists.txt` files (tests, samples, benchmarks, fuzz, examples, integration)
- `vcpkg-ports/kcenon-network-system/` (usage + portfile)
- 18 documentation files (migration guides, quick start, build guides, troubleshooting, READMEs)
- `.github/workflows/release.yml`

## How

1. Renamed cmake module files mechanically
2. Updated all CMake target references in build files
3. Updated documentation CMake examples (only CMake target/package refs, not C++ class names like `NetworkSystemBridge`)
4. Removed legacy backward-compatibility variables from config template

## Test plan

- [ ] CI builds pass on all platforms (Linux, macOS, Windows)
- [ ] All tests pass
- [ ] `find_package(network_system)` works correctly
- [ ] `target_link_libraries(... network_system::network_system)` resolves