### PR TITLE
docs(tutorials): add tutorials, FAQ and troubleshooting guide

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -129,6 +129,11 @@ INPUT                  = include \
                          src \
                          README.md \
                          ./docs/mainpage.dox \
+                         ./docs/tutorial_tcp.dox \
+                         ./docs/tutorial_websocket.dox \
+                         ./docs/tutorial_protocols.dox \
+                         ./docs/faq.dox \
+                         ./docs/troubleshooting.dox \
                          ./examples
 INPUT_ENCODING         = UTF-8
 INPUT_FILTER           =

--- a/docs/faq.dox
+++ b/docs/faq.dox
@@ -1,0 +1,201 @@
+/**
+@page faq Frequently Asked Questions
+
+@tableofcontents
+
+This page collects the most common questions developers ask when integrating
+Network System into their projects. For deeper coverage see the tutorials
+listed under @ref tutorial_protocols and the @ref troubleshooting guide.
+
+@section faq_drops 1. How do I handle connection drops?
+
+The facade interfaces report drops through the `disconnected` callback on
+clients and the `disconnection` callback on servers. To recover, register a
+callback that schedules a retry with exponential backoff:
+
+@code{.cpp}
+client->set_disconnected_callback([&] {
+    auto delay = next_backoff();
+    std::thread([client, delay] {
+        std::this_thread::sleep_for(delay);
+        client->start("server.example.com", 9000);
+    }).detach();
+});
+@endcode
+
+Always cap the backoff (for example, 30 seconds) and add jitter so a
+restarted server is not flooded by reconnecting clients. The
+`is_connected()` accessor lets you avoid duplicate reconnect attempts when
+multiple events fire concurrently.
+
+@section faq_tls 2. How do I configure TLS / SSL?
+
+The TCP facade enables TLS via the `use_ssl` flag plus optional certificate
+paths.
+
+@code{.cpp}
+auto secure_client = tcp.create_client({
+    .host = "example.com",
+    .port = 8443,
+    .use_ssl = true,
+    .ca_cert_path = "/etc/ssl/ca-bundle.crt",
+    .verify_certificate = true,
+});
+
+auto secure_server = tcp.create_server({
+    .port = 8443,
+    .use_ssl = true,
+    .cert_path = "/etc/ssl/server.crt",
+    .key_path = "/etc/ssl/server.key",
+});
+@endcode
+
+Important notes:
+
+- TLS support requires OpenSSL 3.x at build time. OpenSSL 1.1.1 is allowed
+  but emits a build-time warning because it is end-of-life upstream.
+- Setting `verify_certificate = false` disables certificate verification.
+  Only use it for development against self-signed certificates.
+- For mutual TLS or custom cipher policies, use the unified templates layer
+  (`unified_messaging_client<protocol::tcp_protocol, tls_policy>`) directly.
+
+@section faq_concurrency 3. What is the maximum number of concurrent connections?
+
+Network System imposes no hard cap. Practical limits come from the operating
+system file-descriptor budget and the thread pool size you configure on
+`thread_system`. On Linux raise the limit with `ulimit -n` (or
+`LimitNOFILE` in systemd units). The library has been tested with tens of
+thousands of concurrent TCP connections per process.
+
+If you expect very high fan-out, prefer the unified templates with a
+dedicated thread pool sized to match your CPU core count and use the
+connection pool API to amortise socket creation.
+
+@section faq_container 4. How does Network System integrate with container_system?
+
+`container_system` provides serialisation primitives that pair naturally with
+`network_system`. Enable the optional dependency at build time
+(`BUILD_WITH_CONTAINER_SYSTEM=ON`, the default), then serialise your
+container into a byte vector and hand it to `client->send(...)`:
+
+@code{.cpp}
+auto bytes = container.serialize();      // container_system API
+client->send(std::move(bytes));
+@endcode
+
+On the receiving side reconstruct the container in the receive callback:
+
+@code{.cpp}
+client->set_receive_callback([&](const std::vector<uint8_t>& data) {
+    auto container = container_system::value_container::deserialize(data);
+    handle(container);
+});
+@endcode
+
+The bridge in `BUILD_MESSAGING_BRIDGE` glues `messaging_system` to this
+serialisation flow when both libraries are linked.
+
+@section faq_threads 5. What is the threading model?
+
+Each facade uses an ASIO `io_context` driven by a worker thread pool. By
+default the pool follows `thread_system`'s configuration; you can also
+attach a custom pool through the unified templates layer.
+
+Key invariants:
+
+- All callbacks (connect, receive, error, etc.) run on IO worker threads,
+  not on the thread that called `start()`.
+- Multiple callbacks for the same session are serialised; you do not need
+  to synchronise access to per-session state inside a callback.
+- Callbacks for different sessions can run concurrently. Protect any shared
+  state (such as a session map) with a mutex.
+
+@section faq_buffers 6. How do I tune buffer sizes?
+
+Most applications never need to touch buffer sizes; the defaults are tuned
+for high throughput. When you do need to override them:
+
+- TCP socket buffers can be set via the underlying `messaging_client` /
+  `messaging_server` constructors. The facade exposes only the most common
+  knobs; drop down to the unified templates for the full set.
+- Application-level batching (sending many small messages as a single
+  payload) is usually a bigger win than tuning kernel buffers.
+- For UDP, keep payloads under the path MTU (about 1200 bytes for IPv6) to
+  avoid fragmentation, which silently drops packets at many routers.
+
+@section faq_protocol_choice 7. How do I pick the right protocol?
+
+Use this short checklist:
+
+1. Will a browser ever talk to the server? Use **WebSocket**.
+2. Do you need low latency and can tolerate loss? Use **UDP**.
+3. Do you need a guaranteed in-order byte stream? Use **TCP**.
+4. Do you need HTTP semantics (headers, methods)? Use **HTTP/2** via
+   `http_facade`.
+5. Do you need multiplexed streams without head-of-line blocking? Use
+   **QUIC** via `quic_facade`.
+
+A more detailed comparison lives in @ref tutorial_protocols.
+
+@section faq_perf 8. How do I tune performance?
+
+Several actionable steps:
+
+- Build in `Release` mode (`cmake --preset release`) to enable
+  optimisations and disable assertions.
+- Reuse connections through `tcp_facade::create_connection_pool` instead of
+  reconnecting per request.
+- Run the `network_system` benchmarks (`NETWORK_BUILD_BENCHMARKS=ON`) to
+  baseline your machine.
+- Batch small messages into a single `send` call. The TCP layer will not
+  combine writes for you.
+- Pin the worker threads to cores when running on dedicated hardware.
+
+For deeper analysis enable the EventBus metrics and forward them to
+`monitoring_system`. The metrics expose connection counts, bytes per
+second, and pipeline timings.
+
+@section faq_recovery 9. How do I recover from errors safely?
+
+Every facade method returns either a `Result<T>` or invokes the error
+callback. The recovery checklist is:
+
+1. Inspect `result.is_err()` before assuming a send or receive succeeded.
+2. Log `result.error().message` (or the `std::error_code` from the error
+   callback).
+3. Decide whether the error is transient (timeout, connection reset) or
+   terminal (invalid configuration, unsupported feature).
+4. For transient errors, schedule a retry with backoff. For terminal
+   errors, surface the failure to the application layer and stop the
+   client/server.
+
+Avoid swallowing errors silently; the network is the most common source of
+runtime failures in distributed systems.
+
+@section faq_testing 10. How do I test code that uses Network System?
+
+Three patterns work well:
+
+- **Loopback integration tests.** Spin up a server and a client on
+  `127.0.0.1` inside the test. The library is fast enough that thousands
+  of round trips fit in milliseconds. The `examples/` directory shows the
+  pattern.
+- **Mocking the interfaces.** Code that depends on `i_protocol_client` or
+  `i_protocol_server` can be tested with a hand-written mock that records
+  calls and triggers callbacks synchronously.
+- **Sanitizer-enabled CI.** Network System ships ASAN, TSAN, and UBSAN
+  build presets. Run them periodically on integration tests to catch race
+  conditions and use-after-free bugs early.
+
+For long-running soak testing the project provides Google Benchmark suites
+(`NETWORK_BUILD_BENCHMARKS=ON`) and load tests
+(`NETWORK_BUILD_INTEGRATION_TESTS=ON`).
+
+@section faq_more More Resources
+
+- @ref tutorial_tcp
+- @ref tutorial_websocket
+- @ref tutorial_protocols
+- @ref troubleshooting
+
+*/

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -228,6 +228,20 @@ cmake --build build
 | Connection Pool | @ref connection_pool.cpp | Efficient connection reuse and lifecycle management |
 | Observer Pattern | @ref observer_pattern.cpp | Event-driven networking with observer callbacks |
 
