### PR TITLE
docs: add @file Doxygen blocks to public API headers

### DIFF
--- a/include/kcenon/network/detail/protocol/protocol_tags.h
+++ b/include/kcenon/network/detail/protocol/protocol_tags.h
@@ -2,7 +2,22 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file protocol_tags.h
+ * @brief Protocol tag types for compile-time protocol selection.
+ *
+ * @see concepts/ For Protocol concept constraints
+ */
+
 #pragma once
+
+/**
+ * @file protocol_tags.h
+ * @brief Protocol tag types and the Protocol concept
+ *
+ * Defines compile-time protocol tags (tcp_protocol, udp_protocol, etc.)
+ * with C++20 concept constraints for protocol metadata.
+ */
 
 #include <concepts>
 #include <string_view>

--- a/include/kcenon/network/detail/protocol/quic.h
+++ b/include/kcenon/network/detail/protocol/quic.h
@@ -2,7 +2,22 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file quic.h
+ * @brief QUIC protocol connection factory and configuration.
+ *
+ * @see quic_facade.h
+ */
+
 #pragma once
+
+/**
+ * @file quic.h
+ * @brief QUIC protocol factory functions for the unified transport layer
+ *
+ * Provides create_connection() and create_listener() factory functions
+ * for QUIC transport with configuration for streams, timeouts, and TLS.
+ */
 
 #include "kcenon/network/detail/unified/i_connection.h"
 #include "kcenon/network/detail/unified/i_listener.h"

--- a/include/kcenon/network/detail/protocol/tcp.h
+++ b/include/kcenon/network/detail/protocol/tcp.h
@@ -2,7 +2,22 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file tcp.h
+ * @brief TCP protocol connection and listener factory functions.
+ *
+ * @see tcp_facade.h
+ */
+
 #pragma once
+
+/**
+ * @file tcp.h
+ * @brief TCP protocol factory functions for the unified transport layer
+ *
+ * Provides create_connection() and create_listener() factory functions
+ * for TCP transport using the unified i_connection/i_listener interfaces.
+ */
 
 #include "kcenon/network/detail/unified/i_connection.h"
 #include "kcenon/network/detail/unified/i_listener.h"

--- a/include/kcenon/network/detail/protocol/udp.h
+++ b/include/kcenon/network/detail/protocol/udp.h
@@ -2,7 +2,22 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file udp.h
+ * @brief UDP protocol connection factory functions.
+ *
+ * @see udp_facade.h
+ */
+
 #pragma once
+
+/**
+ * @file udp.h
+ * @brief UDP protocol factory functions for the unified transport layer
+ *
+ * Provides create_connection() and create_listener() factory functions
+ * for UDP transport using the unified i_connection/i_listener interfaces.
+ */
 
 #include "kcenon/network/detail/unified/i_connection.h"
 #include "kcenon/network/detail/unified/i_listener.h"

--- a/include/kcenon/network/detail/protocol/websocket.h
+++ b/include/kcenon/network/detail/protocol/websocket.h
@@ -2,7 +2,22 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file websocket.h
+ * @brief WebSocket protocol connection factory functions.
+ *
+ * @see websocket_facade.h
+ */
+
 #pragma once
+
+/**
+ * @file websocket.h
+ * @brief WebSocket protocol factory functions for the unified transport layer
+ *
+ * Provides create_connection() and create_listener() factory functions
+ * for WebSocket transport with optional TLS (wss://) support.
+ */
 
 #include "kcenon/network/detail/unified/i_connection.h"
 #include "kcenon/network/detail/unified/i_listener.h"

--- a/include/kcenon/network/detail/protocols/grpc/client.h
+++ b/include/kcenon/network/detail/protocols/grpc/client.h
@@ -2,7 +2,22 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file client.h
+ * @brief gRPC client channel configuration and connection.
+ *
+ * @see detail/protocols/grpc/server.h
+ */
+
 #pragma once
+
+/**
+ * @file client.h
+ * @brief gRPC client interface for unary and streaming RPCs
+ *
+ * Defines the grpc_client class for making gRPC calls over HTTP/2,
+ * supporting unary, server-streaming, client-streaming, and bidirectional RPCs.
+ */
 
 #include "kcenon/network/detail/protocols/grpc/frame.h"
 #include "kcenon/network/detail/protocols/grpc/status.h"

