### PR TITLE
fix(cmake): install internal and network-core headers for vcpkg consumers

### DIFF
--- a/cmake/network_system_install.cmake
+++ b/cmake/network_system_install.cmake
@@ -37,6 +37,26 @@ function(install_network_system_headers)
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         FILES_MATCHING PATTERN "*.h"
     )
+
+    # Install internal headers referenced by public headers (Issue #944)
+    # Public headers use #include "internal/..." which resolves via the
+    # PRIVATE src/ include directory at build time. At install time these
+    # must be available under the include directory.
+    install(DIRECTORY src/internal/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/internal
+        FILES_MATCHING PATTERN "*.h"
+    )
+
+    # Install network-core headers (Issue #944)
+    # network-core is an INTERFACE library whose headers are needed by
+    # internal headers (e.g. tcp_socket.h includes network-core interfaces).
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/network-core/include/)
+        install(DIRECTORY network-core/include/
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+            FILES_MATCHING PATTERN "*.h"
+        )
+    endif()
+
     message(STATUS "Configured header installation")
 endfunction()
 


### PR DESCRIPTION
## What

### Summary
Add CMake install rules for `src/internal/` and `network-core/include/` headers
that are transitively included by the public installed headers but were missing
from the install tree.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `cmake/network_system_install.cmake` — `install_network_system_headers()` function

## Why

### Problem Solved
Multiple public headers under `include/kcenon/network/` use `#include "internal/..."`
directives that resolve at build time via the PRIVATE `src/` include directory.
At install time (e.g. vcpkg), those internal headers were absent, causing
`fatal error: file not found` for downstream consumers.

Affected includes:
- `detail/session/secure_session.h` → `internal/tcp/secure_tcp_socket.h`
- `detail/session/quic_session.h` → `internal/experimental/quic_client.h`, `internal/interfaces/i_quic_server.h`
- `network_system.h` → 7 internal headers
- `integration/network_system_bridge.h` → 4 internal headers
- `detail/config/network_config.h` → `internal/integration/logger_integration.h`
- `src/internal/tcp/tcp_socket.h` → `kcenon/network-core/interfaces/socket_observer.h`

### Related Issues
- Closes #944

## Where

### Files Changed
| Directory | Files | Type of Change |
|-----------|-------|----------------|
| `cmake/` | 1 | Modified install rules |

### Install Tree Changes
| Source | Install Destination |
|--------|-------------------|
| `src/internal/**/*.h` | `include/internal/` |
| `network-core/include/**/*.h` | `include/` |

## How

### Implementation Details
Two new `install(DIRECTORY ...)` calls added to `install_network_system_headers()`:

1. `src/internal/` → `${CMAKE_INSTALL_INCLUDEDIR}/internal` — so `#include "internal/..."` resolves
2. `network-core/include/` → `${CMAKE_INSTALL_INCLUDEDIR}/` — so `#include "kcenon/network-core/..."` resolves

The network-core install is guarded with `if(EXISTS ...)` to avoid errors if the
subproject is not present.

### Test Plan
- CI build should pass (CMake syntax is valid)
- vcpkg consumers should no longer need portfile workarounds to copy these headers