+@section learning Learning Resources
+
+New to Network System? Start with the tutorials below for a guided tour
+of the facade API, then keep the FAQ and troubleshooting guide handy as
+references during integration.
+
+| Resource | Description |
+|----------|-------------|
+| @ref tutorial_tcp | TCP client and server walkthrough including session management and the echo pattern |
+| @ref tutorial_websocket | WebSocket chat application covering the upgrade handshake and message framing |
+| @ref tutorial_protocols | Decision matrix and code samples for choosing between TCP, UDP, WebSocket, HTTP/2, and QUIC |
+| @ref faq | Frequently asked questions: connection drops, TLS, threading, performance, testing, and more |
+| @ref troubleshooting | Common runtime issues such as connect timeouts, TLS handshakes, leaks, and platform quirks |
+
 @section related Related Systems
 
 Network System is the transport layer (Tier 4) of the kcenon ecosystem.

--- a/docs/troubleshooting.dox
+++ b/docs/troubleshooting.dox
@@ -1,0 +1,166 @@
+/**
+@page troubleshooting Troubleshooting Guide
+
+@tableofcontents
+
+This guide covers the most common runtime problems we see when applications
+adopt Network System. Each entry includes the symptoms, the underlying root
+cause, and a concrete fix.
+
+@section trouble_timeout 1. Connection timeouts
+
+@par Symptoms
+- `client->start(...)` returns successfully but `is_connected()` stays
+  `false`.
+- The error callback fires with
+  `std::errc::timed_out` / `boost::asio::error::timed_out`.
+- TCP retries are visible in `tcpdump` but the SYN never receives an ACK.
+
+@par Likely causes
+- The server is not listening on the host or port you supplied.
+- A firewall (host, cloud security group, or router) is dropping packets.
+- DNS resolution succeeded but the resolved address is unreachable.
+- The default 30-second timeout is too aggressive for high-latency links.
+
+@par Fixes
+@code{.cpp}
+auto client = tcp.create_client({
+    .host = "remote.example.com",
+    .port = 9000,
+    .timeout = std::chrono::seconds(60), // raise the connect timeout
+});
+@endcode
+
+Then verify reachability with `nc -vz remote.example.com 9000` and inspect
+listening ports on the server with `ss -tnlp` (Linux) or `lsof -iTCP
+-sTCP:LISTEN` (macOS). When running inside containers, double-check that
+the port is actually published to the host.
+
+@section trouble_tls 2. TLS handshake failures
+
+@par Symptoms
+- The client connects, then immediately disconnects.
+- The error callback reports `Errors::ssl_handshake_failed`,
+  `certificate verify failed`, or `unsupported protocol`.
+- OpenSSL logs `SSL alert number 40` (handshake failure).
+
+@par Likely causes
+- The CA bundle does not include the server certificate's issuer.
+- The server presents a certificate whose hostname does not match the
+  `host` field used by the client.
+- Client and server negotiate incompatible TLS versions or cipher suites.
+- `verify_certificate` is `true` but the server uses a self-signed cert.
+
+@par Fixes
+- Point `ca_cert_path` at a bundle that contains the issuer chain.
+- Set the `host` field to the exact name on the certificate (Common Name
+  or a SAN entry).
+- Force a modern TLS version on the server side via the `tls_version`
+  field, for example `"TLSv1_3"`.
+- For development with self-signed certificates, set
+  `verify_certificate = false`. Never disable verification in production.
+- Confirm the build links against OpenSSL 3.x. OpenSSL 1.1.1 emits a
+  warning at configure time and is unsupported upstream.
+
+@section trouble_buffer 3. Buffer overflow / oversized payloads
+
+@par Symptoms
+- `client->send(...)` returns an error with message
+  `payload exceeds maximum`.
+- The receiver disconnects mid-message and the connection is reset.
+- WebSocket peers report `frame too large`.
+
+@par Likely causes
+- The application is trying to send a payload larger than the configured
+  pipeline buffer.
+- A WebSocket peer enforces a smaller maximum frame size than the sender.
+- An intermediate proxy truncates large messages.
+
+@par Fixes
+- Split large payloads into chunks at the application layer and reassemble
+  them on the receiver.
+- Reduce per-message size on WebSocket connections by streaming smaller
+  messages instead of one giant blob.
+- For genuine bulk transfer use TCP with length-prefixed framing rather
+  than WebSocket frames.
+- If you must send very large payloads, raise the configured maximum at
+  the unified templates layer (the facade enforces conservative defaults).
+
+@section trouble_leak 4. Memory leaks in long-running connections
+
+@par Symptoms
+- `RSS` (resident set size) grows steadily over hours or days.
+- Heap profilers attribute the growth to `std::map` or `std::shared_ptr`
+  instances under `network_system`.
+- Connections that briefly disconnect leave behind orphan session entries.
+
+@par Likely causes
+- The application stores `std::shared_ptr<i_session>` in a map but never
+  erases entries from the `disconnection` callback.
+- A receive callback captures large objects by value, keeping them alive
+  for the lifetime of the session.
+- Background reconnect logic creates a fresh client on each attempt
+  without releasing the previous one.
+
+@par Fixes
+- Always erase the session map entry inside the `disconnection` callback,
+  under the same mutex used by the `connection` callback.
+- Capture by reference (or weak pointer) in callbacks; copy only the data
+  you actually need.
+- Reuse a single client object across reconnect attempts instead of
+  recreating it.
+- Periodically run the `tsan` or `asan` preset against integration tests
+  to catch missed cleanup paths.
+
+@code{.cpp}
+server->set_disconnection_callback([&](std::string_view session_id) {
+    std::lock_guard lock(sessions_mutex);
+    sessions.erase(std::string(session_id)); // critical: prevents leaks
+});
+@endcode
+
+@section trouble_platform 5. Platform-specific socket issues
+
+@par Symptoms
+- A program that runs fine on Linux fails on macOS or Windows with errors
+  about `EADDRINUSE`, `WSAEACCES`, or `bind: permission denied`.
+- The number of accepted connections plateaus at exactly 1024 or 4096.
+- Closing a listening socket on Windows takes several seconds before the
+  port can be reused.
+
+@par Likely causes
+- macOS and Windows treat ports below 1024 as privileged; running as a
+  normal user denies the bind.
+- File-descriptor limits cap simultaneous sockets at the default of 1024
+  on many Linux distributions.
+- Windows holds sockets in `TIME_WAIT` longer than POSIX systems by
+  default, blocking immediate rebind.
+- Antivirus or endpoint protection on Windows can intercept localhost
+  traffic.
+
+@par Fixes
+- Bind to ports above 1024 unless your service truly requires a privileged
+  port. If it does, run with `sudo`/`CAP_NET_BIND_SERVICE` (Linux),
+  elevation (Windows), or `authopen`/launchd (macOS).
+- Raise the file-descriptor limit with `ulimit -n 65535` (Linux/macOS) or
+  the equivalent registry key on Windows.
+- During development call `server->stop()` and wait briefly before
+  rebinding, or use `SO_REUSEADDR` (already enabled by default in
+  `tcp_facade`).
+- Whitelist your binary in Windows Defender / antivirus tools if you see
+  silent connection failures only on Windows.
+
+@section trouble_more More help
+
+If your symptoms do not match anything above:
+
+- Check the related questions in @ref faq.
+- Re-run the failing scenario under one of the sanitizer presets
+  (`asan`, `tsan`, `ubsan`) to surface hidden races or memory bugs.
+- Capture a packet trace with `tcpdump` or Wireshark; most "library bugs"
+  turn out to be middlebox or firewall problems.
+- Open an issue at
+  https://github.com/kcenon/network_system/issues with the failing
+  configuration, build flags, OS, and a minimal reproduction.
+
+*/