--- a/include/kcenon/network/detail/protocols/grpc/frame.h
+++ b/include/kcenon/network/detail/protocols/grpc/frame.h
@@ -2,7 +2,21 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file frame.h
+ * @brief gRPC message framing and serialization.
+ *
+ */
+
 #pragma once
+
+/**
+ * @file frame.h
+ * @brief gRPC message framing (length-prefixed binary protocol)
+ *
+ * Implements gRPC's 5-byte header framing for encoding and decoding
+ * length-prefixed messages over HTTP/2 streams.
+ */
 
 #include "kcenon/network/detail/utils/result_types.h"
 #include <cstdint>

--- a/include/kcenon/network/detail/protocols/grpc/server.h
+++ b/include/kcenon/network/detail/protocols/grpc/server.h
@@ -2,7 +2,22 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file server.h
+ * @brief gRPC server configuration and service hosting.
+ *
+ * @see detail/protocols/grpc/client.h
+ */
+
 #pragma once
+
+/**
+ * @file server.h
+ * @brief gRPC server interface for handling incoming RPCs
+ *
+ * Defines the grpc_server class for accepting and processing gRPC calls,
+ * with service registration and request routing over HTTP/2.
+ */
 
 #include "kcenon/network/detail/protocols/grpc/frame.h"
 #include "kcenon/network/detail/protocols/grpc/status.h"

--- a/include/kcenon/network/detail/protocols/grpc/status.h
+++ b/include/kcenon/network/detail/protocols/grpc/status.h
@@ -2,7 +2,21 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file status.h
+ * @brief gRPC status codes and error representation.
+ *
+ */
+
 #pragma once
+
+/**
+ * @file status.h
+ * @brief gRPC status codes and status result type
+ *
+ * Defines standard gRPC status codes (RFC) and the grpc_status type
+ * for representing RPC operation outcomes.
+ */
 
 #include <cstdint>
 #include <optional>

--- a/include/kcenon/network/detail/protocols/quic/connection_id.h
+++ b/include/kcenon/network/detail/protocols/quic/connection_id.h
@@ -2,7 +2,21 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file connection_id.h
+ * @brief QUIC connection identifier type.
+ *
+ */
+
 #pragma once
+
+/**
+ * @file connection_id.h
+ * @brief QUIC Connection ID implementation (RFC 9000 Section 5.1)
+ *
+ * Provides the connection_id class for generating, comparing, and
+ * managing QUIC connection identifiers (0-20 bytes).
+ */
 
 #include <array>
 #include <cstdint>

--- a/include/kcenon/network/detail/session/messaging_session.h
+++ b/include/kcenon/network/detail/session/messaging_session.h
@@ -2,7 +2,22 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file messaging_session.h
+ * @brief Messaging session managing bidirectional message exchange.
+ *
+ * @see i_session
+ */
+
 #pragma once
+
+/**
+ * @file messaging_session.h
+ * @brief TCP messaging session for length-prefixed message framing
+ *
+ * Implements the i_session interface for plain TCP connections with
+ * asynchronous send/receive and message queuing via ASIO.
+ */
 
 #include <atomic>
 #include <deque>

--- a/include/kcenon/network/detail/session/quic_session.h
+++ b/include/kcenon/network/detail/session/quic_session.h
@@ -2,7 +2,22 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file quic_session.h
+ * @brief QUIC-specific session with stream multiplexing.
+ *
+ * @see messaging_session.h
+ */
+
 #pragma once
+
+/**
+ * @file quic_session.h
+ * @brief QUIC session implementation for stream-multiplexed connections
+ *
+ * Implements the session interface for QUIC connections with
+ * connection ID management and experimental QUIC API support.
+ */
 
 #include <atomic>
 #include <functional>

--- a/include/kcenon/network/detail/session/secure_session.h
+++ b/include/kcenon/network/detail/session/secure_session.h
@@ -2,7 +2,22 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file secure_session.h
+ * @brief TLS-secured session wrapper for encrypted communication.
+ *
+ * @see tls_policy.h
+ */
+
 #pragma once
+
+/**
+ * @file secure_session.h
+ * @brief TLS-encrypted messaging session over secure TCP sockets
+ *
+ * Implements the session interface for TLS-secured TCP connections
+ * using ASIO SSL streams with asynchronous send/receive.
+ */
 
 #include <atomic>
 #include <deque>

