### PR TITLE
docs: add YAML frontmatter to all docs/ markdown files

### DIFF
--- a/docs/API_REFERENCE.kr.md
+++ b/docs/API_REFERENCE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-API-001"
+doc_title: "API 참조"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "API"
+---
+
 # API 참조
 
 > **Language:** [English](API_REFERENCE.md) | **한국어**

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-API-002"
+doc_title: "API Reference"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "API"
+---
+
 # API Reference
 
 > **Language:** **English** | [한국어](API_REFERENCE.kr.md)

--- a/docs/ARCHITECTURE.kr.md
+++ b/docs/ARCHITECTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-ARCH-001"
+doc_title: "아키텍처 개요"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "ARCH"
+---
+
 # 아키텍처 개요
 
 > **Language:** [English](ARCHITECTURE.md) | **한국어**

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-ARCH-002"
+doc_title: "Network System Architecture"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "ARCH"
+---
+
 # Network System Architecture
 
 > **Language:** **English** | [한국어](ARCHITECTURE.kr.md)

--- a/docs/BENCHMARKS.kr.md
+++ b/docs/BENCHMARKS.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-PERF-001"
+doc_title: "Network System 성능 벤치마크"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "PERF"
+---
+
 # Network System 성능 벤치마크
 
 **언어:** [English](BENCHMARKS.md) | **한국어**

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-PERF-002"
+doc_title: "Network System Performance Benchmarks"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "PERF"
+---
+
 # Network System Performance Benchmarks
 
 **Last Updated**: 2025-11-15

--- a/docs/CHANGELOG.kr.md
+++ b/docs/CHANGELOG.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-PROJ-001"
+doc_title: "변경 이력 - Network System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "PROJ"
+---
+
 # 변경 이력 - Network System
 
 > **언어:** [English](CHANGELOG.md) | **한국어**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-PROJ-002"
+doc_title: "Changelog - Network System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "PROJ"
+---
+
 # Changelog - Network System
 
 > **Language:** **English** | [한국어](CHANGELOG.kr.md)

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-001"
+doc_title: "Design Decisions"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # Design Decisions
 
 > **Language:** **English** | [한국어](DESIGN_DECISIONS.kr.md)

--- a/docs/DTLS_RESILIENT_GUIDE.md
+++ b/docs/DTLS_RESILIENT_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-002"
+doc_title: "DTLS Socket and Resilient Client Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # DTLS Socket and Resilient Client Guide
 
 > **Language:** **English**

--- a/docs/FACADE_GUIDE.md
+++ b/docs/FACADE_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-003"
+doc_title: "Facade API Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # Facade API Guide
 
 > **Language:** **English**

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-FEAT-001"
+doc_title: "Network System - 상세 기능"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "FEAT"
+---
+
 # Network System - 상세 기능
 
 **언어:** [English](ARCHITECTURE.md) | **한국어**

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-FEAT-002"
+doc_title: "Network System Features"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "FEAT"
+---
+
 # Network System Features
 
 **Last Updated**: 2026-02-08

--- a/docs/HTTP2_GUIDE.md
+++ b/docs/HTTP2_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-004"
+doc_title: "HTTP/2 Advanced Features Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # HTTP/2 Advanced Features Guide
 
 > **Language:** **English**

--- a/docs/INTEGRATION.kr.md
+++ b/docs/INTEGRATION.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-INTR-001"
+doc_title: "Integration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "INTR"
+---
+
 # Integration Guide
 
 > **Language:** [English](INTEGRATION.md) | **한국어**

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-INTR-002"
+doc_title: "Integration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "INTR"
+---
+
 # Integration Guide
 
 > **Language:** **English** | [한국어](INTEGRATION.kr.md)

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-MIGR-001"
+doc_title: "Migration Guide: Monolithic to Modular Architecture"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "MIGR"
+---
+
 # Migration Guide: Monolithic to Modular Architecture
 
 This guide helps you migrate from the monolithic `network_system` to the new modular architecture introduced in v2.0.

--- a/docs/PRODUCTION_QUALITY.kr.md
+++ b/docs/PRODUCTION_QUALITY.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-QUAL-001"
+doc_title: "Network System 프로덕션 품질"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "QUAL"
+---
+
 # Network System 프로덕션 품질
 
 **언어:** [English](PRODUCTION_QUALITY.md) | **한국어**

