### PR TITLE
docs: add SSOT documentation registry

### DIFF
--- a/docs/API_REFERENCE.kr.md
+++ b/docs/API_REFERENCE.kr.md
@@ -10,6 +10,8 @@ category: "API"
 
 # API 참조
 
+> **SSOT**: This document is the single source of truth for **API 참조**.
+
 > **Language:** [English](API_REFERENCE.md) | **한국어**
 
 Network System 라이브러리에 대한 포괄적인 API 문서입니다.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -10,6 +10,8 @@ category: "API"
 
 # API Reference
 
+> **SSOT**: This document is the single source of truth for **API Reference**.
+
 > **Language:** **English** | [한국어](API_REFERENCE.kr.md)
 
 Comprehensive API documentation for the Network System library.

--- a/docs/ARCHITECTURE.kr.md
+++ b/docs/ARCHITECTURE.kr.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # 아키텍처 개요
 
+> **SSOT**: This document is the single source of truth for **아키텍처 개요**.
+
 > **Language:** [English](ARCHITECTURE.md) | **한국어**
 
 ## 목적

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Network System Architecture
 
+> **SSOT**: This document is the single source of truth for **Network System Architecture**.
+
 > **Language:** **English** | [한국어](ARCHITECTURE.kr.md)
 
 ## Overview

--- a/docs/BENCHMARKS.kr.md
+++ b/docs/BENCHMARKS.kr.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Network System 성능 벤치마크
 
+> **SSOT**: This document is the single source of truth for **Network System 성능 벤치마크**.
+
 **언어:** [English](BENCHMARKS.md) | **한국어**
 
 **최종 업데이트**: 2025-11-28

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Network System Performance Benchmarks
 
+> **SSOT**: This document is the single source of truth for **Network System Performance Benchmarks**.
+
 **Last Updated**: 2025-11-15
 
 This document provides comprehensive performance metrics, benchmarking methodologies, and load testing results for the network system.

--- a/docs/CHANGELOG.kr.md
+++ b/docs/CHANGELOG.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # 변경 이력 - Network System
 
+> **SSOT**: This document is the single source of truth for **변경 이력 - Network System**.
+
 > **언어:** [English](CHANGELOG.md) | **한국어**
 
 Network System 프로젝트의 모든 주요 변경 사항이 이 파일에 문서화됩니다.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Changelog - Network System
 
+> **SSOT**: This document is the single source of truth for **Changelog - Network System**.
+
 > **Language:** **English** | [한국어](CHANGELOG.kr.md)
 
 All notable changes to the Network System project will be documented in this file.

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Design Decisions
 
+> **SSOT**: This document is the single source of truth for **Design Decisions**.
+
 > **Language:** **English** | [한국어](DESIGN_DECISIONS.kr.md)
 
 This document explains key design decisions in network_system, particularly patterns that may seem unusual but are intentional and necessary.

--- a/docs/DTLS_RESILIENT_GUIDE.md
+++ b/docs/DTLS_RESILIENT_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # DTLS Socket and Resilient Client Guide
 
+> **SSOT**: This document is the single source of truth for **DTLS Socket and Resilient Client Guide**.
+
 > **Language:** **English**
 
 A comprehensive guide to two internal utility components in the `network_system` library: the DTLS (Datagram Transport Layer Security) socket for encrypted UDP communication, and the resilient client with automatic reconnection and circuit breaker support.

--- a/docs/FACADE_GUIDE.md
+++ b/docs/FACADE_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Facade API Guide
 
+> **SSOT**: This document is the single source of truth for **Facade API Guide**.
+
 > **Language:** **English**
 
 A comprehensive guide to the Facade v2.0 API layer, which provides simplified, high-level interfaces for each network protocol in the `network_system` library.

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -10,6 +10,8 @@ category: "FEAT"
 
 # Network System - 상세 기능
 
+> **SSOT**: This document is the single source of truth for **Network System - 상세 기능**.
+
 **언어:** [English](ARCHITECTURE.md) | **한국어**
 
 **최종 업데이트**: 2026-02-08

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -10,6 +10,8 @@ category: "FEAT"
 
 # Network System Features
 
+> **SSOT**: This document is the single source of truth for **Network System Features**.
+
 **Last Updated**: 2026-02-08
 
 This document provides comprehensive details on all features available in the network system.

--- a/docs/HTTP2_GUIDE.md
+++ b/docs/HTTP2_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # HTTP/2 Advanced Features Guide
 
+> **SSOT**: This document is the single source of truth for **HTTP/2 Advanced Features Guide**.
+
 > **Language:** **English**
 
 A comprehensive guide to the HTTP/2 protocol implementation in the `network_system` library, covering HPACK header compression, server-side streaming, client API, frame internals, flow control, and performance characteristics.

--- a/docs/INTEGRATION.kr.md
+++ b/docs/INTEGRATION.kr.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # Integration Guide
 
+> **SSOT**: This document is the single source of truth for **Integration Guide**.
+
 > **Language:** [English](INTEGRATION.md) | **한국어**
 
 이 가이드는 network_system을 외부 시스템 및 라이브러리와 통합하는 방법을 설명합니다.

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # Integration Guide
 
+> **SSOT**: This document is the single source of truth for **Integration Guide**.
+
 > **Language:** **English** | [한국어](INTEGRATION.kr.md)
 
 This guide explains how to integrate network_system with external systems and libraries.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Migration Guide: Monolithic to Modular Architecture
 
+> **SSOT**: This document is the single source of truth for **Migration Guide: Monolithic to Modular Architecture**.
+
 This guide helps you migrate from the monolithic `network_system` to the new modular architecture introduced in v2.0.
 
 ## Overview

--- a/docs/PRODUCTION_QUALITY.kr.md
+++ b/docs/PRODUCTION_QUALITY.kr.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # Network System 프로덕션 품질
 
+> **SSOT**: This document is the single source of truth for **Network System 프로덕션 품질**.
+
 **언어:** [English](PRODUCTION_QUALITY.md) | **한국어**
 
 **최종 업데이트**: 2025-11-28

--- a/docs/PRODUCTION_QUALITY.md
+++ b/docs/PRODUCTION_QUALITY.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # Network System Production Quality
 
+> **SSOT**: This document is the single source of truth for **Network System Production Quality**.
+
 **Last Updated**: 2025-11-15
 
 This document details the production-quality assurance measures, CI/CD infrastructure, security features, and quality metrics for the network system.

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Network System 프로젝트 구조
 
+> **SSOT**: This document is the single source of truth for **Network System 프로젝트 구조**.
+
 **언어:** [English](PROJECT_STRUCTURE.md) | **한국어**
 
 **최종 업데이트**: 2025-11-28

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Network System Project Structure
 
+> **SSOT**: This document is the single source of truth for **Network System Project Structure**.
+
 **Last Updated**: 2025-11-15
 
 This document provides a comprehensive guide to the project directory structure, file organization, and module descriptions.

--- a/docs/README.kr.md
+++ b/docs/README.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Network System 문서
 
+> **SSOT**: This document is the single source of truth for **Network System 문서**.
+
 > **Language:** [English](README.md) | **한국어**
 
 **버전:** 2.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ---
 doc_id: "NET-GUID-006"
-doc_title: "Network System Documentation"
+doc_title: "Network System Documentation Registry"
 doc_version: "1.0.0"
 doc_date: "2026-04-04"
 doc_status: "Released"
@@ -8,284 +8,225 @@ project: "network_system"
 category: "GUID"
 ---
 
-# Network System Documentation
+# Network System — Documentation Registry
 
-> **Language:** **English** | [한국어](README.kr.md)
+> **SSOT**: This file is the single source of truth for the documentation index
+> of **network_system**.
 
-**Version:** 0.2.0.0
-**Last Updated:** 2025-11-28
-**Status:** Comprehensive
+Total documents: **75**
 