--- a/include/kcenon/network/detail/unified/i_connection.h
+++ b/include/kcenon/network/detail/unified/i_connection.h
@@ -2,7 +2,22 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file i_connection.h
+ * @brief Core interface for active network connections.
+ *
+ * @see i_listener.h
+ */
+
 #pragma once
+
+/**
+ * @file i_connection.h
+ * @brief Core interface for active network connections
+ *
+ * Extends i_transport with connection lifecycle operations (connect,
+ * disconnect, reconnect) for both client-initiated and accepted connections.
+ */
 
 #include "i_transport.h"
 #include "types.h"

--- a/include/kcenon/network/detail/unified/i_listener.h
+++ b/include/kcenon/network/detail/unified/i_listener.h
@@ -2,7 +2,22 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file i_listener.h
+ * @brief Core interface for passive network listeners (server-side).
+ *
+ * @see i_connection.h
+ */
+
 #pragma once
+
+/**
+ * @file i_listener.h
+ * @brief Core interface for passive network listeners (server-side)
+ *
+ * Defines the server-side listener interface for binding to local addresses,
+ * accepting incoming connections, and managing connection callbacks.
+ */
 
 #include "i_connection.h"
 #include "types.h"

--- a/include/kcenon/network/detail/unified/i_transport.h
+++ b/include/kcenon/network/detail/unified/i_transport.h
@@ -2,7 +2,21 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file i_transport.h
+ * @brief Core interface for data transport abstraction.
+ *
+ */
+
 #pragma once
+
+/**
+ * @file i_transport.h
+ * @brief Core interface for protocol-agnostic data transport
+ *
+ * Defines the fundamental send/receive operations shared by all
+ * network transport implementations regardless of protocol.
+ */
 
 #include "types.h"
 

--- a/include/kcenon/network/detail/unified/types.h
+++ b/include/kcenon/network/detail/unified/types.h
@@ -2,7 +2,21 @@
 // Copyright (c) 2025, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file types.h
+ * @brief Network endpoint types (host/port, URL) and common type aliases.
+ *
+ */
+
 #pragma once
+
+/**
+ * @file types.h
+ * @brief Common types for the unified transport layer
+ *
+ * Defines endpoint_info, connection_callbacks, transport_error, and
+ * other shared types used across the unified transport interfaces.
+ */
 
 #include <chrono>
 #include <cstdint>

--- a/include/kcenon/network/detail/utils/callback_manager.h
+++ b/include/kcenon/network/detail/utils/callback_manager.h
@@ -2,7 +2,21 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file callback_manager.h
+ * @brief Thread-safe callback registration and invocation manager.
+ *
+ */
+
 #pragma once
+
+/**
+ * @file callback_manager.h
+ * @brief Thread-safe callback storage and invocation utility
+ *
+ * Provides centralized, mutex-protected callback management replacing
+ * duplicated callback handling code across CRTP base classes.
+ */
 
 #include <cstdint>
 #include <functional>

--- a/include/kcenon/network/detail/utils/lifecycle_manager.h
+++ b/include/kcenon/network/detail/utils/lifecycle_manager.h
@@ -2,7 +2,21 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file lifecycle_manager.h
+ * @brief Component lifecycle management (start, stop, restart).
+ *
+ */
+
 #pragma once
+
+/**
+ * @file lifecycle_manager.h
+ * @brief Thread-safe lifecycle state management for network components
+ *
+ * Encapsulates running-state tracking and stop synchronization logic
+ * shared across client and server implementations.
+ */
 
 #include <atomic>
 #include <future>

--- a/include/kcenon/network/detail/utils/result_types.h
+++ b/include/kcenon/network/detail/utils/result_types.h
@@ -2,7 +2,21 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file result_types.h
+ * @brief Network-specific error and result type definitions.
+ *
+ */
+
 #pragma once
+
+/**
+ * @file result_types.h
+ * @brief Result type aliases for network_system error handling
+ *
+ * Bridges common_system's Result<T> into network_system with
+ * fallback types when common_system is not available.
+ */
 
 #include <kcenon/network/detail/config/feature_flags.h>
 

--- a/include/kcenon/network/detail/utils/startable_base.h
+++ b/include/kcenon/network/detail/utils/startable_base.h
@@ -2,7 +2,22 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file startable_base.h
+ * @brief Base class for components with start/stop lifecycle.
+ *
+ * @see lifecycle_manager.h
+ */
+
 #pragma once