--- a/docs/PRODUCTION_QUALITY.md
+++ b/docs/PRODUCTION_QUALITY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-QUAL-002"
+doc_title: "Network System Production Quality"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "QUAL"
+---
+
 # Network System Production Quality
 
 **Last Updated**: 2025-11-15

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-PROJ-003"
+doc_title: "Network System 프로젝트 구조"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "PROJ"
+---
+
 # Network System 프로젝트 구조
 
 **언어:** [English](PROJECT_STRUCTURE.md) | **한국어**

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-PROJ-004"
+doc_title: "Network System Project Structure"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "PROJ"
+---
+
 # Network System Project Structure
 
 **Last Updated**: 2025-11-15

--- a/docs/README.kr.md
+++ b/docs/README.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-005"
+doc_title: "Network System 문서"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # Network System 문서
 
 > **Language:** [English](README.md) | **한국어**

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-006"
+doc_title: "Network System Documentation"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # Network System Documentation
 
 > **Language:** **English** | [한국어](README.kr.md)

--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-PROJ-005"
+doc_title: "SOUP List &mdash; network_system"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "PROJ"
+---
+
 # SOUP List &mdash; network_system
 
 > **Software of Unknown Provenance (SOUP) Register per IEC 62304:2006+AMD1:2015 &sect;8.1.2**

--- a/docs/UNIFIED_API_GUIDE.md
+++ b/docs/UNIFIED_API_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-007"
+doc_title: "Unified API Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # Unified API Guide
 
 > **Language:** **English**

--- a/docs/adr/ADR-001-grpc-official-library-wrapper.md
+++ b/docs/adr/ADR-001-grpc-official-library-wrapper.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-ADR-001"
+doc_title: "ADR-001: gRPC Official Library Wrapper Strategy"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "ADR"
+---
+
 # ADR-001: gRPC Official Library Wrapper Strategy
 
 **Status:** Accepted

--- a/docs/advanced/CONCEPTS.md
+++ b/docs/advanced/CONCEPTS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-API-003"
+doc_title: "C++20 Concepts for Network System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "API"
+---
+
 # C++20 Concepts for Network System
 
 **Version:** 0.1.0

--- a/docs/advanced/CONNECTION_POOLING.md
+++ b/docs/advanced/CONNECTION_POOLING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-008"
+doc_title: "Connection Pooling Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # Connection Pooling Guide
 
 ## Overview

--- a/docs/advanced/HTTP_ADVANCED.md
+++ b/docs/advanced/HTTP_ADVANCED.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-009"
+doc_title: "HTTP Server Advanced Features Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # HTTP Server Advanced Features Guide
 
 **Last Updated**: 2025-11-24

--- a/docs/advanced/MEMORY_PROFILING.md
+++ b/docs/advanced/MEMORY_PROFILING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-PERF-003"
+doc_title: "Memory Profiling Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "PERF"
+---
+
 # Memory Profiling Guide
 
 This guide explains how to profile memory usage in the Network System library and detect memory leaks.

--- a/docs/advanced/MIGRATION.md
+++ b/docs/advanced/MIGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-MIGR-002"
+doc_title: "Migration Guide: messaging_system to network_system"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "MIGR"
+---
+
 # Migration Guide: messaging_system to network_system
 
 > **Language:** **English** | [한국어](MIGRATION_KO.md)

--- a/docs/advanced/OPERATIONS.kr.md
+++ b/docs/advanced/OPERATIONS.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-010"
+doc_title: "운영 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # 운영 가이드
 
 > **Language:** [English](OPERATIONS.md) | **한국어**

--- a/docs/advanced/OPERATIONS.md
+++ b/docs/advanced/OPERATIONS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-011"
+doc_title: "Operations Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # Operations Guide
 
 > **Language:** **English** | [한국어](OPERATIONS.kr.md)

--- a/docs/advanced/PERFORMANCE_TUNING.md
+++ b/docs/advanced/PERFORMANCE_TUNING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-PERF-004"
+doc_title: "Performance Tuning Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "PERF"
+---
+
 # Performance Tuning Guide
 
 **Last Updated**: 2025-11-25