--- a/docs/tutorial_protocols.dox
+++ b/docs/tutorial_protocols.dox
@@ -1,0 +1,194 @@
+/**
+@page tutorial_protocols Tutorial: Choosing the Right Protocol
+
+@tableofcontents
+
+@section proto_intro Introduction
+
+Network System ships facades for several transport protocols. Picking the
+wrong one early in a project leads to expensive rewrites later, so this
+tutorial walks through the trade-offs and shows how each facade is used.
+
+You will learn:
+
+- When to reach for TCP, UDP, or WebSocket
+- How the facade API stays consistent across protocols
+- How to write code that targets the unified
+  @ref kcenon::network::interfaces::i_protocol_client "i_protocol_client"
+  interface so you can swap transports later
+
+@section proto_matrix Decision Matrix
+
+| Concern              | TCP            | UDP             | WebSocket           |
+|----------------------|----------------|-----------------|---------------------|
+| Reliability          | Guaranteed     | Best-effort     | Guaranteed (over TCP) |
+| Ordering             | In-order       | Unordered       | In-order            |
+| Connection-oriented  | Yes            | No              | Yes (with handshake)|
+| Framing              | Stream of bytes| Datagrams       | Discrete messages   |
+| Browser-friendly     | No             | No              | Yes                 |
+| NAT/firewall         | Generally allowed | Frequently blocked | Allowed (HTTP port) |
+| Overhead per message | Low            | Lowest          | ~6 bytes header     |
+| Typical use cases    | RPC, file transfer | Telemetry, gaming, voice | Browser realtime, chat |
+
+Rules of thumb:
+
+- Choose **TCP** when you need reliable byte streams and full control over
+  framing. It is the safest default for new server-to-server protocols.
+- Choose **UDP** when latency matters more than reliability, when you can
+  tolerate (or recover from) lost or reordered packets, or when you need
+  multicast.
+- Choose **WebSocket** when one peer is a web browser, when you need to
+  traverse HTTP proxies, or when the framework's automatic message framing
+  saves you from writing your own length-prefix protocol.
+
+@section proto_facades Facade Quick Reference
+
+Each protocol has a facade in the `kcenon::network::facade` namespace:
+
+| Facade | Header | Purpose |
+|--------|--------|---------|
+| `tcp_facade`       | `kcenon/network/facade/tcp_facade.h`       | Reliable byte-stream client/server with optional TLS |
+| `udp_facade`       | `kcenon/network/facade/udp_facade.h`       | Datagram client/server |
+| `websocket_facade` | `kcenon/network/facade/websocket_facade.h` | Framed full-duplex messaging over an HTTP upgrade |
+| `http_facade`      | `kcenon/network/facade/http_facade.h`      | HTTP/2 client/server |
+| `quic_facade`      | `kcenon/network/facade/quic_facade.h`      | QUIC transport |
+
+All facades follow the same shape:
+
+@code{.cpp}
+facade_type fac;
+auto client = fac.create_client({ /* config */ });
+auto server = fac.create_server({ /* config */ });
+@endcode
+
+The returned objects implement
+@ref kcenon::network::interfaces::i_protocol_client and
+@ref kcenon::network::interfaces::i_protocol_server, so once a connection is
+established the rest of your code is protocol-agnostic.
+
+@section proto_tcp_example Example 1: TCP Reliable Stream
+
+Use TCP for binary protocols where ordering and reliability are mandatory.
+
+@code{.cpp}
+#include <kcenon/network/facade/tcp_facade.h>
+
+using namespace kcenon::network;
+
+int main() {
+    facade::tcp_facade tcp;
+    auto client = tcp.create_client({
+        .host = "127.0.0.1",
+        .port = 9000,
+        .client_id = "rpc-client",
+    });
+
+    client->set_receive_callback([](const std::vector<uint8_t>& data) {
+        // Length-prefixed framing is up to the application.
+    });
+
+    client->start("127.0.0.1", 9000);
+
+    std::vector<uint8_t> request{0x01, 0x02, 0x03};
+    client->send(std::move(request));
+    return 0;
+}
+@endcode
+
+@section proto_udp_example Example 2: UDP Datagrams
+
+Use UDP for telemetry, low-latency control loops, and any traffic that can
+tolerate loss. UDP datagrams are independent and unordered.
+
+@code{.cpp}
+#include <kcenon/network/facade/udp_facade.h>
+
+using namespace kcenon::network;
+
+int main() {
+    facade::udp_facade udp;
+    auto client = udp.create_client({
+        .host = "127.0.0.1",
+        .port = 5555,
+        .client_id = "telemetry-emitter",
+    });
+
+    client->set_receive_callback([](const std::vector<uint8_t>& data) {
+        // Drop or accept stragglers as appropriate for the workload.
+    });
+
+    client->start("127.0.0.1", 5555);
+
+    std::vector<uint8_t> sample = {/* serialized telemetry sample */};
+    client->send(std::move(sample));
+    return 0;
+}
+@endcode
+
+When designing UDP protocols you must handle:
+
+- Packet loss (retransmit at the application layer if necessary)
+- Reordering (include sequence numbers in the payload)
+- Path MTU (keep payloads under ~1200 bytes for IPv6 safety)
+
+@section proto_ws_example Example 3: WebSocket for Browsers
+
+Use WebSocket when browsers are part of the topology or when an HTTP path
+makes routing through proxies easier.
+
+@code{.cpp}
+#include <kcenon/network/facade/websocket_facade.h>
+
+using namespace kcenon::network;
+
+int main() {
+    facade::websocket_facade ws;
+    auto client = ws.create_client({
+        .client_id = "browser-bridge",
+        .ping_interval = std::chrono::seconds(20),
+    });
+
+    client->set_receive_callback([](const std::vector<uint8_t>& data) {
+        // Each callback delivers exactly one message.
+    });
+
+    client->start("127.0.0.1", 9001);
+
+    std::string hello = "hello world";
+    client->send(std::vector<uint8_t>(hello.begin(), hello.end()));
+    return 0;
+}
+@endcode
+
+@section proto_swap Swapping Protocols Without Rewriting
+
+Because all facades return the same `i_protocol_client` interface, you can
+isolate the choice of transport in a single factory function:
+
+@code{.cpp}
+std::shared_ptr<interfaces::i_protocol_client>
+make_client(std::string_view kind) {
+    if (kind == "tcp") {
+        facade::tcp_facade tcp;
+        return tcp.create_client({.host = "127.0.0.1", .port = 9000});
+    }
+    if (kind == "udp") {
+        facade::udp_facade udp;
+        return udp.create_client({.host = "127.0.0.1", .port = 5555});
+    }
+    facade::websocket_facade ws;
+    return ws.create_client({.client_id = "default"});
+}
+@endcode
+
+Application code that calls `client->send(...)` and registers callbacks
+remains unchanged across transports.
+
+@section proto_next Next Steps
+
+- @ref tutorial_tcp for an in-depth TCP walkthrough.
+- @ref tutorial_websocket for WebSocket-specific patterns.
+- @ref faq for protocol selection FAQs.
+- @ref troubleshooting for common runtime issues.
+
+*/