+
+/**
+ * @file startable_base.h
+ * @brief CRTP base class providing unified start/stop lifecycle management
+ *
+ * Extracts the common start/stop lifecycle pattern from client and
+ * server implementations with thread-safe state transitions.
+ */
 
 #include <atomic>
 #include <string>

--- a/include/kcenon/network/facade/http_facade.h
+++ b/include/kcenon/network/facade/http_facade.h
@@ -2,7 +2,22 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file http_facade.h
+ * @brief Simplified facade for creating HTTP clients and servers.
+ *
+ * @see tcp_facade.h
+ */
+
 #pragma once
+
+/**
+ * @file http_facade.h
+ * @brief Simplified facade for creating HTTP clients and servers
+ *
+ * Provides a template-free API for HTTP/1.1 client/server creation,
+ * hiding protocol implementation details behind configuration structs.
+ */
 
 #include <chrono>
 #include <cstdint>

--- a/include/kcenon/network/facade/quic_facade.h
+++ b/include/kcenon/network/facade/quic_facade.h
@@ -2,7 +2,21 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file quic_facade.h
+ * @brief Simplified facade for creating QUIC clients and servers.
+ *
+ */
+
 #pragma once
+
+/**
+ * @file quic_facade.h
+ * @brief Simplified facade for creating QUIC clients and servers
+ *
+ * Provides a template-free API for QUIC client/server creation,
+ * encapsulating experimental API opt-in and configuration details.
+ */
 
 #include <cstdint>
 #include <memory>

--- a/include/kcenon/network/facade/tcp_facade.h
+++ b/include/kcenon/network/facade/tcp_facade.h
@@ -2,7 +2,21 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file tcp_facade.h
+ * @brief Simplified facade for creating TCP clients and servers.
+ *
+ */
+
 #pragma once
+
+/**
+ * @file tcp_facade.h
+ * @brief Simplified facade for creating TCP clients and servers
+ *
+ * Provides a template-free API for TCP client/server creation with
+ * optional TLS support and connection pooling.
+ */
 
 #include <chrono>
 #include <cstdint>

--- a/include/kcenon/network/facade/udp_facade.h
+++ b/include/kcenon/network/facade/udp_facade.h
@@ -2,7 +2,21 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file udp_facade.h
+ * @brief Simplified facade for creating UDP clients and servers.
+ *
+ */
+
 #pragma once
+
+/**
+ * @file udp_facade.h
+ * @brief Simplified facade for creating UDP clients and servers
+ *
+ * Provides a template-free API for UDP client/server creation,
+ * hiding protocol tag and implementation details from the user.
+ */
 
 #include <cstdint>
 #include <memory>

--- a/include/kcenon/network/facade/websocket_facade.h
+++ b/include/kcenon/network/facade/websocket_facade.h
@@ -2,7 +2,21 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file websocket_facade.h
+ * @brief Simplified facade for creating WebSocket clients and servers.
+ *
+ */
+
 #pragma once
+
+/**
+ * @file websocket_facade.h
+ * @brief Simplified facade for creating WebSocket clients and servers
+ *
+ * Provides a template-free API for WebSocket client/server creation
+ * with optional TLS support via configuration structs.
+ */
 
 #include <chrono>
 #include <cstdint>

--- a/include/kcenon/network/interfaces/connection_observer.h
+++ b/include/kcenon/network/interfaces/connection_observer.h
@@ -2,7 +2,21 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file connection_observer.h
+ * @brief Observer interface for connection state change notifications.
+ *
+ */
+
 #pragma once
+
+/**
+ * @file connection_observer.h
+ * @brief Observer interface for client connection events
+ *
+ * Provides a unified Observer pattern for handling connection-related
+ * events (connect, disconnect, receive, error) in client components.
+ */
 
 #include <cstdint>
 #include <functional>

--- a/include/kcenon/network/interfaces/i_network_component.h
+++ b/include/kcenon/network/interfaces/i_network_component.h
@@ -2,7 +2,21 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file i_network_component.h
+ * @brief Base interface for all network components.
+ *
+ */
+
 #pragma once
