### PR TITLE
docs: fix traceability matrix doc_id collision with production quality

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -82,7 +82,7 @@ Total documents: **78**
 | 61 | NET-INTR-006 | NetworkSystemBridge Migration Guide | [network_system_bridge.md](./migration/network_system_bridge.md) | Released |
 | 62 | NET-QUAL-001 | Network System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
 | 63 | NET-QUAL-002 | Network System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
-| 64 | NET-QUAL-002 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
+| 64 | NET-QUAL-005 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
 | 65 | NET-QUAL-003 | Static Analysis Guide | [STATIC_ANALYSIS.md](./advanced/STATIC_ANALYSIS.md) | Released |
 | 66 | NET-QUAL-004 | Dependency & Testing | [02-dependency-and-testing.md](./implementation/02-dependency-and-testing.md) | Released |
 | 67 | NET-SECU-001 | network_system을 위한 TLS/SSL 설정 가이드 | [TLS_SETUP_GUIDE.kr.md](./guides/TLS_SETUP_GUIDE.kr.md) | Released |
@@ -202,7 +202,7 @@ Total documents: **78**
 |--------|-------|----------|--------|
 | NET-QUAL-001 | Network System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
 | NET-QUAL-002 | Network System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
-| NET-QUAL-002 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
+| NET-QUAL-005 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
 | NET-QUAL-003 | Static Analysis Guide | [STATIC_ANALYSIS.md](./advanced/STATIC_ANALYSIS.md) | Released |
 | NET-QUAL-004 | Dependency & Testing | [02-dependency-and-testing.md](./implementation/02-dependency-and-testing.md) | Released |
 

--- a/docs/TRACEABILITY.md
+++ b/docs/TRACEABILITY.md
@@ -1,5 +1,5 @@
 ---
-doc_id: "NET-QUAL-002"
+doc_id: "NET-QUAL-005"
 doc_title: "Feature-Test-Module Traceability Matrix"
 doc_version: "1.0.0"
 doc_date: "2026-04-04"


### PR DESCRIPTION
## Summary

- Fix doc_id collision: `TRACEABILITY.md` and `PRODUCTION_QUALITY.md` both used `NET-QUAL-002`
- Assign unique `NET-QUAL-005` to `TRACEABILITY.md` (next available QUAL number)
- Update SSOT registry (`docs/README.md`) to reflect the corrected doc_id

Related to kcenon/common_system#566

## What

The traceability matrix document (`docs/TRACEABILITY.md`) was sharing `NET-QUAL-002` with `PRODUCTION_QUALITY.md`. Each document in the SSOT registry must have a unique `doc_id`. This PR assigns `NET-QUAL-005` to the traceability matrix.

## How

- Updated `doc_id` in `docs/TRACEABILITY.md` YAML frontmatter from `NET-QUAL-002` to `NET-QUAL-005`
- Updated both entries in `docs/README.md` (numbered table and category index)

## Test Plan

- [x] Verify `NET-QUAL-005` is not used by any other document
- [x] Verify TRACEABILITY.md YAML frontmatter matches README.md registry entry
- [x] Verify all feature-test mappings are accurate (test files exist)
- [x] Verify coverage summary totals match actual feature count (97)