### PR TITLE
refactor(error): complete Result<T> migration in bridge/adapter layer

### DIFF
--- a/src/core/secure_messaging_udp_client.cpp
+++ b/src/core/secure_messaging_udp_client.cpp
@@ -297,8 +297,13 @@ auto secure_messaging_udp_client::do_start_impl(
 	asio::ip::udp::socket udp_socket(*io_context_, asio::ip::udp::v4());
 
 	// Create DTLS socket
-	socket_ = std::make_shared<internal::dtls_socket>(
+	auto dtls_result = internal::dtls_socket::create(
 		std::move(udp_socket), ssl_ctx_);
+	if (dtls_result.is_err()) {
+		return error<void>(dtls_result.error().code,
+			dtls_result.error().message, "secure_messaging_udp_client::start");
+	}
+	socket_ = dtls_result.value();
 
 	// Set peer endpoint
 	{

--- a/src/core/secure_messaging_udp_server.cpp
+++ b/src/core/secure_messaging_udp_server.cpp
@@ -349,8 +349,12 @@ auto secure_messaging_udp_server::create_session(
 		asio::ip::udp::socket client_socket(*io_context_, asio::ip::udp::v4());
 
 		auto session = std::make_shared<dtls_session>();
-		session->socket = std::make_shared<internal::dtls_socket>(
+		auto dtls_result = internal::dtls_socket::create(
 			std::move(client_socket), ssl_ctx_);
+		if (dtls_result.is_err()) {
+			return;
+		}
+		session->socket = dtls_result.value();
 		session->socket->set_peer_endpoint(client_endpoint);
 
 		// Set receive callback

--- a/src/integration/observability_bridge.cpp
+++ b/src/integration/observability_bridge.cpp
@@ -3,9 +3,27 @@
 // See the LICENSE file in the project root for full license information.
 
 #include "internal/integration/observability_bridge.h"
-#include <stdexcept>
 
 namespace kcenon::network::integration {
+
+Result<std::shared_ptr<ObservabilityBridge>> ObservabilityBridge::create(
+    std::shared_ptr<logger_interface> logger,
+    std::shared_ptr<monitoring_interface> monitor, BackendType backend_type) {
+    if (!logger) {
+        return error<std::shared_ptr<ObservabilityBridge>>(
+            error_codes::common_errors::invalid_argument,
+            "ObservabilityBridge requires non-null logger",
+            "ObservabilityBridge::create");
+    }
+    if (!monitor) {
+        return error<std::shared_ptr<ObservabilityBridge>>(
+            error_codes::common_errors::invalid_argument,
+            "ObservabilityBridge requires non-null monitor",
+            "ObservabilityBridge::create");
+    }
+    return ok(std::shared_ptr<ObservabilityBridge>(
+        new ObservabilityBridge(std::move(logger), std::move(monitor), backend_type)));
+}
 
 ObservabilityBridge::ObservabilityBridge(
     std::shared_ptr<logger_interface> logger,
@@ -14,12 +32,6 @@ ObservabilityBridge::ObservabilityBridge(
     : logger_(std::move(logger))
     , monitor_(std::move(monitor))
     , backend_type_(backend_type) {
-    if (!logger_) {
-        throw std::invalid_argument("ObservabilityBridge requires non-null logger");
-    }
-    if (!monitor_) {
-        throw std::invalid_argument("ObservabilityBridge requires non-null monitor");
-    }
 }
 
 ObservabilityBridge::~ObservabilityBridge() {
@@ -144,27 +156,24 @@ ObservabilityBridge::BackendType ObservabilityBridge::get_backend_type() const {
 }
 
 #if KCENON_WITH_COMMON_SYSTEM
-std::shared_ptr<ObservabilityBridge> ObservabilityBridge::from_common_system(
+Result<std::shared_ptr<ObservabilityBridge>> ObservabilityBridge::from_common_system(
     std::shared_ptr<::kcenon::common::interfaces::ILogger> logger,
     std::shared_ptr<::kcenon::common::interfaces::IMonitor> monitor) {
     if (!logger) {
-        throw std::invalid_argument("ObservabilityBridge::from_common_system requires non-null logger");
+        return error<std::shared_ptr<ObservabilityBridge>>(
+            error_codes::common_errors::invalid_argument,
+            "ObservabilityBridge::from_common_system requires non-null logger",
+            "ObservabilityBridge::from_common_system");
     }
     if (!monitor) {
-        throw std::invalid_argument("ObservabilityBridge::from_common_system requires non-null monitor");
+        return error<std::shared_ptr<ObservabilityBridge>>(
+            error_codes::common_errors::invalid_argument,
+            "ObservabilityBridge::from_common_system requires non-null monitor",
+            "ObservabilityBridge::from_common_system");
     }
-
-    // Adapt common_system logger and monitor to network_system interfaces
     auto adapted_logger = std::make_shared<common_system_logger_adapter>();
-
-    // For monitor, we use basic_monitoring since there's no direct adapter yet
-    // This is a known limitation - future work could create a proper adapter
     auto adapted_monitor = std::make_shared<basic_monitoring>();
-
-    return std::make_shared<ObservabilityBridge>(
-        adapted_logger,
-        adapted_monitor,
-        BackendType::CommonSystem);
+    return create(adapted_logger, adapted_monitor, BackendType::CommonSystem);
 }
 #endif
 

--- a/src/integration/thread_pool_bridge.cpp
+++ b/src/integration/thread_pool_bridge.cpp
@@ -8,17 +8,24 @@
 #include "internal/integration/thread_pool_adapters.h"
 #endif
 
-#include <stdexcept>
-
 namespace kcenon::network::integration {
+
+Result<std::shared_ptr<ThreadPoolBridge>> ThreadPoolBridge::create(
+    std::shared_ptr<thread_pool_interface> pool, BackendType backend_type) {
+    if (!pool) {
+        return error<std::shared_ptr<ThreadPoolBridge>>(
+            error_codes::common_errors::invalid_argument,
+            "ThreadPoolBridge requires non-null thread pool",
+            "ThreadPoolBridge::create");
+    }
+    return ok(std::shared_ptr<ThreadPoolBridge>(
+        new ThreadPoolBridge(std::move(pool), backend_type)));
+}
 
 ThreadPoolBridge::ThreadPoolBridge(
     std::shared_ptr<thread_pool_interface> pool,
     BackendType backend_type)
     : pool_(std::move(pool)), backend_type_(backend_type) {
-    if (!pool_) {
-        throw std::invalid_argument("ThreadPoolBridge requires non-null thread pool");
-    }
 }
 
 ThreadPoolBridge::~ThreadPoolBridge() {
@@ -122,29 +129,35 @@ ThreadPoolBridge::BackendType ThreadPoolBridge::get_backend_type() const {
     return backend_type_;
 }
 
-std::shared_ptr<ThreadPoolBridge> ThreadPoolBridge::from_thread_system(
+Result<std::shared_ptr<ThreadPoolBridge>> ThreadPoolBridge::from_thread_system(
     const std::string& pool_name) {
-    (void)pool_name; // Pool name is informational only in current implementation
-
+    (void)pool_name;
     auto pool = thread_integration_manager::instance().get_thread_pool();
     if (!pool) {
-        throw std::runtime_error("Failed to get thread pool from thread_integration_manager");
+        return error<std::shared_ptr<ThreadPoolBridge>>(
+            error_codes::common_errors::not_initialized,
+            "Failed to get thread pool from thread_integration_manager",
+            "ThreadPoolBridge::from_thread_system");
     }
-
-    return std::make_shared<ThreadPoolBridge>(pool, BackendType::ThreadSystem);
+    return create(pool, BackendType::ThreadSystem);
 }
 
 #if KCENON_WITH_COMMON_SYSTEM
-std::shared_ptr<ThreadPoolBridge> ThreadPoolBridge::from_common_system(
+Result<std::shared_ptr<ThreadPoolBridge>> ThreadPoolBridge::from_common_system(
     std::shared_ptr<::kcenon::common::interfaces::IExecutor> executor) {
     if (!executor) {
-        throw std::invalid_argument("ThreadPoolBridge::from_common_system requires non-null executor");
+        return error<std::shared_ptr<ThreadPoolBridge>>(
+            error_codes::common_errors::invalid_argument,
+            "ThreadPoolBridge::from_common_system requires non-null executor",
+            "ThreadPoolBridge::from_common_system");
     }
-
-    // Adapt common_system executor to thread_pool_interface
-    auto adapted_pool = std::make_shared<common_to_network_thread_adapter>(std::move(executor));
-
-    return std::make_shared<ThreadPoolBridge>(adapted_pool, BackendType::CommonSystem);
+    auto adapter_result = common_to_network_thread_adapter::create(std::move(executor));
+    if (adapter_result.is_err()) {
+        return error<std::shared_ptr<ThreadPoolBridge>>(
+            adapter_result.error().code, adapter_result.error().message,
+            "ThreadPoolBridge::from_common_system");
+    }
+    return create(adapter_result.value(), BackendType::CommonSystem);
 }
 #endif
 

--- a/src/integration/thread_system_adapter.cpp
+++ b/src/integration/thread_system_adapter.cpp
@@ -25,20 +25,27 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 
-#include <stdexcept>
 #include <thread>  // For std::thread::hardware_concurrency and std::this_thread::sleep_for (fallback)
 
 #include <kcenon/thread/core/thread_worker.h>
 
 namespace kcenon::network::integration {
 
+Result<std::shared_ptr<thread_system_pool_adapter>> thread_system_pool_adapter::create(
+    std::shared_ptr<kcenon::thread::thread_pool> pool) {
+    if (!pool) {
+        return error<std::shared_ptr<thread_system_pool_adapter>>(
+            error_codes::common_errors::invalid_argument,
+            "thread_system_pool_adapter: pool is null",
+            "thread_system_pool_adapter::create");
+    }
+    return ok(std::shared_ptr<thread_system_pool_adapter>(
+        new thread_system_pool_adapter(std::move(pool))));
+}
+
 thread_system_pool_adapter::thread_system_pool_adapter(
     std::shared_ptr<kcenon::thread::thread_pool> pool)
     : pool_(std::move(pool)) {
-    if (!pool_) {
-        throw std::invalid_argument("thread_system_pool_adapter: pool is null");
-    }
-    // No scheduler thread needed - delayed tasks are handled by thread_pool::submit_delayed
 }
 
 thread_system_pool_adapter::~thread_system_pool_adapter() {

--- a/src/internal/dtls_socket.cpp
+++ b/src/internal/dtls_socket.cpp
@@ -39,40 +39,51 @@ namespace
 
 } // anonymous namespace
 
-dtls_socket::dtls_socket(asio::ip::udp::socket socket, SSL_CTX* ssl_ctx)
-	: socket_(std::move(socket))
-	, ssl_ctx_(ssl_ctx)
-	, ssl_(nullptr)
-	, rbio_(nullptr)
-	, wbio_(nullptr)
+Result<std::shared_ptr<dtls_socket>> dtls_socket::create(
+	asio::ip::udp::socket socket, SSL_CTX* ssl_ctx)
 {
 	// Create SSL object
-	ssl_ = SSL_new(ssl_ctx_);
-	if (!ssl_)
+	SSL* ssl = SSL_new(ssl_ctx);
+	if (!ssl)
 	{
-		throw std::runtime_error("Failed to create SSL object");
+		return error<std::shared_ptr<dtls_socket>>(
+			error_codes::common_errors::internal_error,
+			"Failed to create SSL object",
+			"dtls_socket::create");
 	}
 
 	// Create memory BIOs for non-blocking I/O
-	rbio_ = BIO_new(BIO_s_mem());
-	wbio_ = BIO_new(BIO_s_mem());
-	if (!rbio_ || !wbio_)
+	BIO* rbio = BIO_new(BIO_s_mem());
+	BIO* wbio = BIO_new(BIO_s_mem());
+	if (!rbio || !wbio)
 	{
-		if (rbio_) BIO_free(rbio_);
-		if (wbio_) BIO_free(wbio_);
-		SSL_free(ssl_);
-		throw std::runtime_error("Failed to create BIO objects");
+		if (rbio) BIO_free(rbio);
+		if (wbio) BIO_free(wbio);
+		SSL_free(ssl);
+		return error<std::shared_ptr<dtls_socket>>(
+			error_codes::common_errors::internal_error,
+			"Failed to create BIO objects",
+			"dtls_socket::create");
 	}
 
 	// Set BIOs to non-blocking mode
-	BIO_set_nbio(rbio_, 1);
-	BIO_set_nbio(wbio_, 1);
+	BIO_set_nbio(rbio, 1);
+	BIO_set_nbio(wbio, 1);
 
-	// Connect BIOs to SSL object (SSL takes ownership)
-	SSL_set_bio(ssl_, rbio_, wbio_);
+	// Connect BIOs to SSL object (SSL takes ownership of BIOs)
+	SSL_set_bio(ssl, rbio, wbio);
 
-	// Enable DTLS cookie exchange for servers (DoS protection)
-	// This is optional and can be configured later
+	return ok(std::shared_ptr<dtls_socket>(
+		new dtls_socket(std::move(socket), ssl, rbio, wbio)));
+}
+
+dtls_socket::dtls_socket(asio::ip::udp::socket socket, SSL* ssl, BIO* rbio, BIO* wbio)
+	: socket_(std::move(socket))
+	, ssl_ctx_(nullptr)
+	, ssl_(ssl)
+	, rbio_(rbio)
+	, wbio_(wbio)
+{
 }
 
 dtls_socket::~dtls_socket()

--- a/src/internal/integration/observability_bridge.h
+++ b/src/internal/integration/observability_bridge.h
@@ -105,7 +105,7 @@ public:
      * auto bridge = std::make_shared<ObservabilityBridge>(logger, monitor);
      * @endcode
      */
-    explicit ObservabilityBridge(
+    [[nodiscard]] static Result<std::shared_ptr<ObservabilityBridge>> create(
         std::shared_ptr<logger_interface> logger,
         std::shared_ptr<monitoring_interface> monitor,
         BackendType backend_type = BackendType::Standalone);
@@ -241,12 +241,14 @@ public:
      * bridge->initialize(config);
      * @endcode
      */
-    static std::shared_ptr<ObservabilityBridge> from_common_system(
+    [[nodiscard]] static Result<std::shared_ptr<ObservabilityBridge>> from_common_system(
         std::shared_ptr<::kcenon::common::interfaces::ILogger> logger,
         std::shared_ptr<::kcenon::common::interfaces::IMonitor> monitor);
 #endif
 
 private:
+    ObservabilityBridge(std::shared_ptr<logger_interface> logger,
+        std::shared_ptr<monitoring_interface> monitor, BackendType backend_type);
     std::shared_ptr<logger_interface> logger_;
     std::shared_ptr<monitoring_interface> monitor_;
     BackendType backend_type_;

--- a/src/internal/integration/thread_pool_adapters.h
+++ b/src/internal/integration/thread_pool_adapters.h
@@ -108,17 +108,21 @@ class network_to_common_thread_adapter
     : public ::kcenon::common::interfaces::IExecutor {
 public:
     /**
-     * @brief Construct adapter wrapping a thread_pool_interface
+     * @brief Create adapter wrapping a thread_pool_interface
      * @param pool The network_system thread pool to adapt
-     * @throws std::invalid_argument if pool is nullptr
+     * @return Result with adapter or error if pool is nullptr
      */
-    explicit network_to_common_thread_adapter(
-        std::shared_ptr<thread_pool_interface> pool)
-        : pool_(std::move(pool)) {
-        if (!pool_) {
-            throw std::invalid_argument(
-                "network_to_common_thread_adapter requires non-null pool");
+    [[nodiscard]] static ::kcenon::common::Result<std::shared_ptr<network_to_common_thread_adapter>>
+    create(std::shared_ptr<thread_pool_interface> pool) {
+        if (!pool) {
+            return ::kcenon::common::Result<std::shared_ptr<network_to_common_thread_adapter>>::err(
+                ::kcenon::common::error_codes::INVALID_ARGUMENT,
+                "network_to_common_thread_adapter requires non-null pool",
+                "network_to_common_thread_adapter::create");
         }
+        return ::kcenon::common::Result<std::shared_ptr<network_to_common_thread_adapter>>::ok(
+            std::shared_ptr<network_to_common_thread_adapter>(
+                new network_to_common_thread_adapter(std::move(pool))));
     }
 
     /**
@@ -136,18 +140,22 @@ public:
         }
 
         try {
-            // Wrap the job in a shared_ptr for safe capture in lambda
             auto shared_job = std::shared_ptr<::kcenon::common::interfaces::IJob>(
                 std::move(job));
+            auto prom = std::make_shared<std::promise<void>>();
+            auto fut = prom->get_future();
 
-            auto future = pool_->submit([shared_job]() mutable {
+            pool_->submit([shared_job, prom]() mutable {
                 auto result = shared_job->execute();
                 if (result.is_err()) {
-                    throw std::runtime_error(result.error().message);
+                    prom->set_exception(std::make_exception_ptr(
+                        std::runtime_error(result.error().message)));
+                } else {
+                    prom->set_value();
                 }
             });
 
-            return ::kcenon::common::Result<std::future<void>>::ok(std::move(future));
+            return ::kcenon::common::Result<std::future<void>>::ok(std::move(fut));
         } catch (const std::exception& e) {
             return ::kcenon::common::Result<std::future<void>>::err(
                 ::kcenon::common::error_codes::INTERNAL_ERROR,
@@ -175,17 +183,22 @@ public:
         try {
             auto shared_job = std::shared_ptr<::kcenon::common::interfaces::IJob>(
                 std::move(job));
+            auto prom = std::make_shared<std::promise<void>>();
+            auto fut = prom->get_future();
 
-            auto future = pool_->submit_delayed(
-                [shared_job]() mutable {
+            pool_->submit_delayed(
+                [shared_job, prom]() mutable {
                     auto result = shared_job->execute();
                     if (result.is_err()) {
-                        throw std::runtime_error(result.error().message);
+                        prom->set_exception(std::make_exception_ptr(
+                            std::runtime_error(result.error().message)));
+                    } else {
+                        prom->set_value();
                     }
                 },
                 delay);
 
-            return ::kcenon::common::Result<std::future<void>>::ok(std::move(future));
+            return ::kcenon::common::Result<std::future<void>>::ok(std::move(fut));
         } catch (const std::exception& e) {
             return ::kcenon::common::Result<std::future<void>>::err(
                 ::kcenon::common::error_codes::INTERNAL_ERROR,
@@ -231,6 +244,10 @@ public:
     }
 
 private:
+    explicit network_to_common_thread_adapter(
+        std::shared_ptr<thread_pool_interface> pool)
+        : pool_(std::move(pool)) {}
+
     std::shared_ptr<thread_pool_interface> pool_;
 };
 
@@ -256,17 +273,20 @@ private:
 class common_to_network_thread_adapter : public thread_pool_interface {
 public:
     /**
-     * @brief Construct adapter wrapping an IExecutor
+     * @brief Create adapter wrapping an IExecutor
      * @param executor The common_system executor to adapt
-     * @throws std::invalid_argument if executor is nullptr
+     * @return Result with adapter or error if executor is nullptr
      */
-    explicit common_to_network_thread_adapter(
-        std::shared_ptr<::kcenon::common::interfaces::IExecutor> executor)
-        : executor_(std::move(executor)) {
-        if (!executor_) {
-            throw std::invalid_argument(
-                "common_to_network_thread_adapter requires non-null executor");
+    [[nodiscard]] static Result<std::shared_ptr<common_to_network_thread_adapter>>
+    create(std::shared_ptr<::kcenon::common::interfaces::IExecutor> executor) {
+        if (!executor) {
+            return error<std::shared_ptr<common_to_network_thread_adapter>>(
+                error_codes::common_errors::invalid_argument,
+                "common_to_network_thread_adapter requires non-null executor",
+                "common_to_network_thread_adapter::create");
         }
+        return ok(std::shared_ptr<common_to_network_thread_adapter>(
+            new common_to_network_thread_adapter(std::move(executor))));
     }
 
     /**
@@ -347,6 +367,10 @@ public:
     }
 
 private:
+    explicit common_to_network_thread_adapter(
+        std::shared_ptr<::kcenon::common::interfaces::IExecutor> executor)
+        : executor_(std::move(executor)) {}
+
     static std::future<void> make_error_future(const std::string& message) {
         std::promise<void> promise;
         promise.set_exception(std::make_exception_ptr(std::runtime_error(message)));

--- a/src/internal/integration/thread_pool_bridge.h
+++ b/src/internal/integration/thread_pool_bridge.h
@@ -102,7 +102,7 @@ public:
      * auto bridge = std::make_shared<ThreadPoolBridge>(pool);
      * @endcode
      */
-    explicit ThreadPoolBridge(
+    [[nodiscard]] static Result<std::shared_ptr<ThreadPoolBridge>> create(
         std::shared_ptr<thread_pool_interface> pool,
         BackendType backend_type = BackendType::Custom);
 
@@ -216,7 +216,7 @@ public:
      * bridge->initialize(config);
      * @endcode
      */
-    static std::shared_ptr<ThreadPoolBridge> from_thread_system(
+    [[nodiscard]] static Result<std::shared_ptr<ThreadPoolBridge>> from_thread_system(
         const std::string& pool_name = "network_pool");
 
 #if KCENON_WITH_COMMON_SYSTEM
@@ -238,11 +238,12 @@ public:
      * bridge->initialize(config);
      * @endcode
      */
-    static std::shared_ptr<ThreadPoolBridge> from_common_system(
+    [[nodiscard]] static Result<std::shared_ptr<ThreadPoolBridge>> from_common_system(
         std::shared_ptr<::kcenon::common::interfaces::IExecutor> executor);
 #endif
 
 private:
+    ThreadPoolBridge(std::shared_ptr<thread_pool_interface> pool, BackendType backend_type);
     std::shared_ptr<thread_pool_interface> pool_;
     BackendType backend_type_;
     std::atomic<bool> initialized_{false};

--- a/src/internal/integration/thread_system_adapter.h
+++ b/src/internal/integration/thread_system_adapter.h
@@ -20,6 +20,7 @@
  */
 
 #include "kcenon/network/integration/thread_integration.h"
+#include <kcenon/network/detail/utils/result_types.h>
 #include <memory>
 #include <future>
 #include <string>
@@ -44,7 +45,8 @@ namespace kcenon::network::integration {
 
 class thread_system_pool_adapter : public thread_pool_interface {
 public:
-    explicit thread_system_pool_adapter(std::shared_ptr<kcenon::thread::thread_pool> pool);
+    [[nodiscard]] static Result<std::shared_ptr<thread_system_pool_adapter>> create(
+        std::shared_ptr<kcenon::thread::thread_pool> pool);
     ~thread_system_pool_adapter();
 
     // Non-copyable, non-movable
@@ -70,6 +72,7 @@ public:
         const std::string& pool_name = "network_pool");
 
 private:
+    explicit thread_system_pool_adapter(std::shared_ptr<kcenon::thread::thread_pool> pool);
     /**
      * @brief The underlying thread_pool from thread_system
      *

--- a/src/internal/tcp/dtls_socket.h
+++ b/src/internal/tcp/dtls_socket.h
@@ -16,6 +16,7 @@
 
 #include "internal/utils/common_defs.h"
 #include "internal/utils/openssl_compat.h"
+#include <kcenon/network/detail/utils/result_types.h>
 
 namespace kcenon::network::internal
 {
@@ -65,7 +66,8 @@ namespace kcenon::network::internal
 		 * The socket should be connected (for client) or bound (for server)
 		 * before calling handshake methods.
 		 */
-		dtls_socket(asio::ip::udp::socket socket, SSL_CTX* ssl_ctx);
+		[[nodiscard]] static Result<std::shared_ptr<dtls_socket>> create(
+			asio::ip::udp::socket socket, SSL_CTX* ssl_ctx);
 
 		/*!
 		 * \brief Destructor. Cleans up OpenSSL resources.
@@ -180,6 +182,8 @@ namespace kcenon::network::internal
 		}
 
 	private:
+		dtls_socket(asio::ip::udp::socket socket, SSL* ssl, BIO* rbio, BIO* wbio);
+
 		/*!
 		 * \brief Internal function to handle the receive logic.
 		 */

--- a/src/internal/utils/message_validator.h
+++ b/src/internal/utils/message_validator.h
@@ -134,21 +134,21 @@ public:
     }
 
     /**
-     * @brief Validate and throw if size exceeds limit
+     * @brief Validate message size against limit
      *
      * @param size Size to validate
      * @param max_size Maximum allowed size
-     * @throws std::length_error if size exceeds limit
+     * @return validation_result::ok if valid, validation_result::size_exceeded otherwise
      */
-    static void validate_size_or_throw(
+    [[nodiscard]] static validation_result validate_size(
             size_t size,
             size_t max_size = message_limits::MAX_MESSAGE_SIZE) {
         if (size > max_size) {
-            throw std::length_error(
-                "Message size " + std::to_string(size) +
-                " exceeds limit " + std::to_string(max_size));
+            return validation_result::size_exceeded;
         }
+        return validation_result::ok;
     }
+
 
     /**
      * @brief Safe buffer copy with size validation

--- a/tests/unit/message_validator_extended_test.cpp
+++ b/tests/unit/message_validator_extended_test.cpp
@@ -57,10 +57,10 @@ TEST(MessageValidatorExtendedTest, ValidateZeroSize)
 	EXPECT_TRUE(message_validator::validate_size(0, 0));
 }
 
-TEST(MessageValidatorExtendedTest, ValidateSizeOrThrowCustomLimit)
+TEST(MessageValidatorExtendedTest, ValidateSizeResultCustomLimit)
 {
-	EXPECT_NO_THROW(message_validator::validate_size_or_throw(100, 200));
-	EXPECT_THROW(message_validator::validate_size_or_throw(201, 200), std::length_error);
+	EXPECT_EQ(message_validator::validate_size(100, 200), validation_result::ok);
+	EXPECT_EQ(message_validator::validate_size(201, 200), validation_result::size_exceeded);
 }
 
 TEST(MessageValidatorExtendedTest, SafeCopyZeroSourceSize)

--- a/tests/unit/test_input_validation.cpp
+++ b/tests/unit/test_input_validation.cpp
@@ -40,11 +40,10 @@ TEST_F(MessageValidatorTest, ValidateSizeCustomLimit) {
     EXPECT_FALSE(message_validator::validate_size(1001, 1000));
 }
 
-TEST_F(MessageValidatorTest, ValidateSizeOrThrow) {
-    EXPECT_NO_THROW(message_validator::validate_size_or_throw(1024));
-    EXPECT_THROW(
-        message_validator::validate_size_or_throw(message_limits::MAX_MESSAGE_SIZE + 1),
-        std::length_error);
+TEST_F(MessageValidatorTest, ValidateSizeResult) {
+    EXPECT_EQ(message_validator::validate_size(1024), validation_result::ok);
+    EXPECT_EQ(message_validator::validate_size(message_limits::MAX_MESSAGE_SIZE + 1),
+              validation_result::size_exceeded);
 }
 
 TEST_F(MessageValidatorTest, SafeCopyNormalCase) {


### PR DESCRIPTION
## What

### Summary
Replace all 15 remaining throw statements in src/ with Result<T> factory patterns,
completing the exception-to-Result migration for the internal implementation layer.

### Change Type
- [x] Refactor (no functional changes for success paths)

## Why

### Related Issues
- Closes #957 (Complete Result<T> migration in bridge/adapter implementations)

### Motivation
Public APIs were already migrated to Result<T> in PR #952, but internal code still used
exceptions. This created inconsistency where public APIs return Result<T> but internal
calls could throw, leading to unhandled exception risk.

## Where

### Files Changed (14 files, +194/-112 lines)

| Area | Files | Throws Removed |
|------|-------|---------------|
| Bridges | observability_bridge.cpp/.h, thread_pool_bridge.cpp/.h | 7 |
| Adapters | thread_system_adapter.cpp/.h, thread_pool_adapters.h | 5 |
| Protocol | dtls_socket.cpp/.h | 2 |
| Utility | message_validator.h | 1 |
| Call sites | secure_messaging_udp_client/server.cpp | (updated) |
| Tests | test_input_validation.cpp, message_validator_extended_test.cpp | (updated) |

## How

### Migration Patterns Applied
1. **Constructor -> Factory**: Throwing constructors replaced with static `create()` returning `Result<shared_ptr<T>>`
2. **Lambda throws -> set_exception**: Thread pool lambda throws replaced with `promise::set_exception(make_exception_ptr(...))` to propagate errors through futures without throw
3. **Throwing validator -> Result return**: `validate_size_or_throw` replaced with `validate_size` returning `validation_result` enum

### Verification
- `grep -rn "throw " src/` returns zero matches (excluding comments)
- All call sites updated to handle Result returns
- Tests updated to use new non-throwing APIs

### Test Plan
- [ ] All existing tests pass (success paths unchanged)
- [ ] Updated validator tests verify Result-based API
- [ ] No regressions on all CI platforms

### Breaking Changes
- `dtls_socket` constructor is now private; use `dtls_socket::create()` factory
- `validate_size_or_throw` removed; use `validate_size()` returning `validation_result`
- Bridge/adapter constructors now private; use `::create()` factories