--- a/docs/advanced/STATIC_ANALYSIS.md
+++ b/docs/advanced/STATIC_ANALYSIS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-QUAL-003"
+doc_title: "Static Analysis Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "QUAL"
+---
+
 # Static Analysis Guide
 
 This guide explains how to run static analysis tools for the Network System library.

--- a/docs/advanced/UDP_RELIABILITY.md
+++ b/docs/advanced/UDP_RELIABILITY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-012"
+doc_title: "UDP Reliability Layer Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # UDP Reliability Layer Guide
 
 **Last Updated**: 2025-11-24

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-PROJ-006"
+doc_title: "Contributing to Network System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "PROJ"
+---
+
 > **Note**: The canonical version of this document is at the [project root](../../CONTRIBUTING.md). This copy is kept for reference.
 
 # Contributing to Network System

--- a/docs/design/composition-design.md
+++ b/docs/design/composition-design.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-ARCH-003"
+doc_title: "Composition-Based Design Specification"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "ARCH"
+---
+
 # Composition-Based Design Specification
 
 > **Document Version:** 1.1.0

--- a/docs/design/crtp-analysis.md
+++ b/docs/design/crtp-analysis.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-ARCH-004"
+doc_title: "CRTP Base Classes Analysis"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "ARCH"
+---
+
 # CRTP Base Classes Analysis
 
 > **Document Version:** 2.0.0

--- a/docs/design/session-manager-template-design.md
+++ b/docs/design/session-manager-template-design.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-ARCH-005"
+doc_title: "SessionManager<T> Template Design"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "ARCH"
+---
+
 # SessionManager<T> Template Design
 
 > **Issue**: #461 (Phase 2.2 of #412)

--- a/docs/facades/README.md
+++ b/docs/facades/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-013"
+doc_title: "Network System Facade API"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # Network System Facade API
 
 > **Version:** 2.0.0

--- a/docs/facades/migration-guide.md
+++ b/docs/facades/migration-guide.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-MIGR-003"
+doc_title: "Facade Pattern Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "MIGR"
+---
+
 # Facade Pattern Migration Guide
 
 > **Version:** 2.0.0

--- a/docs/guides/BUILD.kr.md
+++ b/docs/guides/BUILD.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-014"
+doc_title: "빌드 지침"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # 빌드 지침
 
 > **Language:** [English](BUILD.md) | **한국어**

--- a/docs/guides/BUILD.md
+++ b/docs/guides/BUILD.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-015"
+doc_title: "Build Instructions"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # Build Instructions
 
 > **Language:** **English** | [한국어](BUILD.kr.md)

--- a/docs/guides/GRPC_GUIDE.md
+++ b/docs/guides/GRPC_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-016"
+doc_title: "gRPC Integration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # gRPC Integration Guide
 
 > **Language:** **English** | [한국어](GRPC_GUIDE.kr.md)

--- a/docs/guides/LOAD_TEST_GUIDE.md
+++ b/docs/guides/LOAD_TEST_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-PERF-005"
+doc_title: "Network Load Testing Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "PERF"
+---
+
 # Network Load Testing Guide
 
 **Version**: 0.1.0.0

--- a/docs/guides/MIGRATION_UNIFIED_API.md
+++ b/docs/guides/MIGRATION_UNIFIED_API.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-MIGR-004"
+doc_title: "Migration Guide: Unified Interface API"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "MIGR"
+---
+
 # Migration Guide: Unified Interface API
 
 This guide helps you migrate from the legacy protocol-specific interfaces (12+ interfaces) to the new unified interface API (3 core interfaces).

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-017"
+doc_title: "빠른 시작 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # 빠른 시작 가이드
 
 > **Language:** [English](QUICK_START.md) | **한국어**

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-018"
+doc_title: "Quick Start Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # Quick Start Guide
 
 > **Language:** **English** | [한국어](QUICK_START.kr.md)

--- a/docs/guides/TLS_SETUP_GUIDE.kr.md
+++ b/docs/guides/TLS_SETUP_GUIDE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-SECU-001"
+doc_title: "network_system을 위한 TLS/SSL 설정 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "SECU"
+---
+
 # network_system을 위한 TLS/SSL 설정 가이드
 
 > **Language:** [English](TLS_SETUP_GUIDE.md) | **한국어**

