### PR TITLE
test(adapters): add unit tests for 4 unified adapter modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Unit tests for 4 unified adapter modules: `ws_connection`, `ws_listener`, `quic_connection`, `quic_listener` — part of the #953 coverage expansion effort ([#967](https://github.com/kcenon/network_system/issues/967))
+
 ### Changed
 
 - Unify vcpkg manifest mode across all CI platforms (Linux, macOS, Windows) replacing per-platform manual ecosystem dependency builds ([#885](https://github.com/kcenon/network_system/issues/885))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Unit tests for unified adapter modules (#967)**
+  - Added dedicated unit tests for 4 unified adapters: `ws_connection_adapter`, `ws_listener_adapter`, `quic_connection_adapter`, `quic_listener_adapter` (68 tests total)
+  - Registered new test targets in `tests/CMakeLists.txt`
+  - Part of the #953 coverage expansion effort; complements #955 which covered the remaining 13 adapter modules
 - **Modernized Doxygen Documentation with doxygen-awesome-css (#927)**
   - Vendored doxygen-awesome-css theme with dark mode toggle, code copy buttons, and responsive sidebar
   - Added custom header (`docs/header.html`) and branding CSS (`docs/custom.css`)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4045,6 +4045,82 @@ network_gtest_discover_tests(network_udp_listener_adapter_test DISCOVERY_TIMEOUT
 message(STATUS "UDP listener adapter tests enabled")
 
 ##################################################
+# WebSocket Connection Adapter Tests (Issue #967)
+##################################################
+
+add_executable(network_ws_connection_adapter_test
+    unit/test_ws_connection_adapter.cpp
+)
+target_link_libraries(network_ws_connection_adapter_test PRIVATE
+    network_system GTest::gtest GTest::gtest_main Threads::Threads)
+setup_asio_integration(network_ws_connection_adapter_test)
+if(COMMON_SYSTEM_INCLUDE_DIR)
+    target_include_directories(network_ws_connection_adapter_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+    target_compile_definitions(network_ws_connection_adapter_test PRIVATE WITH_COMMON_SYSTEM)
+endif()
+set_target_properties(network_ws_connection_adapter_test PROPERTIES
+    CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+network_gtest_discover_tests(network_ws_connection_adapter_test DISCOVERY_TIMEOUT 60)
+message(STATUS "WebSocket connection adapter tests enabled")
+
+##################################################
+# WebSocket Listener Adapter Tests (Issue #967)
+##################################################
+
+add_executable(network_ws_listener_adapter_test
+    unit/test_ws_listener_adapter.cpp
+)
+target_link_libraries(network_ws_listener_adapter_test PRIVATE
+    network_system GTest::gtest GTest::gtest_main Threads::Threads)
+setup_asio_integration(network_ws_listener_adapter_test)
+if(COMMON_SYSTEM_INCLUDE_DIR)
+    target_include_directories(network_ws_listener_adapter_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+    target_compile_definitions(network_ws_listener_adapter_test PRIVATE WITH_COMMON_SYSTEM)
+endif()
+set_target_properties(network_ws_listener_adapter_test PROPERTIES
+    CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+network_gtest_discover_tests(network_ws_listener_adapter_test DISCOVERY_TIMEOUT 60)
+message(STATUS "WebSocket listener adapter tests enabled")
+
+##################################################
+# QUIC Connection Adapter Tests (Issue #967)
+##################################################
+
+add_executable(network_quic_connection_adapter_test
+    unit/test_quic_connection_adapter.cpp
+)
+target_link_libraries(network_quic_connection_adapter_test PRIVATE
+    network_system GTest::gtest GTest::gtest_main Threads::Threads)
+setup_asio_integration(network_quic_connection_adapter_test)
+if(COMMON_SYSTEM_INCLUDE_DIR)
+    target_include_directories(network_quic_connection_adapter_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+    target_compile_definitions(network_quic_connection_adapter_test PRIVATE WITH_COMMON_SYSTEM)
+endif()
+set_target_properties(network_quic_connection_adapter_test PROPERTIES
+    CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+network_gtest_discover_tests(network_quic_connection_adapter_test DISCOVERY_TIMEOUT 60)
+message(STATUS "QUIC connection adapter tests enabled")
+
+##################################################
+# QUIC Listener Adapter Tests (Issue #967)
+##################################################
+
+add_executable(network_quic_listener_adapter_test
+    unit/test_quic_listener_adapter.cpp
+)
+target_link_libraries(network_quic_listener_adapter_test PRIVATE
+    network_system GTest::gtest GTest::gtest_main Threads::Threads)
+setup_asio_integration(network_quic_listener_adapter_test)
+if(COMMON_SYSTEM_INCLUDE_DIR)
+    target_include_directories(network_quic_listener_adapter_test PRIVATE ${COMMON_SYSTEM_INCLUDE_DIR})
+    target_compile_definitions(network_quic_listener_adapter_test PRIVATE WITH_COMMON_SYSTEM)
+endif()
+set_target_properties(network_quic_listener_adapter_test PROPERTIES
+    CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+network_gtest_discover_tests(network_quic_listener_adapter_test DISCOVERY_TIMEOUT 60)
+message(STATUS "QUIC listener adapter tests enabled")
+
+##################################################
 # Sliding Histogram Tests (Issue #873)
 ##################################################
 

--- a/tests/unit/test_quic_connection_adapter.cpp
+++ b/tests/unit/test_quic_connection_adapter.cpp
@@ -1,0 +1,209 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+*****************************************************************************/
+
+/**
+ * @file test_quic_connection_adapter.cpp
+ * @brief Unit tests for unified QUIC connection adapter (i_connection bridge)
+ *
+ * Tests validate:
+ * - Construction with quic_config and explicit connection ID
+ * - id() accessor returns constructor value
+ * - Initial state (not connected, not connecting)
+ * - Callback, options, timeout registration
+ * - Close idempotency before connect
+ * - Shutdown safety (destructor does not deadlock nor leak resources)
+ *
+ * Note: Live connect()/send() require UDP socket binding and a running QUIC
+ * server. Those paths are covered by integration tests.
+ */
+
+#include "internal/unified/adapters/quic_connection_adapter.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string>
+
+namespace kcenon::network::unified::adapters {
+namespace {
+
+namespace quic_ns = kcenon::network::protocol::quic;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+quic_ns::quic_config make_default_config() {
+    quic_ns::quic_config cfg;
+    cfg.server_name = "example.com";
+    cfg.alpn_protocols = {"h3"};
+    return cfg;
+}
+
+// ============================================================================
+// Construction Tests
+// ============================================================================
+
+TEST(QuicConnectionAdapterTest, ConstructWithExplicitId) {
+    auto cfg = make_default_config();
+    quic_connection_adapter adapter(cfg, "test-quic-conn");
+    SUCCEED();
+}
+
+TEST(QuicConnectionAdapterTest, ConstructWithEmptyId) {
+    auto cfg = make_default_config();
+    quic_connection_adapter adapter(cfg, "");
+    SUCCEED();
+}
+
+TEST(QuicConnectionAdapterTest, ConstructWithDefaultConfig) {
+    quic_ns::quic_config cfg;
+    quic_connection_adapter adapter(cfg, "test-conn");
+    SUCCEED();
+}
+
+TEST(QuicConnectionAdapterTest, IdReturnsConstructorValue) {
+    auto cfg = make_default_config();
+    quic_connection_adapter adapter(cfg, "my-quic-connection");
+    EXPECT_EQ(adapter.id(), "my-quic-connection");
+}
+
+TEST(QuicConnectionAdapterTest, ConstructWithInsecureConfig) {
+    quic_ns::quic_config cfg;
+    cfg.server_name = "localhost";
+    cfg.insecure_skip_verify = true;
+    quic_connection_adapter adapter(cfg, "test-conn");
+    SUCCEED();
+}
+
+TEST(QuicConnectionAdapterTest, ConstructWithCustomStreamLimits) {
+    quic_ns::quic_config cfg;
+    cfg.server_name = "example.com";
+    cfg.max_bidi_streams = 50;
+    cfg.max_uni_streams = 50;
+    quic_connection_adapter adapter(cfg, "test-conn");
+    SUCCEED();
+}
+
+// ============================================================================
+// Initial State Tests
+// ============================================================================
+
+TEST(QuicConnectionAdapterTest, IsNotConnectedBeforeConnect) {
+    auto cfg = make_default_config();
+    quic_connection_adapter adapter(cfg, "test-conn");
+    EXPECT_FALSE(adapter.is_connected());
+}
+
+TEST(QuicConnectionAdapterTest, IsNotConnectingBeforeConnect) {
+    auto cfg = make_default_config();
+    quic_connection_adapter adapter(cfg, "test-conn");
+    EXPECT_FALSE(adapter.is_connecting());
+}
+
+// ============================================================================
+// Configuration Tests
+// ============================================================================
+
+TEST(QuicConnectionAdapterTest, SetCallbacks) {
+    auto cfg = make_default_config();
+    quic_connection_adapter adapter(cfg, "test-conn");
+    connection_callbacks cbs;
+    cbs.on_connected = []() {};
+    cbs.on_disconnected = []() {};
+    cbs.on_data = [](std::span<const std::byte>) {};
+    cbs.on_error = [](std::error_code) {};
+    adapter.set_callbacks(std::move(cbs));
+    SUCCEED();
+}
+
+TEST(QuicConnectionAdapterTest, SetOptions) {
+    auto cfg = make_default_config();
+    quic_connection_adapter adapter(cfg, "test-conn");
+    connection_options opts;
+    adapter.set_options(std::move(opts));
+    SUCCEED();
+}
+
+TEST(QuicConnectionAdapterTest, SetTimeout) {
+    auto cfg = make_default_config();
+    quic_connection_adapter adapter(cfg, "test-conn");
+    adapter.set_timeout(std::chrono::seconds(30));
+    SUCCEED();
+}
+
+TEST(QuicConnectionAdapterTest, SetTimeoutMultipleTimes) {
+    auto cfg = make_default_config();
+    quic_connection_adapter adapter(cfg, "test-conn");
+    adapter.set_timeout(std::chrono::seconds(5));
+    adapter.set_timeout(std::chrono::milliseconds(500));
+    adapter.set_timeout(std::chrono::minutes(1));
+    SUCCEED();
+}
+
+// ============================================================================
+// Shutdown Safety Tests
+// ============================================================================
+
+TEST(QuicConnectionAdapterTest, CloseBeforeConnectIsIdempotent) {
+    auto cfg = make_default_config();
+    quic_connection_adapter adapter(cfg, "test-conn");
+    adapter.close();
+    EXPECT_FALSE(adapter.is_connected());
+}
+
+TEST(QuicConnectionAdapterTest, MultipleCloseCallsAreHarmless) {
+    auto cfg = make_default_config();
+    quic_connection_adapter adapter(cfg, "test-conn");
+    adapter.close();
+    adapter.close();
+    adapter.close();
+    EXPECT_FALSE(adapter.is_connected());
+}
+
+TEST(QuicConnectionAdapterTest, DestructorDoesNotDeadlock) {
+    {
+        auto cfg = make_default_config();
+        quic_connection_adapter adapter(cfg, "test-conn");
+        connection_callbacks cbs;
+        cbs.on_connected = []() {};
+        adapter.set_callbacks(std::move(cbs));
+    }
+    SUCCEED();
+}
+
+TEST(QuicConnectionAdapterTest, RapidCreationAndDestruction) {
+    for (int i = 0; i < 10; ++i) {
+        auto cfg = make_default_config();
+        quic_connection_adapter adapter(cfg, "conn-" + std::to_string(i));
+        EXPECT_FALSE(adapter.is_connected());
+    }
+    SUCCEED();
+}
+
+// ============================================================================
+// Full Configuration Tests
+// ============================================================================
+
+TEST(QuicConnectionAdapterTest, ConfigureAllSettingsBeforeConnect) {
+    auto cfg = make_default_config();
+    quic_connection_adapter adapter(cfg, "test-conn");
+    adapter.set_timeout(std::chrono::seconds(30));
+    connection_options opts;
+    adapter.set_options(std::move(opts));
+    connection_callbacks cbs;
+    cbs.on_connected = []() {};
+    cbs.on_disconnected = []() {};
+    cbs.on_data = [](std::span<const std::byte>) {};
+    cbs.on_error = [](std::error_code) {};
+    adapter.set_callbacks(std::move(cbs));
+    EXPECT_FALSE(adapter.is_connected());
+    EXPECT_FALSE(adapter.is_connecting());
+}
+
+}  // namespace
+}  // namespace kcenon::network::unified::adapters

--- a/tests/unit/test_quic_listener_adapter.cpp
+++ b/tests/unit/test_quic_listener_adapter.cpp
@@ -1,0 +1,210 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+*****************************************************************************/
+
+/**
+ * @file test_quic_listener_adapter.cpp
+ * @brief Unit tests for unified QUIC listener adapter (i_listener bridge)
+ *
+ * Tests validate:
+ * - Construction with quic_config and explicit listener ID
+ * - Initial state (not listening, zero connections)
+ * - Callback registration (listener + accept callbacks)
+ * - Stop idempotency before start
+ * - close_connection() on unknown id is harmless
+ * - Shutdown safety (destructor does not deadlock)
+ *
+ * Note: Live start() requires cert/key files and UDP socket binding.
+ * Those paths are covered by integration tests.
+ */
+
+#include "internal/unified/adapters/quic_listener_adapter.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+namespace kcenon::network::unified::adapters {
+namespace {
+
+namespace quic_ns = kcenon::network::protocol::quic;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+quic_ns::quic_config make_default_config() {
+    quic_ns::quic_config cfg;
+    cfg.server_name = "localhost";
+    cfg.alpn_protocols = {"h3"};
+    return cfg;
+}
+
+// ============================================================================
+// Construction Tests
+// ============================================================================
+
+TEST(QuicListenerAdapterTest, ConstructWithExplicitId) {
+    auto cfg = make_default_config();
+    quic_listener_adapter adapter(cfg, "test-quic-listener");
+    SUCCEED();
+}
+
+TEST(QuicListenerAdapterTest, ConstructWithEmptyId) {
+    auto cfg = make_default_config();
+    quic_listener_adapter adapter(cfg, "");
+    SUCCEED();
+}
+
+TEST(QuicListenerAdapterTest, ConstructWithDefaultConfig) {
+    quic_ns::quic_config cfg;
+    quic_listener_adapter adapter(cfg, "test-listener");
+    SUCCEED();
+}
+
+TEST(QuicListenerAdapterTest, ConstructWithCertAndKey) {
+    quic_ns::quic_config cfg;
+    cfg.server_name = "localhost";
+    cfg.cert_file = "/path/to/cert.pem";
+    cfg.key_file = "/path/to/key.pem";
+    quic_listener_adapter adapter(cfg, "test-listener");
+    SUCCEED();
+}
+
+TEST(QuicListenerAdapterTest, ConstructWithEarlyDataEnabled) {
+    quic_ns::quic_config cfg;
+    cfg.server_name = "localhost";
+    cfg.enable_early_data = true;
+    quic_listener_adapter adapter(cfg, "test-listener");
+    SUCCEED();
+}
+
+// ============================================================================
+// Initial State Tests
+// ============================================================================
+
+TEST(QuicListenerAdapterTest, IsNotListeningBeforeStart) {
+    auto cfg = make_default_config();
+    quic_listener_adapter adapter(cfg, "test-listener");
+    EXPECT_FALSE(adapter.is_listening());
+}
+
+TEST(QuicListenerAdapterTest, ConnectionCountZeroBeforeStart) {
+    auto cfg = make_default_config();
+    quic_listener_adapter adapter(cfg, "test-listener");
+    EXPECT_EQ(adapter.connection_count(), 0u);
+}
+
+// ============================================================================
+// Callback Registration Tests
+// ============================================================================
+
+TEST(QuicListenerAdapterTest, SetCallbacks) {
+    auto cfg = make_default_config();
+    quic_listener_adapter adapter(cfg, "test-listener");
+    listener_callbacks cbs;
+    cbs.on_data = [](std::string_view, std::span<const std::byte>) {};
+    cbs.on_disconnect = [](std::string_view) {};
+    cbs.on_error = [](std::string_view, std::error_code) {};
+    adapter.set_callbacks(std::move(cbs));
+    SUCCEED();
+}
+
+TEST(QuicListenerAdapterTest, SetAcceptCallback) {
+    auto cfg = make_default_config();
+    quic_listener_adapter adapter(cfg, "test-listener");
+    adapter.set_accept_callback([](std::unique_ptr<i_connection>) {});
+    SUCCEED();
+}
+
+TEST(QuicListenerAdapterTest, SetCallbacksMultipleTimes) {
+    auto cfg = make_default_config();
+    quic_listener_adapter adapter(cfg, "test-listener");
+    listener_callbacks cbs1;
+    cbs1.on_data = [](std::string_view, std::span<const std::byte>) {};
+    adapter.set_callbacks(std::move(cbs1));
+
+    listener_callbacks cbs2;
+    cbs2.on_error = [](std::string_view, std::error_code) {};
+    adapter.set_callbacks(std::move(cbs2));
+    SUCCEED();
+}
+
+// ============================================================================
+// Shutdown Safety Tests
+// ============================================================================
+
+TEST(QuicListenerAdapterTest, StopBeforeStartIsIdempotent) {
+    auto cfg = make_default_config();
+    quic_listener_adapter adapter(cfg, "test-listener");
+    adapter.stop();
+    EXPECT_FALSE(adapter.is_listening());
+}
+
+TEST(QuicListenerAdapterTest, MultipleStopCallsAreHarmless) {
+    auto cfg = make_default_config();
+    quic_listener_adapter adapter(cfg, "test-listener");
+    adapter.stop();
+    adapter.stop();
+    adapter.stop();
+    EXPECT_FALSE(adapter.is_listening());
+    EXPECT_EQ(adapter.connection_count(), 0u);
+}
+
+TEST(QuicListenerAdapterTest, CloseNonexistentConnectionIsIdempotent) {
+    auto cfg = make_default_config();
+    quic_listener_adapter adapter(cfg, "test-listener");
+    adapter.close_connection("nonexistent-id");
+    EXPECT_EQ(adapter.connection_count(), 0u);
+}
+
+TEST(QuicListenerAdapterTest, CloseEmptyIdIsHarmless) {
+    auto cfg = make_default_config();
+    quic_listener_adapter adapter(cfg, "test-listener");
+    adapter.close_connection("");
+    EXPECT_EQ(adapter.connection_count(), 0u);
+}
+
+TEST(QuicListenerAdapterTest, DestructorDoesNotDeadlock) {
+    {
+        auto cfg = make_default_config();
+        quic_listener_adapter adapter(cfg, "test-listener");
+        listener_callbacks cbs;
+        cbs.on_data = [](std::string_view, std::span<const std::byte>) {};
+        adapter.set_callbacks(std::move(cbs));
+    }
+    SUCCEED();
+}
+
+TEST(QuicListenerAdapterTest, RapidCreationAndDestruction) {
+    for (int i = 0; i < 10; ++i) {
+        auto cfg = make_default_config();
+        quic_listener_adapter adapter(cfg, "listener-" + std::to_string(i));
+        EXPECT_FALSE(adapter.is_listening());
+    }
+    SUCCEED();
+}
+
+// ============================================================================
+// Full Configuration Tests
+// ============================================================================
+
+TEST(QuicListenerAdapterTest, ConfigureAllSettingsBeforeStart) {
+    auto cfg = make_default_config();
+    quic_listener_adapter adapter(cfg, "test-listener");
+    listener_callbacks cbs;
+    cbs.on_data = [](std::string_view, std::span<const std::byte>) {};
+    cbs.on_disconnect = [](std::string_view) {};
+    cbs.on_error = [](std::string_view, std::error_code) {};
+    adapter.set_callbacks(std::move(cbs));
+    adapter.set_accept_callback([](std::unique_ptr<i_connection>) {});
+    EXPECT_FALSE(adapter.is_listening());
+    EXPECT_EQ(adapter.connection_count(), 0u);
+}
+
+}  // namespace
+}  // namespace kcenon::network::unified::adapters

--- a/tests/unit/test_ws_connection_adapter.cpp
+++ b/tests/unit/test_ws_connection_adapter.cpp
@@ -1,0 +1,187 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+*****************************************************************************/
+
+/**
+ * @file test_ws_connection_adapter.cpp
+ * @brief Unit tests for unified WebSocket connection adapter (i_connection bridge)
+ *
+ * Tests validate:
+ * - Construction with explicit connection ID
+ * - id() accessor returns constructor value
+ * - Initial state (not connected, not connecting)
+ * - Callback registration
+ * - Options and timeout setting
+ * - WebSocket path configuration
+ * - Close idempotency before connect
+ * - Shutdown safety (destructor does not deadlock)
+ *
+ * Note: Live connect()/send() require a running WebSocket server.
+ * Those paths are covered by integration tests.
+ */
+
+#include "internal/unified/adapters/ws_connection_adapter.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string>
+
+namespace kcenon::network::unified::adapters {
+namespace {
+
+// ============================================================================
+// Construction Tests
+// ============================================================================
+
+TEST(WsConnectionAdapterTest, ConstructWithExplicitId) {
+    ws_connection_adapter adapter("test-ws-conn");
+    SUCCEED();
+}
+
+TEST(WsConnectionAdapterTest, ConstructWithEmptyId) {
+    ws_connection_adapter adapter("");
+    SUCCEED();
+}
+
+TEST(WsConnectionAdapterTest, IdReturnsConstructorValue) {
+    ws_connection_adapter adapter("my-ws-connection-id");
+    EXPECT_EQ(adapter.id(), "my-ws-connection-id");
+}
+
+// ============================================================================
+// Initial State Tests
+// ============================================================================
+
+TEST(WsConnectionAdapterTest, IsNotConnectedBeforeConnect) {
+    ws_connection_adapter adapter("test-conn");
+    EXPECT_FALSE(adapter.is_connected());
+}
+
+TEST(WsConnectionAdapterTest, IsNotConnectingBeforeConnect) {
+    ws_connection_adapter adapter("test-conn");
+    EXPECT_FALSE(adapter.is_connecting());
+}
+
+// ============================================================================
+// Configuration Tests
+// ============================================================================
+
+TEST(WsConnectionAdapterTest, SetCallbacks) {
+    ws_connection_adapter adapter("test-conn");
+    connection_callbacks cbs;
+    cbs.on_connected = []() {};
+    cbs.on_disconnected = []() {};
+    cbs.on_data = [](std::span<const std::byte>) {};
+    cbs.on_error = [](std::error_code) {};
+    adapter.set_callbacks(std::move(cbs));
+    SUCCEED();
+}
+
+TEST(WsConnectionAdapterTest, SetOptions) {
+    ws_connection_adapter adapter("test-conn");
+    connection_options opts;
+    adapter.set_options(std::move(opts));
+    SUCCEED();
+}
+
+TEST(WsConnectionAdapterTest, SetTimeout) {
+    ws_connection_adapter adapter("test-conn");
+    adapter.set_timeout(std::chrono::seconds(15));
+    SUCCEED();
+}
+
+TEST(WsConnectionAdapterTest, SetTimeoutMultipleTimes) {
+    ws_connection_adapter adapter("test-conn");
+    adapter.set_timeout(std::chrono::seconds(5));
+    adapter.set_timeout(std::chrono::milliseconds(250));
+    adapter.set_timeout(std::chrono::minutes(1));
+    SUCCEED();
+}
+
+// ============================================================================
+// WebSocket-Specific Configuration Tests
+// ============================================================================
+
+TEST(WsConnectionAdapterTest, SetPath) {
+    ws_connection_adapter adapter("test-conn");
+    adapter.set_path("/ws");
+    SUCCEED();
+}
+
+TEST(WsConnectionAdapterTest, SetPathMultipleTimes) {
+    ws_connection_adapter adapter("test-conn");
+    adapter.set_path("/ws/v1");
+    adapter.set_path("/ws/v2");
+    adapter.set_path("/socket.io/");
+    SUCCEED();
+}
+
+TEST(WsConnectionAdapterTest, SetPathWithEmptyString) {
+    ws_connection_adapter adapter("test-conn");
+    adapter.set_path("");
+    SUCCEED();
+}
+
+// ============================================================================
+// Shutdown Safety Tests
+// ============================================================================
+
+TEST(WsConnectionAdapterTest, CloseBeforeConnectIsIdempotent) {
+    ws_connection_adapter adapter("test-conn");
+    adapter.close();
+    EXPECT_FALSE(adapter.is_connected());
+}
+
+TEST(WsConnectionAdapterTest, MultipleCloseCallsAreHarmless) {
+    ws_connection_adapter adapter("test-conn");
+    adapter.close();
+    adapter.close();
+    adapter.close();
+    EXPECT_FALSE(adapter.is_connected());
+}
+
+TEST(WsConnectionAdapterTest, DestructorDoesNotDeadlock) {
+    {
+        ws_connection_adapter adapter("test-conn");
+        adapter.set_path("/ws");
+        connection_callbacks cbs;
+        cbs.on_connected = []() {};
+        adapter.set_callbacks(std::move(cbs));
+    }
+    SUCCEED();
+}
+
+TEST(WsConnectionAdapterTest, RapidCreationAndDestruction) {
+    for (int i = 0; i < 20; ++i) {
+        ws_connection_adapter adapter("conn-" + std::to_string(i));
+        EXPECT_FALSE(adapter.is_connected());
+    }
+    SUCCEED();
+}
+
+// ============================================================================
+// Full Configuration Tests
+// ============================================================================
+
+TEST(WsConnectionAdapterTest, ConfigureAllSettingsBeforeConnect) {
+    ws_connection_adapter adapter("test-conn");
+    adapter.set_path("/ws/api");
+    adapter.set_timeout(std::chrono::seconds(30));
+    connection_options opts;
+    adapter.set_options(std::move(opts));
+    connection_callbacks cbs;
+    cbs.on_connected = []() {};
+    cbs.on_disconnected = []() {};
+    cbs.on_data = [](std::span<const std::byte>) {};
+    cbs.on_error = [](std::error_code) {};
+    adapter.set_callbacks(std::move(cbs));
+    EXPECT_FALSE(adapter.is_connected());
+    EXPECT_FALSE(adapter.is_connecting());
+}
+
+}  // namespace
+}  // namespace kcenon::network::unified::adapters

--- a/tests/unit/test_ws_listener_adapter.cpp
+++ b/tests/unit/test_ws_listener_adapter.cpp
@@ -1,0 +1,187 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+*****************************************************************************/
+
+/**
+ * @file test_ws_listener_adapter.cpp
+ * @brief Unit tests for unified WebSocket listener adapter (i_listener bridge)
+ *
+ * Tests validate:
+ * - Construction with explicit listener ID
+ * - Initial state (not listening, zero connections)
+ * - Callback registration (listener + accept callbacks)
+ * - WebSocket path configuration
+ * - Stop idempotency before start
+ * - close_connection() on unknown id is harmless
+ * - Shutdown safety (destructor does not deadlock)
+ *
+ * Note: Live start()/send_to()/broadcast() require an actual bind.
+ * Those paths are covered by integration tests.
+ */
+
+#include "internal/unified/adapters/ws_listener_adapter.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+namespace kcenon::network::unified::adapters {
+namespace {
+
+// ============================================================================
+// Construction Tests
+// ============================================================================
+
+TEST(WsListenerAdapterTest, ConstructWithExplicitId) {
+    ws_listener_adapter adapter("test-ws-listener");
+    SUCCEED();
+}
+
+TEST(WsListenerAdapterTest, ConstructWithEmptyId) {
+    ws_listener_adapter adapter("");
+    SUCCEED();
+}
+
+// ============================================================================
+// Initial State Tests
+// ============================================================================
+
+TEST(WsListenerAdapterTest, IsNotListeningBeforeStart) {
+    ws_listener_adapter adapter("test-listener");
+    EXPECT_FALSE(adapter.is_listening());
+}
+
+TEST(WsListenerAdapterTest, ConnectionCountZeroBeforeStart) {
+    ws_listener_adapter adapter("test-listener");
+    EXPECT_EQ(adapter.connection_count(), 0u);
+}
+
+// ============================================================================
+// Callback Registration Tests
+// ============================================================================
+
+TEST(WsListenerAdapterTest, SetCallbacks) {
+    ws_listener_adapter adapter("test-listener");
+    listener_callbacks cbs;
+    cbs.on_data = [](std::string_view, std::span<const std::byte>) {};
+    cbs.on_disconnect = [](std::string_view) {};
+    cbs.on_error = [](std::string_view, std::error_code) {};
+    adapter.set_callbacks(std::move(cbs));
+    SUCCEED();
+}
+
+TEST(WsListenerAdapterTest, SetAcceptCallback) {
+    ws_listener_adapter adapter("test-listener");
+    adapter.set_accept_callback([](std::unique_ptr<i_connection>) {});
+    SUCCEED();
+}
+
+TEST(WsListenerAdapterTest, SetCallbacksMultipleTimes) {
+    ws_listener_adapter adapter("test-listener");
+    listener_callbacks cbs1;
+    cbs1.on_data = [](std::string_view, std::span<const std::byte>) {};
+    adapter.set_callbacks(std::move(cbs1));
+
+    listener_callbacks cbs2;
+    cbs2.on_error = [](std::string_view, std::error_code) {};
+    adapter.set_callbacks(std::move(cbs2));
+    SUCCEED();
+}
+
+// ============================================================================
+// WebSocket-Specific Configuration Tests
+// ============================================================================
+
+TEST(WsListenerAdapterTest, SetPath) {
+    ws_listener_adapter adapter("test-listener");
+    adapter.set_path("/ws");
+    SUCCEED();
+}
+
+TEST(WsListenerAdapterTest, SetPathMultipleTimes) {
+    ws_listener_adapter adapter("test-listener");
+    adapter.set_path("/ws/v1");
+    adapter.set_path("/ws/v2");
+    adapter.set_path("/socket.io/");
+    SUCCEED();
+}
+
+TEST(WsListenerAdapterTest, SetPathWithEmptyString) {
+    ws_listener_adapter adapter("test-listener");
+    adapter.set_path("");
+    SUCCEED();
+}
+
+// ============================================================================
+// Shutdown Safety Tests
+// ============================================================================
+
+TEST(WsListenerAdapterTest, StopBeforeStartIsIdempotent) {
+    ws_listener_adapter adapter("test-listener");
+    adapter.stop();
+    EXPECT_FALSE(adapter.is_listening());
+}
+
+TEST(WsListenerAdapterTest, MultipleStopCallsAreHarmless) {
+    ws_listener_adapter adapter("test-listener");
+    adapter.stop();
+    adapter.stop();
+    adapter.stop();
+    EXPECT_FALSE(adapter.is_listening());
+    EXPECT_EQ(adapter.connection_count(), 0u);
+}
+
+TEST(WsListenerAdapterTest, CloseNonexistentConnectionIsIdempotent) {
+    ws_listener_adapter adapter("test-listener");
+    adapter.close_connection("nonexistent-id");
+    EXPECT_EQ(adapter.connection_count(), 0u);
+}
+
+TEST(WsListenerAdapterTest, CloseEmptyIdIsHarmless) {
+    ws_listener_adapter adapter("test-listener");
+    adapter.close_connection("");
+    EXPECT_EQ(adapter.connection_count(), 0u);
+}
+
+TEST(WsListenerAdapterTest, DestructorDoesNotDeadlock) {
+    {
+        ws_listener_adapter adapter("test-listener");
+        adapter.set_path("/ws");
+        listener_callbacks cbs;
+        cbs.on_data = [](std::string_view, std::span<const std::byte>) {};
+        adapter.set_callbacks(std::move(cbs));
+    }
+    SUCCEED();
+}
+
+TEST(WsListenerAdapterTest, RapidCreationAndDestruction) {
+    for (int i = 0; i < 20; ++i) {
+        ws_listener_adapter adapter("listener-" + std::to_string(i));
+        EXPECT_FALSE(adapter.is_listening());
+    }
+    SUCCEED();
+}
+
+// ============================================================================
+// Full Configuration Tests
+// ============================================================================
+
+TEST(WsListenerAdapterTest, ConfigureAllSettingsBeforeStart) {
+    ws_listener_adapter adapter("test-listener");
+    adapter.set_path("/ws/api");
+    listener_callbacks cbs;
+    cbs.on_data = [](std::string_view, std::span<const std::byte>) {};
+    cbs.on_disconnect = [](std::string_view) {};
+    cbs.on_error = [](std::string_view, std::error_code) {};
+    adapter.set_callbacks(std::move(cbs));
+    adapter.set_accept_callback([](std::unique_ptr<i_connection>) {});
+    EXPECT_FALSE(adapter.is_listening());
+    EXPECT_EQ(adapter.connection_count(), 0u);
+}
+
+}  // namespace
+}  // namespace kcenon::network::unified::adapters


### PR DESCRIPTION
Closes #967

## Summary
- Adds unit tests for 4 unified adapter modules: ws_connection, ws_listener, quic_connection, quic_listener (68 new tests)
- Registers new targets in tests/CMakeLists.txt
- Updates CHANGELOG.md and docs/CHANGELOG.md

## Why
Part of epic #953 — expand unit test coverage from 40% to 80%. The original issue #967 listed 17 adapter modules as untested, but gap analysis found 13 were already covered by #955. This PR completes the remaining 4.

## Where
- tests/unit/test_ws_connection_adapter.cpp (+)
- tests/unit/test_ws_listener_adapter.cpp (+)
- tests/unit/test_quic_connection_adapter.cpp (+)
- tests/unit/test_quic_listener_adapter.cpp (+)
- tests/CMakeLists.txt (modified — 4 new test targets)
- CHANGELOG.md, docs/CHANGELOG.md (modified — Added entries)

## How / Test plan
Local verification (macOS, bash 5.3, cmake 4.3):
  cmake --preset release && cmake --build build
  cd build && ctest --output-on-failure -L unit

Result: 196/196 adapter tests pass (0.66s), no GTEST_SKIP markers.

CI-required coverage:
- Ubuntu GCC/Clang, Windows MSVC, macOS
- Sanitizer variants (ASAN/TSAN/UBSAN)

## Review Summary
- Gap analysis (Task 6): No critical findings — all 4 missing modules implemented, covers construction/error-paths per acceptance criteria.
- Code review (Task 7): Approved — no change requests (see team message log).
- No Minor/Info items outstanding.

## Commits
- ae862a11 test(adapters): add unit tests for unified ws/quic adapters
- 36dfd6cb docs(changelog): note adapter unit test additions for #967