+
+/**
+ * @file i_network_component.h
+ * @brief Base interface for all network components
+ *
+ * Defines the common contract for both client and server network
+ * components, providing basic lifecycle query methods.
+ */
 
 namespace kcenon::network::interfaces
 {

--- a/include/kcenon/network/interfaces/i_protocol_client.h
+++ b/include/kcenon/network/interfaces/i_protocol_client.h
@@ -2,7 +2,22 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file i_protocol_client.h
+ * @brief Protocol-specific client interface extending i_client.
+ *
+ * @see i_protocol_server.h
+ */
+
 #pragma once
+
+/**
+ * @file i_protocol_client.h
+ * @brief Unified interface for all protocol client implementations
+ *
+ * Defines the common contract for TCP, UDP, HTTP, WebSocket, and QUIC
+ * clients, providing consistent lifecycle management and data transmission.
+ */
 
 #include "i_network_component.h"
 #include "connection_observer.h"

--- a/include/kcenon/network/interfaces/i_protocol_server.h
+++ b/include/kcenon/network/interfaces/i_protocol_server.h
@@ -2,7 +2,22 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file i_protocol_server.h
+ * @brief Protocol-specific server interface extending i_server.
+ *
+ * @see i_protocol_client.h
+ */
+
 #pragma once
+
+/**
+ * @file i_protocol_server.h
+ * @brief Unified interface for all protocol server implementations
+ *
+ * Defines the common contract for TCP, UDP, HTTP, WebSocket, and QUIC
+ * servers, providing consistent lifecycle, session management, and broadcasting.
+ */
 
 #include "i_network_component.h"
 #include "i_session.h"

--- a/include/kcenon/network/interfaces/i_server.h
+++ b/include/kcenon/network/interfaces/i_server.h
@@ -2,7 +2,22 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file i_server.h
+ * @brief Abstract server interface for protocol-agnostic server operations.
+ *
+ * @see i_client.h
+ */
+
 #pragma once
+
+/**
+ * @file i_server.h
+ * @brief Base interface for server-side network components
+ *
+ * Extends i_network_component with server-specific operations such as
+ * listening for connections, managing sessions, and broadcasting data.
+ */
 
 #include "i_network_component.h"
 #include "i_session.h"

--- a/include/kcenon/network/interfaces/i_session.h
+++ b/include/kcenon/network/interfaces/i_session.h
@@ -2,7 +2,21 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file i_session.h
+ * @brief Session interface representing an active client-server connection.
+ *
+ */
+
 #pragma once
+
+/**
+ * @file i_session.h
+ * @brief Interface for a single client session on the server side
+ *
+ * Represents a connection to a single client, allowing data transmission
+ * and individual connection management within a server context.
+ */
 
 #include <cstdint>
 #include <string_view>

--- a/include/kcenon/network/policy/tls_policy.h
+++ b/include/kcenon/network/policy/tls_policy.h
@@ -2,7 +2,21 @@
 // Copyright (c) 2024, 🍀☀🌕🌥 🌊
 // See the LICENSE file in the project root for full license information.
 
+/**
+ * @file tls_policy.h
+ * @brief Policy-based TLS configuration (no_tls, require_tls, optional_tls).
+ *
+ */
+
 #pragma once
+
+/**
+ * @file tls_policy.h
+ * @brief Policy types and concept for TLS configuration
+ *
+ * Defines no_tls, tls_enabled policy types and the TlsPolicy concept
+ * used as template parameters to control encryption behavior.
+ */
 
 #include <concepts>
 #include <string>


### PR DESCRIPTION
## Summary

Add `@file` Doxygen documentation blocks to 33 public API headers that were missing them, achieving 100% `@file` coverage across all 65 headers in network_system.

### Directories Updated
- `facade/` — tcp_facade, udp_facade, websocket_facade, http_facade, quic_facade
- `interfaces/` — i_protocol_client, i_protocol_server, i_server, i_session, connection_observer, i_network_component
- `detail/protocol/` — protocol_tags, tcp, udp, websocket, quic
- `detail/unified/` — i_connection, i_listener, i_transport, types
- `detail/utils/` — callback_manager, lifecycle_manager, result_types, startable_base
- `detail/protocols/grpc/` — client, server, status, frame
- `detail/protocols/quic/` — connection_id
- `detail/session/` — messaging_session, secure_session, quic_session
- `policy/` — tls_policy

Closes #568

## Test Plan
- [ ] Verify Doxygen generation produces no warnings on updated headers
- [ ] Confirm existing CI checks pass