--- a/docs/guides/TLS_SETUP_GUIDE.md
+++ b/docs/guides/TLS_SETUP_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-SECU-002"
+doc_title: "TLS/SSL Setup Guide for network_system"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "SECU"
+---
+
 # TLS/SSL Setup Guide for network_system
 
 > **Language:** **English** | [한국어](TLS_SETUP_GUIDE.kr.md)

--- a/docs/guides/TROUBLESHOOTING.kr.md
+++ b/docs/guides/TROUBLESHOOTING.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-019"
+doc_title: "문제 해결 가이드"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # 문제 해결 가이드
 
 > **Language:** [English](TROUBLESHOOTING.md) | **한국어**

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-020"
+doc_title: "Troubleshooting Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # Troubleshooting Guide
 
 > **Language:** **English** | [한국어](TROUBLESHOOTING.kr.md)

--- a/docs/guides/UDP_SUPPORT.md
+++ b/docs/guides/UDP_SUPPORT.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-021"
+doc_title: "UDP Support in Network System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # UDP Support in Network System
 
 This document describes the UDP protocol support added to the network_system library.

--- a/docs/guides/tracing.md
+++ b/docs/guides/tracing.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-022"
+doc_title: "OpenTelemetry Tracing Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # OpenTelemetry Tracing Guide
 
 This guide covers the OpenTelemetry-compatible distributed tracing support in network_system.

--- a/docs/implementation/01-architecture-and-components.md
+++ b/docs/implementation/01-architecture-and-components.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-ARCH-006"
+doc_title: "Architecture & Components"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "ARCH"
+---
+
 # Architecture & Components
 
 > **Part 1 of 4** | [📑 Index](README.md) | [Next: Dependency & Testing →](02-dependency-and-testing.md)

--- a/docs/implementation/02-dependency-and-testing.md
+++ b/docs/implementation/02-dependency-and-testing.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-QUAL-004"
+doc_title: "Dependency & Testing"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "QUAL"
+---
+
 # Dependency & Testing
 
 > **Part 2 of 4** | [📑 Index](README.md) | [← Previous: Architecture](01-architecture-and-components.md) | [Next: Performance →](03-performance-and-resources.md)

--- a/docs/implementation/03-performance-and-resources.md
+++ b/docs/implementation/03-performance-and-resources.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-PERF-006"
+doc_title: "Performance & Resources"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "PERF"
+---
+
 # Performance & Resources
 
 > **Part 3 of 4** | [📑 Index](README.md) | [← Previous: Testing](02-dependency-and-testing.md) | [Next: Error Handling →](04-error-handling.md)

--- a/docs/implementation/04-error-handling.md
+++ b/docs/implementation/04-error-handling.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-023"
+doc_title: "Error Handling Strategy"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # Error Handling Strategy
 
 > **Part 4 of 4** | [📑 Index](README.md) | [← Previous: Performance](03-performance-and-resources.md)

--- a/docs/implementation/README.md
+++ b/docs/implementation/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-024"
+doc_title: "Network System Implementation Details"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # Network System Implementation Details
 
 > **Language:** **English** | [한국어](README.kr.md)

--- a/docs/integration/README.md
+++ b/docs/integration/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-025"
+doc_title: "Network System Integration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # Network System Integration Guide
 
 ## Overview

--- a/docs/integration/with-common-system.md
+++ b/docs/integration/with-common-system.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-INTR-003"
+doc_title: "Integrating Common System with Network System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "INTR"
+---
+
 # Integrating Common System with Network System
 
 ## Overview

--- a/docs/integration/with-logger.md
+++ b/docs/integration/with-logger.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-INTR-004"
+doc_title: "Integrating Logger System with Network System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "INTR"
+---
+
 # Integrating Logger System with Network System
 
 ## Overview

--- a/docs/integration/with-monitoring.md
+++ b/docs/integration/with-monitoring.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-INTR-005"
+doc_title: "Network System Integration with Monitoring System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "INTR"
+---
+
 # Network System Integration with Monitoring System
 
 ## Overview

--- a/docs/migration/adapter_to_bridge_migration.md
+++ b/docs/migration/adapter_to_bridge_migration.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-MIGR-005"
+doc_title: "Migration Guide: From Adapters to NetworkSystemBridge"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "MIGR"
+---
+
 # Migration Guide: From Adapters to NetworkSystemBridge
 
 ## Overview