-Welcome to the network_system documentation! This is a high-performance C++20 asynchronous network library providing reusable transport primitives for distributed systems and messaging applications.
+## Document Index
 
----
+| # | doc_id | Topic | Authority Document | Status |
+|---|--------|-------|-------------------|--------|
+| 1 | NET-ARCH-001 | 아키텍처 개요 | [ARCHITECTURE.kr.md](./ARCHITECTURE.kr.md) | Released |
+| 2 | NET-ARCH-002 | Network System Architecture | [ARCHITECTURE.md](./ARCHITECTURE.md) | Released |
+| 3 | NET-ARCH-003 | Composition-Based Design Specification | [composition-design.md](./design/composition-design.md) | Released |
+| 4 | NET-ARCH-004 | CRTP Base Classes Analysis | [crtp-analysis.md](./design/crtp-analysis.md) | Released |
+| 5 | NET-ARCH-005 | SessionManager<T> Template Design | [session-manager-template-design.md](./design/session-manager-template-design.md) | Released |
+| 6 | NET-ARCH-006 | Architecture & Components | [01-architecture-and-components.md](./implementation/01-architecture-and-components.md) | Released |
+| 7 | NET-ARCH-007 | QUIC Implementation Architecture | [ARCHITECTURE.md](./protocols/quic/ARCHITECTURE.md) | Released |
+| 8 | NET-API-001 | API 참조 | [API_REFERENCE.kr.md](./API_REFERENCE.kr.md) | Released |
+| 9 | NET-API-002 | API Reference | [API_REFERENCE.md](./API_REFERENCE.md) | Released |
+| 10 | NET-API-003 | C++20 Concepts for Network System | [CONCEPTS.md](./advanced/CONCEPTS.md) | Released |
+| 11 | NET-API-004 | QUIC API Reference | [API_REFERENCE.md](./protocols/quic/API_REFERENCE.md) | Released |
+| 12 | NET-FEAT-001 | Network System - 상세 기능 | [FEATURES.kr.md](./FEATURES.kr.md) | Released |
+| 13 | NET-FEAT-002 | Network System Features | [FEATURES.md](./FEATURES.md) | Released |
+| 14 | NET-GUID-001 | Design Decisions | [DESIGN_DECISIONS.md](./DESIGN_DECISIONS.md) | Released |
+| 15 | NET-GUID-002 | DTLS Socket and Resilient Client Guide | [DTLS_RESILIENT_GUIDE.md](./DTLS_RESILIENT_GUIDE.md) | Released |
+| 16 | NET-GUID-003 | Facade API Guide | [FACADE_GUIDE.md](./FACADE_GUIDE.md) | Released |
+| 17 | NET-GUID-004 | HTTP/2 Advanced Features Guide | [HTTP2_GUIDE.md](./HTTP2_GUIDE.md) | Released |
+| 18 | NET-GUID-005 | Network System 문서 | [README.kr.md](./README.kr.md) | Released |
+| 19 | NET-GUID-007 | Unified API Guide | [UNIFIED_API_GUIDE.md](./UNIFIED_API_GUIDE.md) | Released |
+| 20 | NET-GUID-008 | Connection Pooling Guide | [CONNECTION_POOLING.md](./advanced/CONNECTION_POOLING.md) | Released |
+| 21 | NET-GUID-009 | HTTP Server Advanced Features Guide | [HTTP_ADVANCED.md](./advanced/HTTP_ADVANCED.md) | Released |
+| 22 | NET-GUID-010 | 운영 가이드 | [OPERATIONS.kr.md](./advanced/OPERATIONS.kr.md) | Released |
+| 23 | NET-GUID-011 | Operations Guide | [OPERATIONS.md](./advanced/OPERATIONS.md) | Released |
+| 24 | NET-GUID-012 | UDP Reliability Layer Guide | [UDP_RELIABILITY.md](./advanced/UDP_RELIABILITY.md) | Released |
+| 25 | NET-GUID-013 | Network System Facade API | [README.md](./facades/README.md) | Released |
+| 26 | NET-GUID-014 | 빌드 지침 | [BUILD.kr.md](./guides/BUILD.kr.md) | Released |
+| 27 | NET-GUID-015 | Build Instructions | [BUILD.md](./guides/BUILD.md) | Released |
+| 28 | NET-GUID-016 | gRPC Integration Guide | [GRPC_GUIDE.md](./guides/GRPC_GUIDE.md) | Released |
+| 29 | NET-GUID-017 | 빠른 시작 가이드 | [QUICK_START.kr.md](./guides/QUICK_START.kr.md) | Released |
+| 30 | NET-GUID-018 | Quick Start Guide | [QUICK_START.md](./guides/QUICK_START.md) | Released |
+| 31 | NET-GUID-019 | 문제 해결 가이드 | [TROUBLESHOOTING.kr.md](./guides/TROUBLESHOOTING.kr.md) | Released |
+| 32 | NET-GUID-020 | Troubleshooting Guide | [TROUBLESHOOTING.md](./guides/TROUBLESHOOTING.md) | Released |
+| 33 | NET-GUID-021 | UDP Support in Network System | [UDP_SUPPORT.md](./guides/UDP_SUPPORT.md) | Released |
+| 34 | NET-GUID-022 | OpenTelemetry Tracing Guide | [tracing.md](./guides/tracing.md) | Released |
+| 35 | NET-GUID-023 | Error Handling Strategy | [04-error-handling.md](./implementation/04-error-handling.md) | Released |
+| 36 | NET-GUID-024 | Network System Implementation Details | [README.md](./implementation/README.md) | Released |
+| 37 | NET-GUID-025 | Network System Integration Guide | [README.md](./integration/README.md) | Released |
+| 38 | NET-GUID-026 | QUIC Configuration Guide | [CONFIGURATION.md](./protocols/quic/CONFIGURATION.md) | Released |
+| 39 | NET-GUID-027 | QUIC Examples | [EXAMPLES.md](./protocols/quic/EXAMPLES.md) | Released |
+| 40 | NET-GUID-028 | QUIC Protocol Support | [README.md](./protocols/quic/README.md) | Released |
+| 41 | NET-GUID-029 | Refactoring Documentation | [README.md](./refactoring/README.md) | Released |
+| 42 | NET-PERF-001 | Network System 성능 벤치마크 | [BENCHMARKS.kr.md](./BENCHMARKS.kr.md) | Released |
+| 43 | NET-PERF-002 | Network System Performance Benchmarks | [BENCHMARKS.md](./BENCHMARKS.md) | Released |
+| 44 | NET-PERF-003 | Memory Profiling Guide | [MEMORY_PROFILING.md](./advanced/MEMORY_PROFILING.md) | Released |
+| 45 | NET-PERF-004 | Performance Tuning Guide | [PERFORMANCE_TUNING.md](./advanced/PERFORMANCE_TUNING.md) | Released |
+| 46 | NET-PERF-005 | Network Load Testing Guide | [LOAD_TEST_GUIDE.md](./guides/LOAD_TEST_GUIDE.md) | Released |
+| 47 | NET-PERF-006 | Performance & Resources | [03-performance-and-resources.md](./implementation/03-performance-and-resources.md) | Released |
+| 48 | NET-PERF-007 | Network System - 성능 기준 메트릭 | [BASELINE.kr.md](./performance/BASELINE.kr.md) | Released |
+| 49 | NET-PERF-008 | Network System - Performance Baseline Metrics | [BASELINE.md](./performance/BASELINE.md) | Released |
+| 50 | NET-MIGR-001 | Migration Guide: Monolithic to Modular Architecture | [MIGRATION.md](./MIGRATION.md) | Released |
+| 51 | NET-MIGR-002 | Migration Guide: messaging_system to network_system | [MIGRATION.md](./advanced/MIGRATION.md) | Released |
+| 52 | NET-MIGR-003 | Facade Pattern Migration Guide | [migration-guide.md](./facades/migration-guide.md) | Released |
+| 53 | NET-MIGR-004 | Migration Guide: Unified Interface API | [MIGRATION_UNIFIED_API.md](./guides/MIGRATION_UNIFIED_API.md) | Released |
+| 54 | NET-MIGR-005 | Migration Guide: From Adapters to NetworkSystemBridge | [adapter_to_bridge_migration.md](./migration/adapter_to_bridge_migration.md) | Released |
+| 55 | NET-MIGR-006 | Migration Guide: network_system v1.x → v2.0 | [MIGRATION_GUIDE_V2.md](./refactoring/MIGRATION_GUIDE_V2.md) | Released |
+| 56 | NET-INTR-001 | Integration Guide | [INTEGRATION.kr.md](./INTEGRATION.kr.md) | Released |
+| 57 | NET-INTR-002 | Integration Guide | [INTEGRATION.md](./INTEGRATION.md) | Released |
+| 58 | NET-INTR-003 | Integrating Common System with Network System | [with-common-system.md](./integration/with-common-system.md) | Released |
+| 59 | NET-INTR-004 | Integrating Logger System with Network System | [with-logger.md](./integration/with-logger.md) | Released |
+| 60 | NET-INTR-005 | Network System Integration with Monitoring System | [with-monitoring.md](./integration/with-monitoring.md) | Released |
+| 61 | NET-INTR-006 | NetworkSystemBridge Migration Guide | [network_system_bridge.md](./migration/network_system_bridge.md) | Released |
+| 62 | NET-QUAL-001 | Network System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
+| 63 | NET-QUAL-002 | Network System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
+| 64 | NET-QUAL-003 | Static Analysis Guide | [STATIC_ANALYSIS.md](./advanced/STATIC_ANALYSIS.md) | Released |
+| 65 | NET-QUAL-004 | Dependency & Testing | [02-dependency-and-testing.md](./implementation/02-dependency-and-testing.md) | Released |
+| 66 | NET-SECU-001 | network_system을 위한 TLS/SSL 설정 가이드 | [TLS_SETUP_GUIDE.kr.md](./guides/TLS_SETUP_GUIDE.kr.md) | Released |
+| 67 | NET-SECU-002 | TLS/SSL Setup Guide for network_system | [TLS_SETUP_GUIDE.md](./guides/TLS_SETUP_GUIDE.md) | Released |
+| 68 | NET-ADR-001 | ADR-001: gRPC Official Library Wrapper Strategy | [ADR-001-grpc-official-library-wrapper.md](./adr/ADR-001-grpc-official-library-wrapper.md) | Released |
+| 69 | NET-PROJ-001 | 변경 이력 - Network System | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
+| 70 | NET-PROJ-002 | Changelog - Network System | [CHANGELOG.md](./CHANGELOG.md) | Released |
+| 71 | NET-PROJ-003 | Network System 프로젝트 구조 | [PROJECT_STRUCTURE.kr.md](./PROJECT_STRUCTURE.kr.md) | Released |
+| 72 | NET-PROJ-004 | Network System Project Structure | [PROJECT_STRUCTURE.md](./PROJECT_STRUCTURE.md) | Released |
+| 73 | NET-PROJ-005 | SOUP List &mdash; network_system | [SOUP.md](./SOUP.md) | Released |
+| 74 | NET-PROJ-006 | Contributing to Network System | [CONTRIBUTING.md](./contributing/CONTRIBUTING.md) | Released |
+| 75 | NET-PROJ-007 | Header Audit - Phase 1: Preparation for Internal Migration | [HEADER_AUDIT_PHASE1.md](./refactoring/HEADER_AUDIT_PHASE1.md) | Released |
 