--- a/docs/tutorial_tcp.dox
+++ b/docs/tutorial_tcp.dox
@@ -1,0 +1,218 @@
+/**
+@page tutorial_tcp Tutorial: TCP Client and Server
+
+@tableofcontents
+
+@section tcp_intro Introduction
+
+This tutorial walks through building TCP client and server applications using
+Network System's facade API. By the end you will know how to:
+
+- Create a TCP client and connect to a remote endpoint
+- Stand up a TCP server and accept connections
+- Track sessions, send and receive arbitrary byte payloads
+- Implement an echo pattern for round-trip messaging
+- Handle connection, disconnection, and error callbacks safely
+
+All examples target the @ref kcenon::network::facade::tcp_facade "tcp_facade"
+class. The facade hides protocol tags and template parameters, returning the
+unified interfaces @ref kcenon::network::interfaces::i_protocol_client
+"i_protocol_client" and
+@ref kcenon::network::interfaces::i_protocol_server "i_protocol_server".
+
+@section tcp_concepts Core Concepts
+
+| Concept | Description |
+|---------|-------------|
+| Facade  | Type-erased entry point that returns interface pointers |
+| Session | Server-side handle for a single connected client (`i_session`) |
+| Callback| User-supplied function invoked on connect, receive, error, etc. |
+| Result  | `Result<T>` from common_system represents success or error code |
+
+The facade API uses byte vectors (`std::vector<uint8_t>`) as the canonical
+payload format. Text messages are simply byte vectors initialised from a
+string range.
+
+@section tcp_client Tutorial 1: Connecting a Client
+
+The simplest TCP client connects to a server, sends a payload, and prints
+incoming data through a receive callback.
+
+@code{.cpp}
+#include <kcenon/network/facade/tcp_facade.h>
+
+#include <chrono>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+using namespace kcenon::network;
+
+int main() {
+    facade::tcp_facade tcp;
+
+    auto client = tcp.create_client({
+        .host = "127.0.0.1",
+        .port = 9000,
+        .client_id = "tutorial-client",
+    });
+
+    client->set_connected_callback([] {
+        std::cout << "[client] connected\n";
+    });
+
+    client->set_receive_callback([](const std::vector<uint8_t>& data) {
+        std::string msg(data.begin(), data.end());
+        std::cout << "[client] received: " << msg << '\n';
+    });
+
+    client->set_error_callback([](std::error_code ec) {
+        std::cerr << "[client] error: " << ec.message() << '\n';
+    });
+
+    if (auto r = client->start("127.0.0.1", 9000); r.is_err()) {
+        std::cerr << "connect failed: " << r.error().message << '\n';
+        return 1;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    std::string msg = "hello, server";
+    client->send(std::vector<uint8_t>(msg.begin(), msg.end()));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    client->stop();
+    return 0;
+}
+@endcode
+
+Notes:
+
+- `start(host, port)` initiates the asynchronous connect; the call returns
+  immediately and connection state is reported through callbacks.
+- `is_connected()` can be polled if you need a blocking wait, but production
+  code should react to the `connected` callback.
+- `send()` accepts an rvalue byte vector for zero-copy ownership transfer.
+
+@section tcp_server Tutorial 2: Accepting Connections
+
+A server tracks incoming sessions in a thread-safe map and responds to
+each client. The facade publishes three callbacks for the server lifecycle:
+`connection`, `disconnection`, and `receive`.
+
+@code{.cpp}
+#include <kcenon/network/facade/tcp_facade.h>
+#include <kcenon/network/interfaces/i_session.h>
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <thread>
+
+using namespace kcenon::network;
+
+int main() {
+    facade::tcp_facade tcp;
+    auto server = tcp.create_server({
+        .port = 9000,
+        .server_id = "tutorial-server",
+    });
+
+    std::mutex sessions_mutex;
+    std::map<std::string, std::shared_ptr<interfaces::i_session>> sessions;
+
+    server->set_connection_callback(
+        [&](std::shared_ptr<interfaces::i_session> session) {
+            std::lock_guard lock(sessions_mutex);
+            sessions[std::string(session->id())] = session;
+            std::cout << "[server] connect: " << session->id() << '\n';
+        });
+
+    server->set_disconnection_callback(
+        [&](std::string_view session_id) {
+            std::lock_guard lock(sessions_mutex);
+            sessions.erase(std::string(session_id));
+            std::cout << "[server] disconnect: " << session_id << '\n';
+        });
+
+    server->set_receive_callback(
+        [&](std::string_view session_id, const std::vector<uint8_t>& data) {
+            std::cout << "[server] " << session_id << " bytes=" << data.size() << '\n';
+        });
+
+    if (auto r = server->start(9000); r.is_err()) {
+        std::cerr << "start failed: " << r.error().message << '\n';
+        return 1;
+    }
+
+    std::cout << "[server] listening on 9000, Ctrl+C to stop\n";
+    std::this_thread::sleep_for(std::chrono::seconds(60));
+
+    server->stop();
+    return 0;
+}
+@endcode
+
+Important details about session storage:
+
+- The `connection` callback hands you a `std::shared_ptr<i_session>`. Holding
+  the shared pointer is what keeps the session alive; if you discard it the
+  framework still owns its internal copy, but you cannot send to it later.
+- Always guard the session map with a mutex. Callbacks may fire from any of
+  the IO threads.
+- The `disconnection` callback receives only the session id. Erase the entry
+  immediately to release the session shared pointer.
+
+@section tcp_echo Tutorial 3: Building an Echo Server
+
+The echo pattern is the canonical "hello world" of network programming. It
+exercises the full receive-then-send round trip in a single callback. Combine
+the previous server skeleton with a send-back step:
+
+@code{.cpp}
+server->set_receive_callback(
+    [&](std::string_view session_id, const std::vector<uint8_t>& data) {
+        std::shared_ptr<interfaces::i_session> session;
+        {
+            std::lock_guard lock(sessions_mutex);
+            if (auto it = sessions.find(std::string(session_id));
+                it != sessions.end()) {
+                session = it->second;
+            }
+        }
+
+        if (!session) {
+            return;
+        }
+
+        // Echo the original payload back to the sender.
+        if (auto r = session->send(std::vector<uint8_t>(data));
+            r.is_err()) {
+            std::cerr << "[server] echo failed: "
+                      << r.error().message << '\n';
+        }
+    });
+@endcode
+
+Pair this server with the client from Tutorial 1 and you should observe the
+client receive the same bytes it sent. For a complete runnable program see
+@ref tcp_echo_server.cpp and @ref tcp_client.cpp under `examples/`.
+
+@section tcp_session_lifetime Session Lifetime and Cleanup
+
+The Network System's session model has two important rules:
+
+1. The server keeps an internal reference until disconnect; user code should
+   release sessions in the `disconnection` callback to avoid leaks.
+2. Calls on a closed session return `Result<>` errors rather than throwing.
+   Always check `is_err()` before assuming a send succeeded.
+
+@section tcp_next Next Steps
+
+- Read @ref tutorial_websocket for full-duplex messaging over HTTP.
+- Read @ref tutorial_protocols to choose between TCP, UDP, and WebSocket.
+- Browse @ref faq for common questions, and @ref troubleshooting for fixes.
+
+*/