--- a/docs/migration/network_system_bridge.md
+++ b/docs/migration/network_system_bridge.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-INTR-006"
+doc_title: "NetworkSystemBridge Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "INTR"
+---
+
 # NetworkSystemBridge Migration Guide
 
 ## Overview

--- a/docs/performance/BASELINE.kr.md
+++ b/docs/performance/BASELINE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-PERF-007"
+doc_title: "Network System - 성능 기준 메트릭"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "PERF"
+---
+
 # Network System - 성능 기준 메트릭
 
 [English](BASELINE.md) | **한국어**

--- a/docs/performance/BASELINE.md
+++ b/docs/performance/BASELINE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-PERF-008"
+doc_title: "Network System - Performance Baseline Metrics"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "PERF"
+---
+
 # Network System - Performance Baseline Metrics
 
 **English** | [한국어](BASELINE.kr.md)

--- a/docs/protocols/quic/API_REFERENCE.md
+++ b/docs/protocols/quic/API_REFERENCE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-API-004"
+doc_title: "QUIC API Reference"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "API"
+---
+
 # QUIC API Reference
 
 ## Namespace

--- a/docs/protocols/quic/ARCHITECTURE.md
+++ b/docs/protocols/quic/ARCHITECTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-ARCH-007"
+doc_title: "QUIC Implementation Architecture"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "ARCH"
+---
+
 # QUIC Implementation Architecture
 
 ## Layer Structure

--- a/docs/protocols/quic/CONFIGURATION.md
+++ b/docs/protocols/quic/CONFIGURATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-026"
+doc_title: "QUIC Configuration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # QUIC Configuration Guide
 
 ## Build Configuration

--- a/docs/protocols/quic/EXAMPLES.md
+++ b/docs/protocols/quic/EXAMPLES.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-027"
+doc_title: "QUIC Examples"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # QUIC Examples
 
 ## Basic Echo Server and Client

--- a/docs/protocols/quic/README.md
+++ b/docs/protocols/quic/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-028"
+doc_title: "QUIC Protocol Support"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # QUIC Protocol Support
 
 ## Overview

--- a/docs/refactoring/HEADER_AUDIT_PHASE1.md
+++ b/docs/refactoring/HEADER_AUDIT_PHASE1.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-PROJ-007"
+doc_title: "Header Audit - Phase 1: Preparation for Internal Migration"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "PROJ"
+---
+
 # Header Audit - Phase 1: Preparation for Internal Migration
 
 > **Issue**: #610

--- a/docs/refactoring/MIGRATION_GUIDE_V2.md
+++ b/docs/refactoring/MIGRATION_GUIDE_V2.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-MIGR-006"
+doc_title: "Migration Guide: network_system v1.x → v2.0"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "MIGR"
+---
+
 # Migration Guide: network_system v1.x → v2.0
 
 > **Version**: 0.2.0.0

--- a/docs/refactoring/README.md
+++ b/docs/refactoring/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "NET-GUID-029"
+doc_title: "Refactoring Documentation"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "network_system"
+category: "GUID"
+---
+
 # Refactoring Documentation
 
 > **Epic**: #577 - Apply Facade pattern to reduce protocol header complexity


### PR DESCRIPTION
Part of kcenon/common_system#562

## Summary
- Add standardized YAML frontmatter metadata to 76 markdown files in `docs/`
- Each file gets a unique `doc_id` (`NET-{CATEGORY}-{NNN}`), title, version, date, status, project, and category

## Category Breakdown (76 files)
| Category | Count | Description |
|----------|-------|-------------|
| ADR | 1 | Decision Records |
| API | 4 | API Reference |
| ARCH | 7 | Architecture |
| FEAT | 2 | Features |
| GUID | 29 | User Guides |
| INTR | 6 | Integration |
| MIGR | 6 | Migration |
| PERF | 8 | Performance |
| PROJ | 7 | Project Info |
| QUAL | 4 | Quality |
| SECU | 2 | Security |

## Test Plan
- [x] Script runs idempotently (re-running skips all files)
- [x] No duplicate doc_id values
- [x] Existing document content unchanged (frontmatter prepended only)