-## Quick Navigation
+## Documents by Category
 
-| I want to... | Document |
-|--------------|----------|
-| Get started quickly | [Build Guide](guides/BUILD.md) |
-| Understand the architecture | [Architecture](ARCHITECTURE.md) |
-| Learn the API | [API Reference](API_REFERENCE.md) |
-| **Migrate to modular architecture** | **[Migration Guide](MIGRATION.md)** |
-| Use C++20 Concepts | [Concepts Guide](advanced/CONCEPTS.md) |
-| Configure TLS/SSL | [TLS Setup Guide](guides/TLS_SETUP_GUIDE.md) |
-| Troubleshoot an issue | [Troubleshooting](guides/TROUBLESHOOTING.md) |
-| Tune performance | [Performance Tuning](advanced/PERFORMANCE_TUNING.md) |
-| Integrate with other systems | [Integration Guide](INTEGRATION.md) |
+### Architecture (7)
 
----
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| NET-ARCH-001 | 아키텍처 개요 | [ARCHITECTURE.kr.md](./ARCHITECTURE.kr.md) | Released |
+| NET-ARCH-002 | Network System Architecture | [ARCHITECTURE.md](./ARCHITECTURE.md) | Released |
+| NET-ARCH-003 | Composition-Based Design Specification | [composition-design.md](./design/composition-design.md) | Released |
+| NET-ARCH-004 | CRTP Base Classes Analysis | [crtp-analysis.md](./design/crtp-analysis.md) | Released |
+| NET-ARCH-005 | SessionManager<T> Template Design | [session-manager-template-design.md](./design/session-manager-template-design.md) | Released |
+| NET-ARCH-006 | Architecture & Components | [01-architecture-and-components.md](./implementation/01-architecture-and-components.md) | Released |
+| NET-ARCH-007 | QUIC Implementation Architecture | [ARCHITECTURE.md](./protocols/quic/ARCHITECTURE.md) | Released |
 
-## Table of Contents
+### API Reference (4)
 