--- a/docs/tutorial_websocket.dox
+++ b/docs/tutorial_websocket.dox
@@ -1,0 +1,193 @@
+/**
+@page tutorial_websocket Tutorial: WebSocket Chat Application
+
+@tableofcontents
+
+@section ws_intro Introduction
+
+WebSockets (RFC 6455) provide a full-duplex message channel layered over an
+HTTP/1.1 upgrade handshake. Network System exposes WebSocket support through
+the @ref kcenon::network::facade::websocket_facade "websocket_facade" class
+which mirrors the TCP facade API but is purpose-built for framed messages.
+
+This tutorial builds a small chat room: a server that broadcasts each
+incoming message to every connected participant, plus a client that posts
+messages and prints incoming traffic.
+
+@section ws_concepts Concepts
+
+| Concept | Notes |
+|---------|-------|
+| Upgrade handshake | Network System performs the HTTP `Upgrade: websocket` exchange transparently |
+| Frames | The facade delivers and accepts complete WebSocket frames as `std::vector<uint8_t>` |
+| Path | A server is bound to a single URL path (default `/`) |
+| Ping interval | Clients send periodic pings to keep idle connections alive |
+
+By default the facade emits binary frames. If you need text frames or other
+WebSocket-specific features, cast the returned interface to
+`i_websocket_client` or `i_websocket_server`.
+
+@section ws_server Tutorial 1: A Broadcasting Chat Server
+
+Start with a server bound to `/chat`. Track every connected session and
+forward each message to all peers.
+
+@code{.cpp}
+#include <kcenon/network/facade/websocket_facade.h>
+#include <kcenon/network/interfaces/i_session.h>
+
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <thread>
+
+using namespace kcenon::network;
+
+int main() {
+    facade::websocket_facade ws;
+
+    auto server = ws.create_server({
+        .port = 9001,
+        .path = "/chat",
+        .server_id = "chat-server",
+    });
+
+    std::mutex mtx;
+    std::map<std::string, std::shared_ptr<interfaces::i_session>> sessions;
+
+    server->set_connection_callback(
+        [&](std::shared_ptr<interfaces::i_session> session) {
+            std::lock_guard lock(mtx);
+            sessions[std::string(session->id())] = session;
+            std::cout << "[chat] join " << session->id()
+                      << " (" << sessions.size() << " online)\n";
+        });
+
+    server->set_disconnection_callback(
+        [&](std::string_view id) {
+            std::lock_guard lock(mtx);
+            sessions.erase(std::string(id));
+            std::cout << "[chat] leave " << id << '\n';
+        });
+
+    server->set_receive_callback(
+        [&](std::string_view sender_id, const std::vector<uint8_t>& payload) {
+            std::string broadcast = std::string(sender_id) + ": ";
+            broadcast.append(payload.begin(), payload.end());
+            std::vector<uint8_t> frame(broadcast.begin(), broadcast.end());
+
+            std::lock_guard lock(mtx);
+            for (auto& [id, session] : sessions) {
+                session->send(std::vector<uint8_t>(frame));
+            }
+        });
+
+    if (auto r = server->start(9001); r.is_err()) {
+        std::cerr << "start failed: " << r.error().message << '\n';
+        return 1;
+    }
+
+    std::cout << "[chat] ws://localhost:9001/chat\n";
+    std::this_thread::sleep_for(std::chrono::minutes(10));
+    server->stop();
+    return 0;
+}
+@endcode
+
+Notes:
+
+- The `path` field is part of the upgrade handshake. Clients that target a
+  different URL path will be rejected during the upgrade.
+- Broadcasting is done from the receive callback, which already runs on a
+  worker thread, so it is safe to send synchronously.
+- Always copy the frame vector when fanning out to multiple peers; sending
+  consumes the rvalue.
+
+@section ws_client Tutorial 2: A Chat Client
+
+The client is similarly compact. It connects to the server, posts a few
+messages, and prints any broadcasts received in between.
+
+@code{.cpp}
+#include <kcenon/network/facade/websocket_facade.h>
+
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
+
+using namespace kcenon::network;
+
+int main(int argc, char** argv) {
+    std::string nick = (argc > 1) ? argv[1] : "alice";
+
+    facade::websocket_facade ws;
+    auto client = ws.create_client({
+        .client_id = nick,
+        .ping_interval = std::chrono::seconds(15),
+    });
+
+    client->set_receive_callback([&](const std::vector<uint8_t>& data) {
+        std::string msg(data.begin(), data.end());
+        std::cout << "[" << nick << "] " << msg << '\n';
+    });
+
+    client->set_error_callback([&](std::error_code ec) {
+        std::cerr << "[" << nick << "] error: " << ec.message() << '\n';
+    });
+
+    if (auto r = client->start("127.0.0.1", 9001); r.is_err()) {
+        std::cerr << "connect failed: " << r.error().message << '\n';
+        return 1;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    for (auto* line : {"hello chat", "anyone here?", "goodbye"}) {
+        std::string s(line);
+        client->send(std::vector<uint8_t>(s.begin(), s.end()));
+        std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    client->stop();
+    return 0;
+}
+@endcode
+
+Run the server in one terminal and two clients with different nicknames in
+two more terminals; each broadcast prefixed with the sender id should appear
+in every client's output.
+
+@section ws_framing Tutorial 3: Working with Message Framing
+
+The facade delivers exactly one logical message per receive callback invocation.
+Internally the framework reassembles continuation frames so applications never
+see partial messages. To send larger payloads, build the entire byte vector
+and let the framework split it into frames if necessary.
+
+@code{.cpp}
+// Construct a 64 KiB binary payload and send as a single message.
+std::vector<uint8_t> blob(64 * 1024, 0xAB);
+auto result = client->send(std::move(blob));
+if (result.is_err()) {
+    std::cerr << "send failed: " << result.error().message << '\n';
+}
+@endcode
+
+Tips:
+
+- Keep individual messages under a few megabytes. WebSocket allows larger
+  payloads, but most proxies and middleboxes drop oversized frames.
+- For realtime applications enable `ping_interval` so dropped TCP connections
+  are detected within a known interval.
+- TLS WebSocket (`wss://`) is enabled at the unified-templates layer; the
+  facade currently exposes plain WebSocket only.
+
+@section ws_next Next Steps
+
+- @ref tutorial_tcp covers raw TCP if you need a custom binary protocol.
+- @ref tutorial_protocols compares TCP, UDP, and WebSocket trade-offs.
+- See @ref websocket_chat.cpp for a runnable client/server combination.
+
+*/


### PR DESCRIPTION
Closes #933

## Summary
- Add 3 tutorials: TCP, WebSocket, and protocol selection guide
- Add FAQ page with 10 entries (connection drops, TLS, threads, buffers, performance, recovery, testing, and more)
- Add troubleshooting guide with 5 common runtime issues and fixes
- Update mainpage.dox with a Learning Resources section
- Register the new .dox files in Doxyfile INPUT

## Test plan
- [ ] CI builds Doxygen without warnings on the new pages
- [ ] All tutorials reference real facade APIs (`tcp_facade`, `websocket_facade`, `udp_facade`)
- [ ] Cross-references between tutorials, FAQ, and troubleshooting resolve