-- [Documentation Structure](#documentation-structure)
-- [Documentation by Role](#documentation-by-role)
-- [By Feature](#by-feature)
-- [Contributing to Documentation](#contributing-to-documentation)
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| NET-API-001 | API 참조 | [API_REFERENCE.kr.md](./API_REFERENCE.kr.md) | Released |
+| NET-API-002 | API Reference | [API_REFERENCE.md](./API_REFERENCE.md) | Released |
+| NET-API-003 | C++20 Concepts for Network System | [CONCEPTS.md](./advanced/CONCEPTS.md) | Released |
+| NET-API-004 | QUIC API Reference | [API_REFERENCE.md](./protocols/quic/API_REFERENCE.md) | Released |
 
----
+### Features (2)
 
-## Documentation Structure
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| NET-FEAT-001 | Network System - 상세 기능 | [FEATURES.kr.md](./FEATURES.kr.md) | Released |
+| NET-FEAT-002 | Network System Features | [FEATURES.md](./FEATURES.md) | Released |
 
-### Core Documentation
+### Guides (28)
 
-Essential documents for understanding the system:
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| NET-GUID-001 | Design Decisions | [DESIGN_DECISIONS.md](./DESIGN_DECISIONS.md) | Released |
+| NET-GUID-002 | DTLS Socket and Resilient Client Guide | [DTLS_RESILIENT_GUIDE.md](./DTLS_RESILIENT_GUIDE.md) | Released |
+| NET-GUID-003 | Facade API Guide | [FACADE_GUIDE.md](./FACADE_GUIDE.md) | Released |
+| NET-GUID-004 | HTTP/2 Advanced Features Guide | [HTTP2_GUIDE.md](./HTTP2_GUIDE.md) | Released |
+| NET-GUID-005 | Network System 문서 | [README.kr.md](./README.kr.md) | Released |
+| NET-GUID-007 | Unified API Guide | [UNIFIED_API_GUIDE.md](./UNIFIED_API_GUIDE.md) | Released |
+| NET-GUID-008 | Connection Pooling Guide | [CONNECTION_POOLING.md](./advanced/CONNECTION_POOLING.md) | Released |
+| NET-GUID-009 | HTTP Server Advanced Features Guide | [HTTP_ADVANCED.md](./advanced/HTTP_ADVANCED.md) | Released |
+| NET-GUID-010 | 운영 가이드 | [OPERATIONS.kr.md](./advanced/OPERATIONS.kr.md) | Released |
+| NET-GUID-011 | Operations Guide | [OPERATIONS.md](./advanced/OPERATIONS.md) | Released |
+| NET-GUID-012 | UDP Reliability Layer Guide | [UDP_RELIABILITY.md](./advanced/UDP_RELIABILITY.md) | Released |
+| NET-GUID-013 | Network System Facade API | [README.md](./facades/README.md) | Released |
+| NET-GUID-014 | 빌드 지침 | [BUILD.kr.md](./guides/BUILD.kr.md) | Released |
+| NET-GUID-015 | Build Instructions | [BUILD.md](./guides/BUILD.md) | Released |
+| NET-GUID-016 | gRPC Integration Guide | [GRPC_GUIDE.md](./guides/GRPC_GUIDE.md) | Released |
+| NET-GUID-017 | 빠른 시작 가이드 | [QUICK_START.kr.md](./guides/QUICK_START.kr.md) | Released |
+| NET-GUID-018 | Quick Start Guide | [QUICK_START.md](./guides/QUICK_START.md) | Released |
+| NET-GUID-019 | 문제 해결 가이드 | [TROUBLESHOOTING.kr.md](./guides/TROUBLESHOOTING.kr.md) | Released |
+| NET-GUID-020 | Troubleshooting Guide | [TROUBLESHOOTING.md](./guides/TROUBLESHOOTING.md) | Released |
+| NET-GUID-021 | UDP Support in Network System | [UDP_SUPPORT.md](./guides/UDP_SUPPORT.md) | Released |
+| NET-GUID-022 | OpenTelemetry Tracing Guide | [tracing.md](./guides/tracing.md) | Released |
+| NET-GUID-023 | Error Handling Strategy | [04-error-handling.md](./implementation/04-error-handling.md) | Released |
+| NET-GUID-024 | Network System Implementation Details | [README.md](./implementation/README.md) | Released |
+| NET-GUID-025 | Network System Integration Guide | [README.md](./integration/README.md) | Released |
+| NET-GUID-026 | QUIC Configuration Guide | [CONFIGURATION.md](./protocols/quic/CONFIGURATION.md) | Released |
+| NET-GUID-027 | QUIC Examples | [EXAMPLES.md](./protocols/quic/EXAMPLES.md) | Released |
+| NET-GUID-028 | QUIC Protocol Support | [README.md](./protocols/quic/README.md) | Released |
+| NET-GUID-029 | Refactoring Documentation | [README.md](./refactoring/README.md) | Released |
 
-| Document | Description | Korean |
-|----------|-------------|--------|
-| [ARCHITECTURE.md](ARCHITECTURE.md) | System design, ASIO integration, protocol layers | [KO](ARCHITECTURE.kr.md) |
-| [API_REFERENCE.md](API_REFERENCE.md) | Complete API documentation with examples | [KO](API_REFERENCE.kr.md) |
-| [FEATURES.md](FEATURES.md) | Detailed feature descriptions and capabilities | [KO](FEATURES.kr.md) |
-| [BENCHMARKS.md](BENCHMARKS.md) | Performance metrics and methodology | [KO](BENCHMARKS.kr.md) |
-| [PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md) | Codebase organization and directory layout | [KO](PROJECT_STRUCTURE.kr.md) |
-| [PRODUCTION_QUALITY.md](PRODUCTION_QUALITY.md) | Quality metrics and CI/CD status | [KO](PRODUCTION_QUALITY.kr.md) |
-| [CHANGELOG.md](CHANGELOG.md) | Version history and changes | [KO](CHANGELOG.kr.md) |
-| **[MIGRATION.md](MIGRATION.md)** | **Migration guide for modular architecture** | - |
+### Performance (8)
 
-### User Guides
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| NET-PERF-001 | Network System 성능 벤치마크 | [BENCHMARKS.kr.md](./BENCHMARKS.kr.md) | Released |
+| NET-PERF-002 | Network System Performance Benchmarks | [BENCHMARKS.md](./BENCHMARKS.md) | Released |
+| NET-PERF-003 | Memory Profiling Guide | [MEMORY_PROFILING.md](./advanced/MEMORY_PROFILING.md) | Released |
+| NET-PERF-004 | Performance Tuning Guide | [PERFORMANCE_TUNING.md](./advanced/PERFORMANCE_TUNING.md) | Released |
+| NET-PERF-005 | Network Load Testing Guide | [LOAD_TEST_GUIDE.md](./guides/LOAD_TEST_GUIDE.md) | Released |
+| NET-PERF-006 | Performance & Resources | [03-performance-and-resources.md](./implementation/03-performance-and-resources.md) | Released |
+| NET-PERF-007 | Network System - 성능 기준 메트릭 | [BASELINE.kr.md](./performance/BASELINE.kr.md) | Released |
+| NET-PERF-008 | Network System - Performance Baseline Metrics | [BASELINE.md](./performance/BASELINE.md) | Released |
 
-Step-by-step guides for users:
+### Migration (6)
 
-| Document | Description | Korean |
-|----------|-------------|--------|
-| [guides/BUILD.md](guides/BUILD.md) | Build instructions for all platforms | [KO](guides/BUILD.kr.md) |
-| **[facades/README.md](facades/README.md)** | **Simplified Facade API reference (NEW)** | - |
-| **[facades/migration-guide.md](facades/migration-guide.md)** | **Migration guide from direct templates to Facade API** | - |
-| [guides/TLS_SETUP_GUIDE.md](guides/TLS_SETUP_GUIDE.md) | TLS/SSL configuration and certificates | [KO](guides/TLS_SETUP_GUIDE.kr.md) |
-| [guides/TROUBLESHOOTING.md](guides/TROUBLESHOOTING.md) | Common problems and solutions | [KO](guides/TROUBLESHOOTING.kr.md) |
-| [INTEGRATION.md](INTEGRATION.md) | Integration with ecosystem systems | [KO](INTEGRATION.kr.md) |
-| [advanced/OPERATIONS.md](advanced/OPERATIONS.md) | Operational guidelines and deployment | [KO](advanced/OPERATIONS.kr.md) |
-| [guides/LOAD_TEST_GUIDE.md](guides/LOAD_TEST_GUIDE.md) | Load testing methodology and tools | - |
-| [guides/UDP_SUPPORT.md](guides/UDP_SUPPORT.md) | UDP protocol support and usage | - |
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| NET-MIGR-001 | Migration Guide: Monolithic to Modular Architecture | [MIGRATION.md](./MIGRATION.md) | Released |
+| NET-MIGR-002 | Migration Guide: messaging_system to network_system | [MIGRATION.md](./advanced/MIGRATION.md) | Released |
+| NET-MIGR-003 | Facade Pattern Migration Guide | [migration-guide.md](./facades/migration-guide.md) | Released |
+| NET-MIGR-004 | Migration Guide: Unified Interface API | [MIGRATION_UNIFIED_API.md](./guides/MIGRATION_UNIFIED_API.md) | Released |
+| NET-MIGR-005 | Migration Guide: From Adapters to NetworkSystemBridge | [adapter_to_bridge_migration.md](./migration/adapter_to_bridge_migration.md) | Released |
+| NET-MIGR-006 | Migration Guide: network_system v1.x → v2.0 | [MIGRATION_GUIDE_V2.md](./refactoring/MIGRATION_GUIDE_V2.md) | Released |
 
-### Advanced Topics
+### Integration (6)
 
-For experienced users and performance optimization:
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| NET-INTR-001 | Integration Guide | [INTEGRATION.kr.md](./INTEGRATION.kr.md) | Released |
+| NET-INTR-002 | Integration Guide | [INTEGRATION.md](./INTEGRATION.md) | Released |
+| NET-INTR-003 | Integrating Common System with Network System | [with-common-system.md](./integration/with-common-system.md) | Released |
+| NET-INTR-004 | Integrating Logger System with Network System | [with-logger.md](./integration/with-logger.md) | Released |
+| NET-INTR-005 | Network System Integration with Monitoring System | [with-monitoring.md](./integration/with-monitoring.md) | Released |
+| NET-INTR-006 | NetworkSystemBridge Migration Guide | [network_system_bridge.md](./migration/network_system_bridge.md) | Released |
 
-| Document | Description |
-|----------|-------------|
-| [advanced/CONCEPTS.md](advanced/CONCEPTS.md) | C++20 Concepts for compile-time type validation |
-| [advanced/PERFORMANCE_TUNING.md](advanced/PERFORMANCE_TUNING.md) | Performance optimization techniques |
-| [advanced/CONNECTION_POOLING.md](advanced/CONNECTION_POOLING.md) | Connection pool architecture and usage |
-| [advanced/UDP_RELIABILITY.md](advanced/UDP_RELIABILITY.md) | UDP reliability patterns and implementation |
-| [advanced/HTTP_ADVANCED.md](advanced/HTTP_ADVANCED.md) | Advanced HTTP features and configuration |
-| [advanced/MEMORY_PROFILING.md](advanced/MEMORY_PROFILING.md) | Memory analysis and optimization |
-| [advanced/STATIC_ANALYSIS.md](advanced/STATIC_ANALYSIS.md) | Static analysis configuration and results |
-| [advanced/MIGRATION.md](advanced/MIGRATION.md) | Migration guide from messaging_system |
+### Quality (4)
 
-### Performance
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| NET-QUAL-001 | Network System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
+| NET-QUAL-002 | Network System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
+| NET-QUAL-003 | Static Analysis Guide | [STATIC_ANALYSIS.md](./advanced/STATIC_ANALYSIS.md) | Released |
+| NET-QUAL-004 | Dependency & Testing | [02-dependency-and-testing.md](./implementation/02-dependency-and-testing.md) | Released |
 
-Performance metrics and baselines:
+### Security (2)
 
-| Document | Description | Korean |
-|----------|-------------|--------|
-| [performance/BASELINE.md](performance/BASELINE.md) | Performance baseline metrics | [KO](performance/BASELINE.kr.md) |
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| NET-SECU-001 | network_system을 위한 TLS/SSL 설정 가이드 | [TLS_SETUP_GUIDE.kr.md](./guides/TLS_SETUP_GUIDE.kr.md) | Released |
+| NET-SECU-002 | TLS/SSL Setup Guide for network_system | [TLS_SETUP_GUIDE.md](./guides/TLS_SETUP_GUIDE.md) | Released |
 
-### Contributing
+### Architecture Decision Records (1)
 
-| Document | Description |
-|----------|-------------|
-| [contributing/CONTRIBUTING.md](contributing/CONTRIBUTING.md) | Contribution guidelines |
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| NET-ADR-001 | ADR-001: gRPC Official Library Wrapper Strategy | [ADR-001-grpc-official-library-wrapper.md](./adr/ADR-001-grpc-official-library-wrapper.md) | Released |
 
-### Implementation Details
+### Project (7)
 
-Technical implementation documentation:
-
-| Document | Description |
-|----------|-------------|
-| [implementation/README.md](implementation/README.md) | Implementation overview |
-| [01-architecture-and-components.md](implementation/01-architecture-and-components.md) | Component architecture |
-| [02-dependency-and-testing.md](implementation/02-dependency-and-testing.md) | Dependencies and test strategy |
-| [03-performance-and-resources.md](implementation/03-performance-and-resources.md) | Performance characteristics |
-| [04-error-handling.md](implementation/04-error-handling.md) | Error handling patterns |
-
-### Integration Guides
-
-System integration documentation:
-
-| Document | Description |
-|----------|-------------|
-| [integration/README.md](integration/README.md) | Integration overview |
-| [integration/with-common-system.md](integration/with-common-system.md) | Common system integration |
-| [integration/with-logger.md](integration/with-logger.md) | Logger system integration |
-
----
-
-## Documentation by Role
-
-### For New Users
-
-**Getting Started Path**:
-1. **Build** - [Build Guide](guides/BUILD.md) to compile the library
-2. **Architecture** - [Architecture](ARCHITECTURE.md) for system overview
-3. **API** - [API Reference](API_REFERENCE.md) for basic usage
-4. **Examples** - Check `samples/` directory for working examples
-
-**When You Have Issues**:
-- Check [Troubleshooting](guides/TROUBLESHOOTING.md) first
-- Review [TLS Setup Guide](guides/TLS_SETUP_GUIDE.md) for SSL issues
-- Search [GitHub Issues](https://github.com/kcenon/network_system/issues)
-
-### For Experienced Developers
-
-**Advanced Usage Path**:
-1. **Architecture** - Deep dive into [Architecture](ARCHITECTURE.md)
-2. **Performance** - Learn [Performance Tuning](advanced/PERFORMANCE_TUNING.md)
-3. **Protocols** - Study protocol-specific docs (HTTP, WebSocket, UDP)
-4. **Integration** - Review [Integration Guide](INTEGRATION.md)
-
-**Deep Dive Topics**:
-- [Connection Pooling](advanced/CONNECTION_POOLING.md) - Pool architecture
-- [UDP Reliability](advanced/UDP_RELIABILITY.md) - Reliable UDP patterns
-- [Memory Profiling](advanced/MEMORY_PROFILING.md) - Memory optimization
-
-### For System Integrators
-
-**Integration Path**:
-1. **Integration Guide** - [System integration](INTEGRATION.md)
-2. **Common System** - [Common system integration](integration/with-common-system.md)
-3. **Logger** - [Logger integration](integration/with-logger.md)
-4. **Operations** - [Deployment guide](advanced/OPERATIONS.md)
-
----
-
-## By Feature
-
-### TCP/UDP Networking
-
-| Topic | Document |
-|-------|----------|
-| Architecture | [Architecture](ARCHITECTURE.md) |
-| API | [API Reference](API_REFERENCE.md) |
-| UDP Reliability | [UDP Reliability](advanced/UDP_RELIABILITY.md) |
-
-### TLS/SSL Security
-
-| Topic | Document |
-|-------|----------|
-| Setup | [TLS Setup Guide](guides/TLS_SETUP_GUIDE.md) |
-| Configuration | [Architecture](ARCHITECTURE.md#tls-configuration) |
-| Troubleshooting | [Troubleshooting](guides/TROUBLESHOOTING.md#tls-issues) |
-
-### HTTP Protocol
-
-| Topic | Document |
-|-------|----------|
-| Basic Usage | [API Reference](API_REFERENCE.md#http) |
-| Advanced | [HTTP Advanced](advanced/HTTP_ADVANCED.md) |
-| Performance | [Benchmarks](BENCHMARKS.md#http-performance) |
-
-### WebSocket Protocol
-
-| Topic | Document |
-|-------|----------|
-| Usage | [API Reference](API_REFERENCE.md#websocket) |
-| Features | [Features](FEATURES.md#websocket) |
-| Performance | [Benchmarks](BENCHMARKS.md#websocket-performance) |
-
-### Performance
-
-| Topic | Document |
-|-------|----------|
-| Benchmarks | [Benchmarks](BENCHMARKS.md) |
-| Tuning | [Performance Tuning](advanced/PERFORMANCE_TUNING.md) |
-| Profiling | [Memory Profiling](advanced/MEMORY_PROFILING.md) |
-| Load Testing | [Load Test Guide](guides/LOAD_TEST_GUIDE.md) |
-
----
-
-## Project Information
-
-### Current Status
-- **Version**: 0.2.0.0
-- **Type**: Static Library
-- **C++ Standard**: C++20 (C++17 compatible for some features)
-- **License**: BSD 3-Clause
-- **Test Status**: Under Development
-
-### Supported Protocols
-- TCP with lifecycle management and health monitoring
-- UDP with reliability options
-- TLS 1.2/1.3 with modern cipher suites
-- WebSocket (RFC 6455) with framing and keepalive
-- HTTP/1.1 with routing, cookies, multipart support
-- HTTP/2 frame and HPACK implementation
-- DTLS support
-
-### Key Features
-- ASIO-based non-blocking event loop
-- ~769K msg/sec for small payloads
-- Move-semantics friendly APIs (zero-copy)
-- C++20 coroutine support
-- Pipeline architecture for message transformation
-- Comprehensive error handling (Result<> types)
-
-### Platform Support
-- **Linux**: Ubuntu 22.04+, GCC 9+, Clang 10+
-- **macOS**: 12+, Apple Clang 14+
-- **Windows**: 11, MSVC 2019+
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| NET-PROJ-001 | 변경 이력 - Network System | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
+| NET-PROJ-002 | Changelog - Network System | [CHANGELOG.md](./CHANGELOG.md) | Released |
+| NET-PROJ-003 | Network System 프로젝트 구조 | [PROJECT_STRUCTURE.kr.md](./PROJECT_STRUCTURE.kr.md) | Released |
+| NET-PROJ-004 | Network System Project Structure | [PROJECT_STRUCTURE.md](./PROJECT_STRUCTURE.md) | Released |
+| NET-PROJ-005 | SOUP List &mdash; network_system | [SOUP.md](./SOUP.md) | Released |
+| NET-PROJ-006 | Contributing to Network System | [CONTRIBUTING.md](./contributing/CONTRIBUTING.md) | Released |
+| NET-PROJ-007 | Header Audit - Phase 1: Preparation for Internal Migration | [HEADER_AUDIT_PHASE1.md](./refactoring/HEADER_AUDIT_PHASE1.md) | Released |
 
 ---
 
-## Contributing to Documentation
-
-### Documentation Standards
-- Front matter on all documents (version, date, status)
-- Code examples must compile
-- Bilingual support (English/Korean)
-- Cross-references with relative links
-
-### Submission Process
-1. Edit markdown files
-2. Test all code examples
-3. Update Korean translations if applicable
-4. Submit pull request
-
----
-
-## Getting Help
-
-### Documentation Issues
-- **Missing info**: Open documentation issue on GitHub
-- **Incorrect examples**: Report with details
-- **Unclear instructions**: Suggest improvements
-
-### Technical Support
-1. Check [Troubleshooting](guides/TROUBLESHOOTING.md)
-2. Search [GitHub Issues](https://github.com/kcenon/network_system/issues)
-3. Ask on GitHub Discussions
-
----
-
-## External Resources
-
-- **GitHub Repository**: [kcenon/network_system](https://github.com/kcenon/network_system)
-- **Issue Tracker**: [GitHub Issues](https://github.com/kcenon/network_system/issues)
-- **Main README**: [../README.md](../README.md)
-- **Ecosystem Overview**: [../../docs/ECOSYSTEM_OVERVIEW.md](../../docs/ECOSYSTEM_OVERVIEW.md)
-
----
-
-**Network System Documentation** - High-Performance C++20 Async Networking
-
-**Last Updated**: 2025-12-10
+*Registry generated for issue [#563](https://github.com/kcenon/network_system/issues/563).*

--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # SOUP List &mdash; network_system
 
+> **SSOT**: This document is the single source of truth for **SOUP List &mdash; network_system**.
+
 > **Software of Unknown Provenance (SOUP) Register per IEC 62304:2006+AMD1:2015 &sect;8.1.2**
 >
 > This document is the authoritative reference for all external software dependencies.

--- a/docs/UNIFIED_API_GUIDE.md
+++ b/docs/UNIFIED_API_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Unified API Guide
 
+> **SSOT**: This document is the single source of truth for **Unified API Guide**.
+
 > **Language:** **English**
 
 A comprehensive guide to the Unified API interface layer, which provides protocol-agnostic abstractions for connections, listeners, and transports in the `network_system` library.

--- a/docs/adr/ADR-001-grpc-official-library-wrapper.md
+++ b/docs/adr/ADR-001-grpc-official-library-wrapper.md
@@ -10,6 +10,8 @@ category: "ADR"
 
 # ADR-001: gRPC Official Library Wrapper Strategy
 
+> **SSOT**: This document is the single source of truth for **ADR-001: gRPC Official Library Wrapper Strategy**.
+
 **Status:** Accepted
 **Date:** 2024-12-28
 **Decision Makers:** Development Team

--- a/docs/advanced/CONCEPTS.md
+++ b/docs/advanced/CONCEPTS.md
@@ -10,6 +10,8 @@ category: "API"
 
 # C++20 Concepts for Network System
 
+> **SSOT**: This document is the single source of truth for **C++20 Concepts for Network System**.
+
 **Version:** 0.1.0
 **Last Updated:** 2025-12-10
 **Status:** Complete

--- a/docs/advanced/CONNECTION_POOLING.md
+++ b/docs/advanced/CONNECTION_POOLING.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Connection Pooling Guide
 
+> **SSOT**: This document is the single source of truth for **Connection Pooling Guide**.
+
 ## Overview
 
 Connection pooling allows efficient reuse of network connections, reducing the overhead of establishing new connections for each request. The `connection_pool` class manages a pool of `messaging_client` instances that can be borrowed and returned.

--- a/docs/advanced/HTTP_ADVANCED.md
+++ b/docs/advanced/HTTP_ADVANCED.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # HTTP Server Advanced Features Guide
 
+> **SSOT**: This document is the single source of truth for **HTTP Server Advanced Features Guide**.
+
 **Last Updated**: 2025-11-24
 **Version**: 0.1.0.0
 

--- a/docs/advanced/MEMORY_PROFILING.md
+++ b/docs/advanced/MEMORY_PROFILING.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Memory Profiling Guide
 
+> **SSOT**: This document is the single source of truth for **Memory Profiling Guide**.
+
 This guide explains how to profile memory usage in the Network System library and detect memory leaks.
 
 ## Quick Start

--- a/docs/advanced/MIGRATION.md
+++ b/docs/advanced/MIGRATION.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Migration Guide: messaging_system to network_system
 
+> **SSOT**: This document is the single source of truth for **Migration Guide: messaging_system to network_system**.
+
 > **Language:** **English** | [한국어](MIGRATION_KO.md)
 
 **Document Version**: 1.0.0

--- a/docs/advanced/OPERATIONS.kr.md
+++ b/docs/advanced/OPERATIONS.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # 운영 가이드
 
+> **SSOT**: This document is the single source of truth for **운영 가이드**.
+
 > **Language:** [English](OPERATIONS.md) | **한국어**
 
 이 가이드는 Network System의 배포, 구성, 모니터링 및 운영 모범 사례를 다룹니다.

--- a/docs/advanced/OPERATIONS.md
+++ b/docs/advanced/OPERATIONS.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Operations Guide
 
+> **SSOT**: This document is the single source of truth for **Operations Guide**.
+
 > **Language:** **English** | [한국어](OPERATIONS.kr.md)
 
 This guide covers deployment, configuration, monitoring, and operational best practices for the Network System.

--- a/docs/advanced/PERFORMANCE_TUNING.md
+++ b/docs/advanced/PERFORMANCE_TUNING.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Performance Tuning Guide
 
+> **SSOT**: This document is the single source of truth for **Performance Tuning Guide**.
+
 **Last Updated**: 2025-11-25
 
 This guide provides comprehensive guidance on optimizing network system performance for different workloads and environments.

--- a/docs/advanced/STATIC_ANALYSIS.md
+++ b/docs/advanced/STATIC_ANALYSIS.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # Static Analysis Guide
 
+> **SSOT**: This document is the single source of truth for **Static Analysis Guide**.
+
 This guide explains how to run static analysis tools for the Network System library.
 
 ## Quick Start

--- a/docs/advanced/UDP_RELIABILITY.md
+++ b/docs/advanced/UDP_RELIABILITY.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # UDP Reliability Layer Guide
 
+> **SSOT**: This document is the single source of truth for **UDP Reliability Layer Guide**.
+
 **Last Updated**: 2025-11-24
 **Version**: 0.1.0.0
 

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -12,6 +12,8 @@ category: "PROJ"
 
 # Contributing to Network System
 
+> **SSOT**: This document is the single source of truth for **Contributing to Network System**.
+
 **Version:** 0.1.0.0
 **Last Updated:** 2025-11-28
 

--- a/docs/design/composition-design.md
+++ b/docs/design/composition-design.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Composition-Based Design Specification
 
+> **SSOT**: This document is the single source of truth for **Composition-Based Design Specification**.
+
 > **Document Version:** 1.1.0
 > **Related Issue:** [#411](https://github.com/kcenon/network_system/issues/411), [#422](https://github.com/kcenon/network_system/issues/422), [#423](https://github.com/kcenon/network_system/issues/423)
 > **Last Updated:** 2025-01-13

--- a/docs/design/crtp-analysis.md
+++ b/docs/design/crtp-analysis.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # CRTP Base Classes Analysis
 
+> **SSOT**: This document is the single source of truth for **CRTP Base Classes Analysis**.
+
 > **Document Version:** 2.0.0
 > **Related Issue:** [#411](https://github.com/kcenon/network_system/issues/411), [#422](https://github.com/kcenon/network_system/issues/422)
 > **Last Updated:** 2025-01-15

--- a/docs/design/session-manager-template-design.md
+++ b/docs/design/session-manager-template-design.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # SessionManager<T> Template Design
 
+> **SSOT**: This document is the single source of truth for **SessionManager<T> Template Design**.
+
 > **Issue**: #461 (Phase 2.2 of #412)
 > **Status**: Draft
 > **Author**: TBD

--- a/docs/facades/README.md
+++ b/docs/facades/README.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Network System Facade API
 
+> **SSOT**: This document is the single source of truth for **Network System Facade API**.
+
 > **Version:** 2.0.0
 > **Last Updated:** 2025-02-04
 > **Status:** Complete

--- a/docs/facades/migration-guide.md
+++ b/docs/facades/migration-guide.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Facade Pattern Migration Guide
 
+> **SSOT**: This document is the single source of truth for **Facade Pattern Migration Guide**.
+
 > **Version:** 2.0.0
 > **Last Updated:** 2025-02-04
 > **Audience:** Developers migrating from direct template usage to Facade API

--- a/docs/guides/BUILD.kr.md
+++ b/docs/guides/BUILD.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # 빌드 지침
 
+> **SSOT**: This document is the single source of truth for **빌드 지침**.
+
 > **Language:** [English](BUILD.md) | **한국어**
 
 ## 목차

--- a/docs/guides/BUILD.md
+++ b/docs/guides/BUILD.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Build Instructions
 
+> **SSOT**: This document is the single source of truth for **Build Instructions**.
+
 > **Language:** **English** | [한국어](BUILD.kr.md)
 
 ## Table of Contents

--- a/docs/guides/GRPC_GUIDE.md
+++ b/docs/guides/GRPC_GUIDE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # gRPC Integration Guide
 
+> **SSOT**: This document is the single source of truth for **gRPC Integration Guide**.
+
 > **Language:** **English** | [한국어](GRPC_GUIDE.kr.md)
 
 ---

--- a/docs/guides/LOAD_TEST_GUIDE.md
+++ b/docs/guides/LOAD_TEST_GUIDE.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Network Load Testing Guide
 
+> **SSOT**: This document is the single source of truth for **Network Load Testing Guide**.
+
 **Version**: 0.1.0.0
 **Last Updated**: 2025-10-26
 **Phase**: Phase 7 - Network Load Testing & Real Baseline Metrics

--- a/docs/guides/MIGRATION_UNIFIED_API.md
+++ b/docs/guides/MIGRATION_UNIFIED_API.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Migration Guide: Unified Interface API
 
+> **SSOT**: This document is the single source of truth for **Migration Guide: Unified Interface API**.
+
 This guide helps you migrate from the legacy protocol-specific interfaces (12+ interfaces) to the new unified interface API (3 core interfaces).
 
 ## Overview

--- a/docs/guides/QUICK_START.kr.md
+++ b/docs/guides/QUICK_START.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # 빠른 시작 가이드
 
+> **SSOT**: This document is the single source of truth for **빠른 시작 가이드**.
+
 > **Language:** [English](QUICK_START.md) | **한국어**
 
 Network System을 5분 만에 시작하세요.

--- a/docs/guides/QUICK_START.md
+++ b/docs/guides/QUICK_START.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Quick Start Guide
 
+> **SSOT**: This document is the single source of truth for **Quick Start Guide**.
+
 > **Language:** **English** | [한국어](QUICK_START.kr.md)
 
 Get up and running with Network System in 5 minutes.

--- a/docs/guides/TLS_SETUP_GUIDE.kr.md
+++ b/docs/guides/TLS_SETUP_GUIDE.kr.md
@@ -10,6 +10,8 @@ category: "SECU"
 
 # network_system을 위한 TLS/SSL 설정 가이드
 
+> **SSOT**: This document is the single source of truth for **network_system을 위한 TLS/SSL 설정 가이드**.
+
 > **Language:** [English](TLS_SETUP_GUIDE.md) | **한국어**
 
 ## 목차

--- a/docs/guides/TLS_SETUP_GUIDE.md
+++ b/docs/guides/TLS_SETUP_GUIDE.md
@@ -10,6 +10,8 @@ category: "SECU"
 
 # TLS/SSL Setup Guide for network_system
 
+> **SSOT**: This document is the single source of truth for **TLS/SSL Setup Guide for network_system**.
+
 > **Language:** **English** | [한국어](TLS_SETUP_GUIDE.kr.md)
 
 ## Table of Contents

--- a/docs/guides/TROUBLESHOOTING.kr.md
+++ b/docs/guides/TROUBLESHOOTING.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # 문제 해결 가이드
 
+> **SSOT**: This document is the single source of truth for **문제 해결 가이드**.
+
 > **Language:** [English](TROUBLESHOOTING.md) | **한국어**
 
 이 가이드는 Network System의 일반적인 문제, 디버깅 기법 및 문제 해결 전략에 대한 솔루션을 제공합니다.

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Troubleshooting Guide
 
+> **SSOT**: This document is the single source of truth for **Troubleshooting Guide**.
+
 > **Language:** **English** | [한국어](TROUBLESHOOTING.kr.md)
 
 This guide provides solutions for common issues, debugging techniques, and problem resolution strategies for the Network System.

--- a/docs/guides/UDP_SUPPORT.md
+++ b/docs/guides/UDP_SUPPORT.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # UDP Support in Network System
 
+> **SSOT**: This document is the single source of truth for **UDP Support in Network System**.
+
 This document describes the UDP protocol support added to the network_system library.
 
 ## Overview

--- a/docs/guides/tracing.md
+++ b/docs/guides/tracing.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # OpenTelemetry Tracing Guide
 
+> **SSOT**: This document is the single source of truth for **OpenTelemetry Tracing Guide**.
+
 This guide covers the OpenTelemetry-compatible distributed tracing support in network_system.
 
 ## Overview

--- a/docs/implementation/01-architecture-and-components.md
+++ b/docs/implementation/01-architecture-and-components.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Architecture & Components
 
+> **SSOT**: This document is the single source of truth for **Architecture & Components**.
+
 > **Part 1 of 4** | [📑 Index](README.md) | [Next: Dependency & Testing →](02-dependency-and-testing.md)
 
 > **Language:** **English** | [한국어](01-architecture-and-components.kr.md)

--- a/docs/implementation/02-dependency-and-testing.md
+++ b/docs/implementation/02-dependency-and-testing.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # Dependency & Testing
 
+> **SSOT**: This document is the single source of truth for **Dependency & Testing**.
+
 > **Part 2 of 4** | [📑 Index](README.md) | [← Previous: Architecture](01-architecture-and-components.md) | [Next: Performance →](03-performance-and-resources.md)
 
 > **Language:** **English** | [한국어](02-dependency-and-testing.kr.md)

--- a/docs/implementation/03-performance-and-resources.md
+++ b/docs/implementation/03-performance-and-resources.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Performance & Resources
 
+> **SSOT**: This document is the single source of truth for **Performance & Resources**.
+
 > **Part 3 of 4** | [📑 Index](README.md) | [← Previous: Testing](02-dependency-and-testing.md) | [Next: Error Handling →](04-error-handling.md)
 
 > **Language:** **English** | [한국어](03-performance-and-resources.kr.md)

--- a/docs/implementation/04-error-handling.md
+++ b/docs/implementation/04-error-handling.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Error Handling Strategy
 
+> **SSOT**: This document is the single source of truth for **Error Handling Strategy**.
+
 > **Part 4 of 4** | [📑 Index](README.md) | [← Previous: Performance](03-performance-and-resources.md)
 
 > **Language:** **English** | [한국어](04-error-handling.kr.md)

--- a/docs/implementation/README.md
+++ b/docs/implementation/README.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Network System Implementation Details
 
+> **SSOT**: This document is the single source of truth for **Network System Implementation Details**.
+
 > **Language:** **English** | [한국어](README.kr.md)
 
 This directory contains detailed technical implementation documentation for the network_system separation project.

--- a/docs/integration/README.md
+++ b/docs/integration/README.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Network System Integration Guide
 
+> **SSOT**: This document is the single source of truth for **Network System Integration Guide**.
+
 ## Overview
 
 This directory contains integration guides for using network_system with other KCENON systems and components.

--- a/docs/integration/with-common-system.md
+++ b/docs/integration/with-common-system.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # Integrating Common System with Network System
 
+> **SSOT**: This document is the single source of truth for **Integrating Common System with Network System**.
+
 ## Overview
 
 The network system depends on common_system for:

--- a/docs/integration/with-logger.md
+++ b/docs/integration/with-logger.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # Integrating Logger System with Network System
 
+> **SSOT**: This document is the single source of truth for **Integrating Logger System with Network System**.
+
 ## Overview
 
 The network system provides unified logging through common_system's ILogger interface and

--- a/docs/integration/with-monitoring.md
+++ b/docs/integration/with-monitoring.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # Network System Integration with Monitoring System
 
+> **SSOT**: This document is the single source of truth for **Network System Integration with Monitoring System**.
+
 ## Overview
 
 This guide explains how network_system publishes metrics that can be consumed by monitoring_system or other metric collectors.

--- a/docs/migration/adapter_to_bridge_migration.md
+++ b/docs/migration/adapter_to_bridge_migration.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Migration Guide: From Adapters to NetworkSystemBridge
 
+> **SSOT**: This document is the single source of truth for **Migration Guide: From Adapters to NetworkSystemBridge**.
+
 ## Overview
 
 This guide helps you migrate from the deprecated adapter classes to the new `NetworkSystemBridge` facade pattern. The new bridge pattern provides a unified, simplified interface for all external system integrations.

--- a/docs/migration/network_system_bridge.md
+++ b/docs/migration/network_system_bridge.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # NetworkSystemBridge Migration Guide
 
+> **SSOT**: This document is the single source of truth for **NetworkSystemBridge Migration Guide**.
+
 ## Overview
 
 This guide explains how to migrate from individual integration adapters to the unified `NetworkSystemBridge` facade.

--- a/docs/performance/BASELINE.kr.md
+++ b/docs/performance/BASELINE.kr.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Network System - 성능 기준 메트릭
 
+> **SSOT**: This document is the single source of truth for **Network System - 성능 기준 메트릭**.
+
 [English](BASELINE.md) | **한국어**
 
 **버전**: development (matches `VERSION`)

--- a/docs/performance/BASELINE.md
+++ b/docs/performance/BASELINE.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Network System - Performance Baseline Metrics
 
+> **SSOT**: This document is the single source of truth for **Network System - Performance Baseline Metrics**.
+
 **English** | [한국어](BASELINE.kr.md)
 
 **Version**: development (matches `VERSION`)

--- a/docs/protocols/quic/API_REFERENCE.md
+++ b/docs/protocols/quic/API_REFERENCE.md
@@ -10,6 +10,8 @@ category: "API"
 
 # QUIC API Reference
 
+> **SSOT**: This document is the single source of truth for **QUIC API Reference**.
+
 ## Namespace
 
 ```cpp

--- a/docs/protocols/quic/ARCHITECTURE.md
+++ b/docs/protocols/quic/ARCHITECTURE.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # QUIC Implementation Architecture
 
+> **SSOT**: This document is the single source of truth for **QUIC Implementation Architecture**.
+
 ## Layer Structure
 
 The QUIC implementation follows a layered architecture consistent with the existing network_system design. The public API classes use the composition-based pattern with interfaces and utility classes for lifecycle management.

--- a/docs/protocols/quic/CONFIGURATION.md
+++ b/docs/protocols/quic/CONFIGURATION.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # QUIC Configuration Guide
 
+> **SSOT**: This document is the single source of truth for **QUIC Configuration Guide**.
+
 ## Build Configuration
 
 ### Enabling QUIC Support

--- a/docs/protocols/quic/EXAMPLES.md
+++ b/docs/protocols/quic/EXAMPLES.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # QUIC Examples
 
+> **SSOT**: This document is the single source of truth for **QUIC Examples**.
+
 ## Basic Echo Server and Client
 
 ### Echo Server

--- a/docs/protocols/quic/README.md
+++ b/docs/protocols/quic/README.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # QUIC Protocol Support
 
+> **SSOT**: This document is the single source of truth for **QUIC Protocol Support**.
+
 ## Overview
 
 network_system provides native QUIC protocol support implementing RFC 9000, RFC 9001, and RFC 9002. The implementation follows the same design philosophy as other protocols in the library: direct RFC implementation with minimal external dependencies.

--- a/docs/refactoring/HEADER_AUDIT_PHASE1.md
+++ b/docs/refactoring/HEADER_AUDIT_PHASE1.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Header Audit - Phase 1: Preparation for Internal Migration
 
+> **SSOT**: This document is the single source of truth for **Header Audit - Phase 1: Preparation for Internal Migration**.
+
 > **Issue**: #610
 > **Epic**: #577
 > **Date**: 2026-02-02

--- a/docs/refactoring/MIGRATION_GUIDE_V2.md
+++ b/docs/refactoring/MIGRATION_GUIDE_V2.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Migration Guide: network_system v1.x → v2.0
 
+> **SSOT**: This document is the single source of truth for **Migration Guide: network_system v1.x → v2.0**.
+
 > **Version**: 0.2.0.0
 > **Issue**: #610 (Part of Epic #577)
 > **Breaking Changes**: Yes - Core implementation headers moved to internal

--- a/docs/refactoring/README.md
+++ b/docs/refactoring/README.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Refactoring Documentation
 
+> **SSOT**: This document is the single source of truth for **Refactoring Documentation**.
+
 > **Epic**: #577 - Apply Facade pattern to reduce protocol header complexity
 > **Issue**: #610 - Move protocol implementation headers to internal
 > **Goal**: Reduce public headers from 153 to < 40


### PR DESCRIPTION
## Summary

- Create `docs/README.md` as the single source of truth documentation index for network_system
- Add SSOT declarations (`> **SSOT**: ...`) to each authoritative document header
- Registry table lists all 75 documents with doc_id, topic, authority document link, and status
- Documents grouped by category (Architecture, API, Features, Guides, etc.)
- Verified no duplicate doc_id values and all file links are valid

## Test Plan

- [x] All 75 document entries have valid file links
- [x] No duplicate doc_id values within the project
- [x] SSOT declarations added to authoritative documents
- [x] Registry follows the format specified in kcenon/common_system#563

Closes kcenon/common_system#563