### PR TITLE
test(quic): add unit tests for 5 remaining QUIC protocol modules

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4643,6 +4643,17 @@ add_network_test(network_websocket_socket_test unit/websocket_socket_test.cpp)
 message(STATUS "WebSocket socket unit tests enabled (Issue #968)")
 
 ##################################################
+# QUIC Protocol Module Unit Tests (Issue #974)
+##################################################
+
+add_network_test(network_session_ticket_store_test unit/session_ticket_store_test.cpp)
+add_network_test(network_quic_pmtud_controller_test unit/quic_pmtud_controller_test.cpp)
+add_network_test(network_quic_crypto_test unit/quic_crypto_test.cpp)
+add_network_test(network_quic_connection_test unit/quic_connection_test.cpp)
+add_network_test(network_quic_socket_construction_test unit/quic_socket_construction_test.cpp)
+message(STATUS "QUIC protocol module unit tests enabled (Issue #974)")
+
+##################################################
 # Integration Tests
 ##################################################
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4648,8 +4648,8 @@ message(STATUS "WebSocket socket unit tests enabled (Issue #968)")
 
 add_network_test(network_session_ticket_store_test unit/session_ticket_store_test.cpp)
 add_network_test(network_quic_pmtud_controller_test unit/quic_pmtud_controller_test.cpp)
-add_network_test(network_quic_crypto_test unit/quic_crypto_test.cpp)
-add_network_test(network_quic_connection_test unit/quic_connection_test.cpp)
+add_network_test(network_quic_crypto_module_test unit/quic_crypto_test.cpp)
+add_network_test(network_quic_connection_module_test unit/quic_connection_test.cpp)
 add_network_test(network_quic_socket_construction_test unit/quic_socket_construction_test.cpp)
 message(STATUS "QUIC protocol module unit tests enabled (Issue #974)")
 

--- a/tests/unit/quic_connection_test.cpp
+++ b/tests/unit/quic_connection_test.cpp
@@ -1,0 +1,529 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+*****************************************************************************/
+
+#include "internal/protocols/quic/connection.h"
+#include <gtest/gtest.h>
+
+#include "kcenon/network/detail/protocols/quic/connection_id.h"
+
+namespace quic = kcenon::network::protocols::quic;
+
+/**
+ * @file quic_connection_test.cpp
+ * @brief Unit tests for QUIC connection state machine (RFC 9000 Section 5)
+ *
+ * Tests validate:
+ * - Client and server construction with initial state
+ * - Connection ID accessors: local_cid(), initial_dcid(), remote_cid()
+ * - Statistics: bytes_sent/received, packets_sent/received == 0 initially
+ * - Transport parameter accessors
+ * - has_pending_data() initially false
+ * - close() state transition
+ * - PMTUD enable/disable through connection interface
+ * - State and handshake state string conversions
+ * - CID management: add, retire, duplicates
+ * - Subsystem accessors: flow_control(), streams(), crypto(), pmtud()
+ */
+
+// ============================================================================
+// State String Conversion Tests
+// ============================================================================
+
+class ConnectionStateStringTest : public ::testing::Test
+{
+};
+
+TEST_F(ConnectionStateStringTest, AllConnectionStates)
+{
+    EXPECT_STREQ(quic::connection_state_to_string(quic::connection_state::idle), "idle");
+    EXPECT_STREQ(quic::connection_state_to_string(quic::connection_state::handshaking),
+                 "handshaking");
+    EXPECT_STREQ(quic::connection_state_to_string(quic::connection_state::connected),
+                 "connected");
+    EXPECT_STREQ(quic::connection_state_to_string(quic::connection_state::closing), "closing");
+    EXPECT_STREQ(quic::connection_state_to_string(quic::connection_state::draining),
+                 "draining");
+    EXPECT_STREQ(quic::connection_state_to_string(quic::connection_state::closed), "closed");
+}
+
+TEST_F(ConnectionStateStringTest, AllHandshakeStates)
+{
+    EXPECT_STREQ(quic::handshake_state_to_string(quic::handshake_state::initial), "initial");
+    EXPECT_STREQ(
+        quic::handshake_state_to_string(quic::handshake_state::waiting_server_hello),
+        "waiting_server_hello");
+    EXPECT_STREQ(quic::handshake_state_to_string(quic::handshake_state::waiting_finished),
+                 "waiting_finished");
+    EXPECT_STREQ(quic::handshake_state_to_string(quic::handshake_state::complete), "complete");
+}
+
+// ============================================================================
+// Client Construction Tests
+// ============================================================================
+
+class ConnectionClientConstructionTest : public ::testing::Test
+{
+protected:
+    quic::connection_id dcid;
+
+    void SetUp() override
+    {
+        std::vector<uint8_t> dcid_bytes = {0x01, 0x02, 0x03, 0x04};
+        dcid = quic::connection_id(dcid_bytes);
+    }
+};
+
+TEST_F(ConnectionClientConstructionTest, StateIsIdle)
+{
+    quic::connection conn(false, dcid);
+    EXPECT_EQ(conn.state(), quic::connection_state::idle);
+}
+
+TEST_F(ConnectionClientConstructionTest, HandshakeStateIsInitial)
+{
+    quic::connection conn(false, dcid);
+    EXPECT_EQ(conn.handshake_state(), quic::handshake_state::initial);
+}
+
+TEST_F(ConnectionClientConstructionTest, IsNotServer)
+{
+    quic::connection conn(false, dcid);
+    EXPECT_FALSE(conn.is_server());
+}
+
+TEST_F(ConnectionClientConstructionTest, IsNotEstablished)
+{
+    quic::connection conn(false, dcid);
+    EXPECT_FALSE(conn.is_established());
+}
+
+TEST_F(ConnectionClientConstructionTest, IsNotDraining)
+{
+    quic::connection conn(false, dcid);
+    EXPECT_FALSE(conn.is_draining());
+}
+
+TEST_F(ConnectionClientConstructionTest, IsNotClosed)
+{
+    quic::connection conn(false, dcid);
+    EXPECT_FALSE(conn.is_closed());
+}
+
+TEST_F(ConnectionClientConstructionTest, LocalCidIsNonEmpty)
+{
+    quic::connection conn(false, dcid);
+    EXPECT_FALSE(conn.local_cid().empty());
+}
+
+TEST_F(ConnectionClientConstructionTest, InitialDcidMatchesInput)
+{
+    quic::connection conn(false, dcid);
+    EXPECT_EQ(conn.initial_dcid(), dcid);
+}
+
+TEST_F(ConnectionClientConstructionTest, RemoteCidMatchesDcid)
+{
+    quic::connection conn(false, dcid);
+    EXPECT_EQ(conn.remote_cid(), dcid);
+}
+
+TEST_F(ConnectionClientConstructionTest, NoCloseErrorCode)
+{
+    quic::connection conn(false, dcid);
+    EXPECT_FALSE(conn.close_error_code().has_value());
+}
+
+TEST_F(ConnectionClientConstructionTest, CloseReasonEmpty)
+{
+    quic::connection conn(false, dcid);
+    EXPECT_TRUE(conn.close_reason().empty());
+}
+
+// ============================================================================
+// Server Construction Tests
+// ============================================================================
+
+class ConnectionServerConstructionTest : public ::testing::Test
+{
+protected:
+    quic::connection_id dcid;
+
+    void SetUp() override
+    {
+        std::vector<uint8_t> dcid_bytes = {0x05, 0x06, 0x07, 0x08};
+        dcid = quic::connection_id(dcid_bytes);
+    }
+};
+
+TEST_F(ConnectionServerConstructionTest, StateIsIdle)
+{
+    quic::connection conn(true, dcid);
+    EXPECT_EQ(conn.state(), quic::connection_state::idle);
+}
+
+TEST_F(ConnectionServerConstructionTest, IsServer)
+{
+    quic::connection conn(true, dcid);
+    EXPECT_TRUE(conn.is_server());
+}
+
+TEST_F(ConnectionServerConstructionTest, IsNotEstablished)
+{
+    quic::connection conn(true, dcid);
+    EXPECT_FALSE(conn.is_established());
+}
+
+// ============================================================================
+// Statistics Tests
+// ============================================================================
+
+class ConnectionStatisticsTest : public ::testing::Test
+{
+protected:
+    quic::connection_id dcid;
+
+    void SetUp() override
+    {
+        std::vector<uint8_t> dcid_bytes = {0x01, 0x02};
+        dcid = quic::connection_id(dcid_bytes);
+    }
+};
+
+TEST_F(ConnectionStatisticsTest, BytesSentInitiallyZero)
+{
+    quic::connection conn(false, dcid);
+    EXPECT_EQ(conn.bytes_sent(), 0);
+}
+
+TEST_F(ConnectionStatisticsTest, BytesReceivedInitiallyZero)
+{
+    quic::connection conn(false, dcid);
+    EXPECT_EQ(conn.bytes_received(), 0);
+}
+
+TEST_F(ConnectionStatisticsTest, PacketsSentInitiallyZero)
+{
+    quic::connection conn(false, dcid);
+    EXPECT_EQ(conn.packets_sent(), 0);
+}
+
+TEST_F(ConnectionStatisticsTest, PacketsReceivedInitiallyZero)
+{
+    quic::connection conn(false, dcid);
+    EXPECT_EQ(conn.packets_received(), 0);
+}
+
+// ============================================================================
+// Transport Parameter Tests
+// ============================================================================
+
+class ConnectionTransportParamsTest : public ::testing::Test
+{
+protected:
+    quic::connection_id dcid;
+
+    void SetUp() override
+    {
+        std::vector<uint8_t> dcid_bytes = {0x01, 0x02};
+        dcid = quic::connection_id(dcid_bytes);
+    }
+};
+
+TEST_F(ConnectionTransportParamsTest, SetLocalParams)
+{
+    quic::connection conn(false, dcid);
+
+    quic::transport_parameters params;
+    params.initial_max_data = 1048576;
+    params.initial_max_streams_bidi = 100;
+    params.initial_max_streams_uni = 50;
+
+    conn.set_local_params(params);
+
+    auto& lp = conn.local_params();
+    EXPECT_EQ(lp.initial_max_data, 1048576);
+    EXPECT_EQ(lp.initial_max_streams_bidi, 100);
+    EXPECT_EQ(lp.initial_max_streams_uni, 50);
+}
+
+TEST_F(ConnectionTransportParamsTest, SetRemoteParams)
+{
+    quic::connection conn(false, dcid);
+
+    quic::transport_parameters params;
+    params.initial_max_data = 2097152;
+    params.initial_max_streams_bidi = 200;
+    params.active_connection_id_limit = 4;
+    params.max_idle_timeout = 30000;
+
+    conn.set_remote_params(params);
+
+    auto& rp = conn.remote_params();
+    EXPECT_EQ(rp.initial_max_data, 2097152);
+    EXPECT_EQ(rp.initial_max_streams_bidi, 200);
+    EXPECT_EQ(rp.active_connection_id_limit, 4);
+}
+
+// ============================================================================
+// Pending Data Tests
+// ============================================================================
+
+class ConnectionPendingDataTest : public ::testing::Test
+{
+};
+
+TEST_F(ConnectionPendingDataTest, InitiallyNoPendingData)
+{
+    std::vector<uint8_t> dcid_bytes = {0x01, 0x02};
+    quic::connection conn(false, quic::connection_id(dcid_bytes));
+    EXPECT_FALSE(conn.has_pending_data());
+}
+
+TEST_F(ConnectionPendingDataTest, ReceiveEmptyPacketFails)
+{
+    std::vector<uint8_t> dcid_bytes = {0x01, 0x02};
+    quic::connection conn(false, quic::connection_id(dcid_bytes));
+
+    std::vector<uint8_t> empty_packet;
+    auto result = conn.receive_packet(empty_packet);
+    EXPECT_FALSE(result.is_ok());
+}
+
+// ============================================================================
+// Close Tests
+// ============================================================================
+
+class ConnectionCloseTest : public ::testing::Test
+{
+protected:
+    quic::connection_id dcid;
+
+    void SetUp() override
+    {
+        std::vector<uint8_t> dcid_bytes = {0x01, 0x02};
+        dcid = quic::connection_id(dcid_bytes);
+    }
+};
+
+TEST_F(ConnectionCloseTest, CloseIdleConnection)
+{
+    quic::connection conn(false, dcid);
+    auto result = conn.close(0, "test close");
+    EXPECT_TRUE(result.is_ok());
+    EXPECT_TRUE(conn.is_draining() || conn.is_closed());
+}
+
+TEST_F(ConnectionCloseTest, CloseWithErrorCode)
+{
+    quic::connection conn(false, dcid);
+    auto result = conn.close(0x0A, "flow control error");
+    EXPECT_TRUE(result.is_ok());
+}
+
+// ============================================================================
+// PMTUD through Connection Interface Tests
+// ============================================================================
+
+class ConnectionPmtudTest : public ::testing::Test
+{
+protected:
+    quic::connection_id dcid;
+
+    void SetUp() override
+    {
+        std::vector<uint8_t> dcid_bytes = {0x01, 0x02};
+        dcid = quic::connection_id(dcid_bytes);
+    }
+};
+
+TEST_F(ConnectionPmtudTest, PmtudInitiallyDisabled)
+{
+    quic::connection conn(false, dcid);
+    EXPECT_FALSE(conn.pmtud_enabled());
+    EXPECT_EQ(conn.path_mtu(), 1200);
+}
+
+TEST_F(ConnectionPmtudTest, EnablePmtud)
+{
+    quic::connection conn(false, dcid);
+    conn.enable_pmtud();
+    EXPECT_TRUE(conn.pmtud_enabled());
+}
+
+TEST_F(ConnectionPmtudTest, DisablePmtud)
+{
+    quic::connection conn(false, dcid);
+    conn.enable_pmtud();
+    conn.disable_pmtud();
+    EXPECT_FALSE(conn.pmtud_enabled());
+    EXPECT_EQ(conn.path_mtu(), 1200);
+}
+
+TEST_F(ConnectionPmtudTest, PmtudControllerAccess)
+{
+    quic::connection conn(false, dcid);
+    auto& pmtud = conn.pmtud();
+    EXPECT_EQ(pmtud.state(), quic::pmtud_state::disabled);
+
+    const auto& cpmtud = std::as_const(conn).pmtud();
+    EXPECT_EQ(cpmtud.state(), quic::pmtud_state::disabled);
+}
+
+// ============================================================================
+// CID Management Tests
+// ============================================================================
+
+class ConnectionCidManagementTest : public ::testing::Test
+{
+protected:
+    quic::connection_id dcid;
+
+    void SetUp() override
+    {
+        std::vector<uint8_t> dcid_bytes = {0x01, 0x02};
+        dcid = quic::connection_id(dcid_bytes);
+    }
+};
+
+TEST_F(ConnectionCidManagementTest, AddLocalCid)
+{
+    quic::connection conn(false, dcid);
+    auto new_cid = quic::connection_id::generate();
+    auto result = conn.add_local_cid(new_cid, 1);
+    EXPECT_TRUE(result.is_ok());
+}
+
+TEST_F(ConnectionCidManagementTest, AddDuplicateSequenceFails)
+{
+    quic::connection conn(false, dcid);
+    auto cid1 = quic::connection_id::generate();
+    auto cid2 = quic::connection_id::generate();
+
+    auto r1 = conn.add_local_cid(cid1, 1);
+    EXPECT_TRUE(r1.is_ok());
+
+    auto r2 = conn.add_local_cid(cid2, 1);
+    EXPECT_FALSE(r2.is_ok());
+}
+
+TEST_F(ConnectionCidManagementTest, RetireExistingCid)
+{
+    quic::connection conn(false, dcid);
+    auto new_cid = quic::connection_id::generate();
+    (void)conn.add_local_cid(new_cid, 1);
+
+    auto result = conn.retire_cid(1);
+    EXPECT_TRUE(result.is_ok());
+}
+
+TEST_F(ConnectionCidManagementTest, RetireNonExistentCidFails)
+{
+    quic::connection conn(false, dcid);
+    auto result = conn.retire_cid(99);
+    EXPECT_FALSE(result.is_ok());
+}
+
+TEST_F(ConnectionCidManagementTest, RetireLastCidFails)
+{
+    quic::connection conn(false, dcid);
+    auto result = conn.retire_cid(0);
+    EXPECT_FALSE(result.is_ok());
+}
+
+// ============================================================================
+// Subsystem Accessor Tests
+// ============================================================================
+
+class ConnectionSubsystemAccessTest : public ::testing::Test
+{
+};
+
+TEST_F(ConnectionSubsystemAccessTest, FlowControlAccess)
+{
+    std::vector<uint8_t> dcid_bytes = {0x01, 0x02};
+    quic::connection conn(false, quic::connection_id(dcid_bytes));
+
+    auto& fc = conn.flow_control();
+    const auto& cfc = std::as_const(conn).flow_control();
+    (void)fc;
+    (void)cfc;
+}
+
+TEST_F(ConnectionSubsystemAccessTest, StreamManagerAccess)
+{
+    std::vector<uint8_t> dcid_bytes = {0x01, 0x02};
+    quic::connection conn(false, quic::connection_id(dcid_bytes));
+
+    auto& sm = conn.streams();
+    const auto& csm = std::as_const(conn).streams();
+    (void)sm;
+    (void)csm;
+}
+
+TEST_F(ConnectionSubsystemAccessTest, CryptoAccess)
+{
+    std::vector<uint8_t> dcid_bytes = {0x01, 0x02};
+    quic::connection conn(false, quic::connection_id(dcid_bytes));
+
+    auto& crypto = conn.crypto();
+    const auto& ccrypto = std::as_const(conn).crypto();
+    EXPECT_FALSE(crypto.is_handshake_complete());
+    EXPECT_FALSE(ccrypto.is_handshake_complete());
+}
+
+TEST_F(ConnectionSubsystemAccessTest, PeerCidManagerAccess)
+{
+    std::vector<uint8_t> dcid_bytes = {0x01, 0x02};
+    quic::connection conn(false, quic::connection_id(dcid_bytes));
+
+    auto& mgr = conn.peer_cid_manager();
+    const auto& cmgr = std::as_const(conn).peer_cid_manager();
+    (void)mgr;
+    (void)cmgr;
+}
+
+// ============================================================================
+// Handshake Tests
+// ============================================================================
+
+class ConnectionHandshakeTest : public ::testing::Test
+{
+};
+
+TEST_F(ConnectionHandshakeTest, ServerCannotStartHandshake)
+{
+    std::vector<uint8_t> dcid_bytes = {0x01, 0x02};
+    quic::connection conn(true, quic::connection_id(dcid_bytes));
+
+    auto result = conn.start_handshake("localhost");
+    EXPECT_FALSE(result.is_ok());
+}
+
+TEST_F(ConnectionHandshakeTest, ClientStartHandshake)
+{
+    std::vector<uint8_t> dcid_bytes = {0x01, 0x02, 0x03, 0x04};
+    quic::connection conn(false, quic::connection_id(dcid_bytes));
+
+    auto result = conn.start_handshake("localhost");
+    ASSERT_TRUE(result.is_ok());
+
+    EXPECT_EQ(conn.state(), quic::connection_state::handshaking);
+    EXPECT_EQ(conn.handshake_state(), quic::handshake_state::waiting_server_hello);
+    EXPECT_FALSE(conn.is_established());
+}
+
+TEST_F(ConnectionHandshakeTest, DoubleStartHandshakeFails)
+{
+    std::vector<uint8_t> dcid_bytes = {0x01, 0x02, 0x03, 0x04};
+    quic::connection conn(false, quic::connection_id(dcid_bytes));
+
+    auto r1 = conn.start_handshake("localhost");
+    ASSERT_TRUE(r1.is_ok());
+
+    auto r2 = conn.start_handshake("localhost");
+    EXPECT_FALSE(r2.is_ok());
+}

--- a/tests/unit/quic_crypto_test.cpp
+++ b/tests/unit/quic_crypto_test.cpp
@@ -1,0 +1,426 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+*****************************************************************************/
+
+#include "internal/protocols/quic/crypto.h"
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+#include "kcenon/network/detail/protocols/quic/connection_id.h"
+#include "internal/protocols/quic/keys.h"
+
+namespace quic = kcenon::network::protocols::quic;
+
+/**
+ * @file quic_crypto_test.cpp
+ * @brief Unit tests for QUIC crypto handler, HKDF, initial keys, and packet protection
+ *
+ * Tests validate:
+ * - quic_crypto default construction and initial state
+ * - is_handshake_complete(), current_level(), key_phase()
+ * - init_client(), init_server() behavior
+ * - HKDF extract/expand with known inputs
+ * - initial_keys::derive with known connection ID
+ * - Packet protection round-trip
+ * - Header protection round-trip
+ * - Move semantics for quic_crypto
+ * - Key setting and retrieval
+ */
+
+// ============================================================================
+// quic_crypto Default State Tests
+// ============================================================================
+
+class QuicCryptoDefaultTest : public ::testing::Test
+{
+};
+
+TEST_F(QuicCryptoDefaultTest, HandshakeNotComplete)
+{
+    quic::quic_crypto crypto;
+    EXPECT_FALSE(crypto.is_handshake_complete());
+}
+
+TEST_F(QuicCryptoDefaultTest, CurrentLevelIsInitial)
+{
+    quic::quic_crypto crypto;
+    EXPECT_EQ(crypto.current_level(), quic::encryption_level::initial);
+}
+
+TEST_F(QuicCryptoDefaultTest, KeyPhaseIsZero)
+{
+    quic::quic_crypto crypto;
+    EXPECT_EQ(crypto.key_phase(), 0);
+}
+
+TEST_F(QuicCryptoDefaultTest, EarlyDataNotAccepted)
+{
+    quic::quic_crypto crypto;
+    EXPECT_FALSE(crypto.is_early_data_accepted());
+}
+
+TEST_F(QuicCryptoDefaultTest, NoZeroRttKeys)
+{
+    quic::quic_crypto crypto;
+    EXPECT_FALSE(crypto.has_zero_rtt_keys());
+}
+
+TEST_F(QuicCryptoDefaultTest, GetAlpnReturnsEmpty)
+{
+    quic::quic_crypto crypto;
+    EXPECT_TRUE(crypto.get_alpn().empty());
+}
+
+TEST_F(QuicCryptoDefaultTest, MissingReadKeysReturnError)
+{
+    quic::quic_crypto crypto;
+    auto result = crypto.get_read_keys(quic::encryption_level::application);
+    EXPECT_FALSE(result.is_ok());
+}
+
+TEST_F(QuicCryptoDefaultTest, MissingWriteKeysReturnError)
+{
+    quic::quic_crypto crypto;
+    auto result = crypto.get_write_keys(quic::encryption_level::application);
+    EXPECT_FALSE(result.is_ok());
+}
+
+// ============================================================================
+// quic_crypto Init Tests
+// ============================================================================
+
+class QuicCryptoInitTest : public ::testing::Test
+{
+};
+
+TEST_F(QuicCryptoInitTest, InitClientSucceeds)
+{
+    quic::quic_crypto crypto;
+    auto result = crypto.init_client("localhost");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_FALSE(crypto.is_server());
+}
+
+TEST_F(QuicCryptoInitTest, InitServerFailsWithoutValidCerts)
+{
+    quic::quic_crypto crypto;
+    auto result = crypto.init_server("nonexistent_cert.pem", "nonexistent_key.pem");
+    EXPECT_FALSE(result.is_ok());
+}
+
+// ============================================================================
+// HKDF Tests
+// ============================================================================
+
+class HkdfTest : public ::testing::Test
+{
+};
+
+TEST_F(HkdfTest, ExtractProducesNonZeroResult)
+{
+    // Use QUIC v1 initial salt
+    std::array<uint8_t, 20> salt = {
+        0x38, 0x76, 0x2c, 0xf7, 0xf5, 0x59, 0x34, 0xb3, 0x4d, 0x17,
+        0x9a, 0xe6, 0xa4, 0xc8, 0x0c, 0xad, 0xcc, 0xbb, 0x7f, 0x0a};
+    std::vector<uint8_t> ikm = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+
+    auto result = quic::hkdf::extract(salt, ikm);
+    ASSERT_TRUE(result.is_ok());
+
+    auto& prk = result.value();
+    EXPECT_EQ(prk.size(), quic::secret_size);
+
+    bool all_zero = std::all_of(prk.begin(), prk.end(),
+                                [](uint8_t b) { return b == 0; });
+    EXPECT_FALSE(all_zero);
+}
+
+TEST_F(HkdfTest, ExpandProducesCorrectLength)
+{
+    std::array<uint8_t, 32> prk;
+    prk.fill(0xAB);
+    std::vector<uint8_t> info = {0x01, 0x02, 0x03};
+
+    auto result16 = quic::hkdf::expand(prk, info, 16);
+    ASSERT_TRUE(result16.is_ok());
+    EXPECT_EQ(result16.value().size(), 16);
+
+    auto result32 = quic::hkdf::expand(prk, info, 32);
+    ASSERT_TRUE(result32.is_ok());
+    EXPECT_EQ(result32.value().size(), 32);
+}
+
+TEST_F(HkdfTest, ExpandLabelWithQuicLabels)
+{
+    std::array<uint8_t, 32> secret;
+    secret.fill(0xAB);
+
+    auto key_result = quic::hkdf::expand_label(
+        secret, "quic key", {}, quic::aes_128_key_size);
+    ASSERT_TRUE(key_result.is_ok());
+    EXPECT_EQ(key_result.value().size(), quic::aes_128_key_size);
+
+    auto iv_result = quic::hkdf::expand_label(
+        secret, "quic iv", {}, quic::aead_iv_size);
+    ASSERT_TRUE(iv_result.is_ok());
+    EXPECT_EQ(iv_result.value().size(), quic::aead_iv_size);
+
+    auto hp_result = quic::hkdf::expand_label(
+        secret, "quic hp", {}, quic::hp_key_size);
+    ASSERT_TRUE(hp_result.is_ok());
+    EXPECT_EQ(hp_result.value().size(), quic::hp_key_size);
+}
+
+// ============================================================================
+// initial_keys Tests
+// ============================================================================
+
+class InitialKeysTest : public ::testing::Test
+{
+protected:
+    quic::connection_id test_dcid;
+
+    void SetUp() override
+    {
+        // RFC 9001 Appendix A.1 test vector DCID
+        std::vector<uint8_t> dcid_bytes = {
+            0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08};
+        test_dcid = quic::connection_id(dcid_bytes);
+    }
+};
+
+TEST_F(InitialKeysTest, DeriveProducesValidKeys)
+{
+    auto result = quic::initial_keys::derive(test_dcid);
+    ASSERT_TRUE(result.is_ok());
+
+    auto& keys = result.value();
+    EXPECT_TRUE(keys.is_valid());
+    EXPECT_TRUE(keys.read.is_valid());
+    EXPECT_TRUE(keys.write.is_valid());
+}
+
+TEST_F(InitialKeysTest, ClientAndServerKeysDiffer)
+{
+    auto result = quic::initial_keys::derive(test_dcid);
+    ASSERT_TRUE(result.is_ok());
+
+    auto& keys = result.value();
+    EXPECT_NE(keys.read.key, keys.write.key);
+    EXPECT_NE(keys.read.iv, keys.write.iv);
+    EXPECT_NE(keys.read.hp_key, keys.write.hp_key);
+}
+
+TEST_F(InitialKeysTest, DeterministicDerivation)
+{
+    auto result1 = quic::initial_keys::derive(test_dcid);
+    auto result2 = quic::initial_keys::derive(test_dcid);
+
+    ASSERT_TRUE(result1.is_ok());
+    ASSERT_TRUE(result2.is_ok());
+
+    EXPECT_EQ(result1.value().write.key, result2.value().write.key);
+    EXPECT_EQ(result1.value().write.iv, result2.value().write.iv);
+    EXPECT_EQ(result1.value().read.key, result2.value().read.key);
+    EXPECT_EQ(result1.value().read.iv, result2.value().read.iv);
+}
+
+TEST_F(InitialKeysTest, DifferentCidProducesDifferentKeys)
+{
+    std::vector<uint8_t> other_dcid_bytes = {0x01, 0x02, 0x03, 0x04};
+    quic::connection_id other_dcid(other_dcid_bytes);
+
+    auto result1 = quic::initial_keys::derive(test_dcid);
+    auto result2 = quic::initial_keys::derive(other_dcid);
+
+    ASSERT_TRUE(result1.is_ok());
+    ASSERT_TRUE(result2.is_ok());
+
+    EXPECT_NE(result1.value().write.key, result2.value().write.key);
+}
+
+// ============================================================================
+// quic_crypto Derive Initial Secrets Tests
+// ============================================================================
+
+class QuicCryptoDeriveTest : public ::testing::Test
+{
+};
+
+TEST_F(QuicCryptoDeriveTest, DeriveInitialSecretsAfterInit)
+{
+    quic::quic_crypto crypto;
+    auto init_result = crypto.init_client("localhost");
+    ASSERT_TRUE(init_result.is_ok());
+
+    std::vector<uint8_t> dcid_bytes = {0x83, 0x94, 0xc8, 0xf0, 0x3e, 0x51, 0x57, 0x08};
+    quic::connection_id dcid(dcid_bytes);
+
+    auto derive_result = crypto.derive_initial_secrets(dcid);
+    ASSERT_TRUE(derive_result.is_ok());
+
+    auto write_keys = crypto.get_write_keys(quic::encryption_level::initial);
+    ASSERT_TRUE(write_keys.is_ok());
+    EXPECT_TRUE(write_keys.value().is_valid());
+
+    auto read_keys = crypto.get_read_keys(quic::encryption_level::initial);
+    ASSERT_TRUE(read_keys.is_ok());
+    EXPECT_TRUE(read_keys.value().is_valid());
+}
+
+// ============================================================================
+// quic_crypto Set/Get Keys Tests
+// ============================================================================
+
+class QuicCryptoSetKeysTest : public ::testing::Test
+{
+};
+
+TEST_F(QuicCryptoSetKeysTest, SetAndGetKeys)
+{
+    quic::quic_crypto crypto;
+
+    quic::quic_keys read_keys, write_keys;
+    read_keys.key.fill(0xAA);
+    write_keys.key.fill(0xBB);
+
+    crypto.set_keys(quic::encryption_level::handshake, read_keys, write_keys);
+
+    auto get_read = crypto.get_read_keys(quic::encryption_level::handshake);
+    ASSERT_TRUE(get_read.is_ok());
+    EXPECT_EQ(get_read.value().key, read_keys.key);
+
+    auto get_write = crypto.get_write_keys(quic::encryption_level::handshake);
+    ASSERT_TRUE(get_write.is_ok());
+    EXPECT_EQ(get_write.value().key, write_keys.key);
+}
+
+// ============================================================================
+// quic_crypto Move Semantics Tests
+// ============================================================================
+
+class QuicCryptoMoveTest : public ::testing::Test
+{
+};
+
+TEST_F(QuicCryptoMoveTest, MoveConstruction)
+{
+    quic::quic_crypto crypto1;
+    auto result = crypto1.init_client("localhost");
+    ASSERT_TRUE(result.is_ok());
+
+    quic::quic_crypto crypto2(std::move(crypto1));
+    EXPECT_FALSE(crypto2.is_server());
+}
+
+TEST_F(QuicCryptoMoveTest, MoveAssignment)
+{
+    quic::quic_crypto crypto1;
+    auto result = crypto1.init_client("localhost");
+    ASSERT_TRUE(result.is_ok());
+
+    quic::quic_crypto crypto2;
+    crypto2 = std::move(crypto1);
+    EXPECT_FALSE(crypto2.is_server());
+}
+
+// ============================================================================
+// Packet Protection Tests
+// ============================================================================
+
+class PacketProtectionTest : public ::testing::Test
+{
+protected:
+    quic::quic_keys test_keys;
+
+    void SetUp() override
+    {
+        for (size_t i = 0; i < test_keys.key.size(); ++i)
+            test_keys.key[i] = static_cast<uint8_t>(i);
+        for (size_t i = 0; i < test_keys.iv.size(); ++i)
+            test_keys.iv[i] = static_cast<uint8_t>(i + 16);
+        for (size_t i = 0; i < test_keys.hp_key.size(); ++i)
+            test_keys.hp_key[i] = static_cast<uint8_t>(i + 32);
+    }
+};
+
+TEST_F(PacketProtectionTest, ProtectUnprotectRoundTrip)
+{
+    std::vector<uint8_t> header = {0xC0, 0x00, 0x00, 0x01, 0x08};
+    std::vector<uint8_t> payload = {'H', 'e', 'l', 'l', 'o', ' ', 'Q', 'U', 'I', 'C'};
+    uint64_t packet_number = 42;
+
+    auto protect_result = quic::packet_protection::protect(
+        test_keys, header, payload, packet_number);
+    ASSERT_TRUE(protect_result.is_ok());
+
+    auto& protected_packet = protect_result.value();
+    EXPECT_GT(protected_packet.size(), header.size() + payload.size());
+
+    auto unprotect_result = quic::packet_protection::unprotect(
+        test_keys, protected_packet, header.size(), packet_number);
+    ASSERT_TRUE(unprotect_result.is_ok());
+
+    auto& [recovered_header, recovered_payload] = unprotect_result.value();
+    EXPECT_EQ(recovered_header, header);
+    EXPECT_EQ(recovered_payload, payload);
+}
+
+TEST_F(PacketProtectionTest, TamperedDataFailsAuthentication)
+{
+    std::vector<uint8_t> header = {0xC0, 0x00, 0x00, 0x01, 0x08};
+    std::vector<uint8_t> payload = {'S', 'e', 'c', 'r', 'e', 't'};
+    uint64_t packet_number = 100;
+
+    auto protect_result = quic::packet_protection::protect(
+        test_keys, header, payload, packet_number);
+    ASSERT_TRUE(protect_result.is_ok());
+
+    auto& protected_packet = protect_result.value();
+    if (protected_packet.size() > header.size() + 1)
+    {
+        protected_packet[header.size() + 1] ^= 0xFF;
+    }
+
+    auto unprotect_result = quic::packet_protection::unprotect(
+        test_keys, protected_packet, header.size(), packet_number);
+    EXPECT_FALSE(unprotect_result.is_ok());
+}
+
+TEST_F(PacketProtectionTest, GenerateHpMask)
+{
+    std::vector<uint8_t> sample(quic::hp_sample_size, 0xAB);
+
+    auto result = quic::packet_protection::generate_hp_mask(test_keys.hp_key, sample);
+    ASSERT_TRUE(result.is_ok());
+
+    auto& mask = result.value();
+    EXPECT_EQ(mask.size(), 5);
+}
+
+TEST_F(PacketProtectionTest, HeaderProtectionRoundTrip)
+{
+    std::vector<uint8_t> header = {0xC3, 0x00, 0x00, 0x01, 0x08, 0x00, 0x00, 0x00, 0x01};
+    std::vector<uint8_t> original_header = header;
+    std::vector<uint8_t> sample(quic::hp_sample_size, 0x55);
+    size_t pn_offset = 5;
+    size_t pn_length = 4;
+
+    auto protect_result = quic::packet_protection::protect_header(
+        test_keys, header, pn_offset, pn_length, sample);
+    ASSERT_TRUE(protect_result.is_ok());
+
+    EXPECT_NE(header, original_header);
+
+    auto unprotect_result = quic::packet_protection::unprotect_header(
+        test_keys, header, pn_offset, sample);
+    ASSERT_TRUE(unprotect_result.is_ok());
+
+    auto [first_byte, recovered_pn_len] = unprotect_result.value();
+    EXPECT_EQ(recovered_pn_len, pn_length);
+    EXPECT_EQ(header, original_header);
+}

--- a/tests/unit/quic_pmtud_controller_test.cpp
+++ b/tests/unit/quic_pmtud_controller_test.cpp
@@ -1,0 +1,444 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+*****************************************************************************/
+
+#include "internal/protocols/quic/pmtud_controller.h"
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+namespace quic = kcenon::network::protocols::quic;
+
+using namespace std::chrono_literals;
+
+/**
+ * @file quic_pmtud_controller_test.cpp
+ * @brief Unit tests for QUIC PMTUD controller (RFC 8899 DPLPMTUD)
+ *
+ * Tests validate:
+ * - Default and custom config construction
+ * - State transitions: enable(), disable(), reset()
+ * - State queries: is_enabled(), is_search_complete()
+ * - MTU accessors: current_mtu(), min_mtu(), max_mtu()
+ * - Probing: should_probe(), probe_size()
+ * - Probe acknowledgment and loss handling
+ * - Packet Too Big handling
+ * - Binary search convergence
+ * - Black hole detection
+ * - Timeout handling
+ * - State string conversion
+ */
+
+// ============================================================================
+// Default Construction Tests
+// ============================================================================
+
+class PmtudDefaultConstructionTest : public ::testing::Test
+{
+};
+
+TEST_F(PmtudDefaultConstructionTest, StateIsDisabled)
+{
+    quic::pmtud_controller pmtud;
+    EXPECT_EQ(pmtud.state(), quic::pmtud_state::disabled);
+}
+
+TEST_F(PmtudDefaultConstructionTest, IsNotEnabled)
+{
+    quic::pmtud_controller pmtud;
+    EXPECT_FALSE(pmtud.is_enabled());
+}
+
+TEST_F(PmtudDefaultConstructionTest, IsNotSearchComplete)
+{
+    quic::pmtud_controller pmtud;
+    EXPECT_FALSE(pmtud.is_search_complete());
+}
+
+TEST_F(PmtudDefaultConstructionTest, CurrentMtuIs1200)
+{
+    quic::pmtud_controller pmtud;
+    EXPECT_EQ(pmtud.current_mtu(), 1200);
+}
+
+TEST_F(PmtudDefaultConstructionTest, MinMtuIs1200)
+{
+    quic::pmtud_controller pmtud;
+    EXPECT_EQ(pmtud.min_mtu(), 1200);
+}
+
+TEST_F(PmtudDefaultConstructionTest, MaxMtuIs1500)
+{
+    quic::pmtud_controller pmtud;
+    EXPECT_EQ(pmtud.max_mtu(), 1500);
+}
+
+// ============================================================================
+// Custom Configuration Tests
+// ============================================================================
+
+class PmtudCustomConfigTest : public ::testing::Test
+{
+};
+
+TEST_F(PmtudCustomConfigTest, CustomMinMaxMtu)
+{
+    quic::pmtud_config config;
+    config.min_mtu = 1280;
+    config.max_probe_mtu = 9000;
+
+    quic::pmtud_controller pmtud(config);
+
+    EXPECT_EQ(pmtud.min_mtu(), 1280);
+    EXPECT_EQ(pmtud.max_mtu(), 9000);
+    EXPECT_EQ(pmtud.current_mtu(), 1280);
+}
+
+TEST_F(PmtudCustomConfigTest, JumboFrameDiscovery)
+{
+    quic::pmtud_config config;
+    config.min_mtu = 1200;
+    config.max_probe_mtu = 9000;
+
+    quic::pmtud_controller pmtud(config);
+    pmtud.enable();
+
+    size_t iterations = 0;
+    while (!pmtud.is_search_complete() && iterations < 50)
+    {
+        auto probe_size = pmtud.probe_size();
+        if (!probe_size.has_value())
+        {
+            break;
+        }
+
+        pmtud.on_probe_sent(probe_size.value(), std::chrono::steady_clock::now());
+        pmtud.on_probe_acked(probe_size.value());
+        ++iterations;
+    }
+
+    EXPECT_GT(pmtud.current_mtu(), 8000);
+}
+
+// ============================================================================
+// Enable/Disable Tests
+// ============================================================================
+
+class PmtudEnableDisableTest : public ::testing::Test
+{
+protected:
+    quic::pmtud_controller pmtud_;
+};
+
+TEST_F(PmtudEnableDisableTest, EnableTransitionsToSearching)
+{
+    pmtud_.enable();
+    EXPECT_TRUE(pmtud_.is_enabled());
+    EXPECT_EQ(pmtud_.state(), quic::pmtud_state::searching);
+}
+
+TEST_F(PmtudEnableDisableTest, DisableTransitionsToDisabled)
+{
+    pmtud_.enable();
+    pmtud_.disable();
+
+    EXPECT_FALSE(pmtud_.is_enabled());
+    EXPECT_EQ(pmtud_.state(), quic::pmtud_state::disabled);
+    EXPECT_EQ(pmtud_.current_mtu(), 1200);
+}
+
+TEST_F(PmtudEnableDisableTest, ResetReturnsToInitialState)
+{
+    pmtud_.enable();
+    auto probe_size = pmtud_.probe_size();
+    ASSERT_TRUE(probe_size.has_value());
+    pmtud_.on_probe_sent(probe_size.value(), std::chrono::steady_clock::now());
+    pmtud_.on_probe_acked(probe_size.value());
+
+    pmtud_.reset();
+    EXPECT_EQ(pmtud_.state(), quic::pmtud_state::disabled);
+    EXPECT_EQ(pmtud_.current_mtu(), 1200);
+    EXPECT_FALSE(pmtud_.is_enabled());
+}
+
+// ============================================================================
+// Probing Tests
+// ============================================================================
+
+class PmtudProbingTest : public ::testing::Test
+{
+protected:
+    quic::pmtud_controller pmtud_;
+};
+
+TEST_F(PmtudProbingTest, ShouldProbeReturnsFalseWhenDisabled)
+{
+    auto now = std::chrono::steady_clock::now();
+    EXPECT_FALSE(pmtud_.should_probe(now));
+}
+
+TEST_F(PmtudProbingTest, ShouldProbeReturnsTrueWhenEnabled)
+{
+    auto now = std::chrono::steady_clock::now();
+    pmtud_.enable();
+    EXPECT_TRUE(pmtud_.should_probe(now));
+}
+
+TEST_F(PmtudProbingTest, ProbeSizeReturnsNulloptWhenDisabled)
+{
+    EXPECT_FALSE(pmtud_.probe_size().has_value());
+}
+
+TEST_F(PmtudProbingTest, ProbeSizeBetweenMinAndMax)
+{
+    pmtud_.enable();
+    auto probe = pmtud_.probe_size();
+    ASSERT_TRUE(probe.has_value());
+
+    EXPECT_GT(probe.value(), pmtud_.min_mtu());
+    EXPECT_LE(probe.value(), pmtud_.max_mtu());
+}
+
+// ============================================================================
+// Probe Acked/Lost Tests
+// ============================================================================
+
+class PmtudProbeAckedTest : public ::testing::Test
+{
+protected:
+    quic::pmtud_controller pmtud_;
+};
+
+TEST_F(PmtudProbeAckedTest, AckedProbeIncreasesMtu)
+{
+    pmtud_.enable();
+    auto initial_mtu = pmtud_.current_mtu();
+
+    auto probe_size = pmtud_.probe_size();
+    ASSERT_TRUE(probe_size.has_value());
+
+    pmtud_.on_probe_sent(probe_size.value(), std::chrono::steady_clock::now());
+    pmtud_.on_probe_acked(probe_size.value());
+
+    EXPECT_GE(pmtud_.current_mtu(), initial_mtu);
+}
+
+TEST_F(PmtudProbeAckedTest, BinarySearchConvergence)
+{
+    pmtud_.enable();
+
+    size_t iterations = 0;
+    const size_t max_iterations = 20;
+
+    while (!pmtud_.is_search_complete() && iterations < max_iterations)
+    {
+        auto probe_size = pmtud_.probe_size();
+        if (!probe_size.has_value())
+        {
+            break;
+        }
+
+        pmtud_.on_probe_sent(probe_size.value(), std::chrono::steady_clock::now());
+        pmtud_.on_probe_acked(probe_size.value());
+        ++iterations;
+    }
+
+    EXPECT_TRUE(pmtud_.is_search_complete());
+    EXPECT_EQ(pmtud_.state(), quic::pmtud_state::search_complete);
+    EXPECT_GT(pmtud_.current_mtu(), pmtud_.min_mtu());
+    EXPECT_LE(pmtud_.current_mtu(), pmtud_.max_mtu());
+}
+
+class PmtudProbeLostTest : public ::testing::Test
+{
+protected:
+    quic::pmtud_controller pmtud_;
+};
+
+TEST_F(PmtudProbeLostTest, MultipleLossesReduceSearchRange)
+{
+    pmtud_.enable();
+
+    auto initial_probe = pmtud_.probe_size();
+    ASSERT_TRUE(initial_probe.has_value());
+
+    // max_probes defaults to 3, so after 3 failures the range should shrink
+    for (size_t i = 0; i < 3; ++i)
+    {
+        pmtud_.on_probe_sent(initial_probe.value(), std::chrono::steady_clock::now());
+        pmtud_.on_probe_lost(initial_probe.value());
+    }
+
+    EXPECT_EQ(pmtud_.state(), quic::pmtud_state::searching);
+
+    auto next_probe = pmtud_.probe_size();
+    ASSERT_TRUE(next_probe.has_value());
+    EXPECT_LT(next_probe.value(), initial_probe.value());
+}
+
+// ============================================================================
+// Packet Too Big Tests
+// ============================================================================
+
+class PmtudPacketTooBigTest : public ::testing::Test
+{
+protected:
+    quic::pmtud_controller pmtud_;
+};
+
+TEST_F(PmtudPacketTooBigTest, ReducesMtu)
+{
+    pmtud_.enable();
+
+    pmtud_.on_probe_sent(1400, std::chrono::steady_clock::now());
+    pmtud_.on_probe_acked(1400);
+    EXPECT_GE(pmtud_.current_mtu(), 1400);
+
+    pmtud_.on_packet_too_big(1350);
+    EXPECT_LE(pmtud_.current_mtu(), 1350);
+}
+
+TEST_F(PmtudPacketTooBigTest, BelowMinimumTriggersError)
+{
+    pmtud_.enable();
+
+    pmtud_.on_packet_too_big(1000);
+
+    EXPECT_EQ(pmtud_.state(), quic::pmtud_state::error);
+    EXPECT_EQ(pmtud_.current_mtu(), pmtud_.min_mtu());
+}
+
+// ============================================================================
+// Black Hole Detection Tests
+// ============================================================================
+
+class PmtudBlackHoleTest : public ::testing::Test
+{
+protected:
+    quic::pmtud_controller pmtud_;
+};
+
+TEST_F(PmtudBlackHoleTest, ConsecutiveFailuresEnterError)
+{
+    pmtud_.enable();
+
+    auto probe_size = pmtud_.probe_size();
+    ASSERT_TRUE(probe_size.has_value());
+
+    for (size_t i = 0; i < 6; ++i)
+    {
+        pmtud_.on_probe_sent(probe_size.value(), std::chrono::steady_clock::now());
+        pmtud_.on_probe_lost(probe_size.value());
+    }
+
+    EXPECT_EQ(pmtud_.state(), quic::pmtud_state::error);
+    EXPECT_EQ(pmtud_.current_mtu(), pmtud_.min_mtu());
+}
+
+// ============================================================================
+// Timeout Tests
+// ============================================================================
+
+class PmtudTimeoutTest : public ::testing::Test
+{
+protected:
+    quic::pmtud_controller pmtud_;
+};
+
+TEST_F(PmtudTimeoutTest, TimeoutIsSetAfterProbeSent)
+{
+    pmtud_.enable();
+
+    auto probe_size = pmtud_.probe_size();
+    ASSERT_TRUE(probe_size.has_value());
+
+    auto sent_time = std::chrono::steady_clock::now();
+    pmtud_.on_probe_sent(probe_size.value(), sent_time);
+
+    auto timeout = pmtud_.next_timeout();
+    ASSERT_TRUE(timeout.has_value());
+    EXPECT_GT(timeout.value(), sent_time);
+}
+
+TEST_F(PmtudTimeoutTest, TimeoutTriggersLoss)
+{
+    pmtud_.enable();
+
+    auto probe_size = pmtud_.probe_size();
+    ASSERT_TRUE(probe_size.has_value());
+
+    auto sent_time = std::chrono::steady_clock::now();
+    pmtud_.on_probe_sent(probe_size.value(), sent_time);
+
+    auto timeout_time = sent_time + std::chrono::seconds{4};
+    pmtud_.on_timeout(timeout_time);
+
+    EXPECT_EQ(pmtud_.state(), quic::pmtud_state::searching);
+}
+
+// ============================================================================
+// State String Conversion Tests
+// ============================================================================
+
+class PmtudStateToStringTest : public ::testing::Test
+{
+};
+
+TEST_F(PmtudStateToStringTest, AllStates)
+{
+    EXPECT_STREQ(quic::pmtud_state_to_string(quic::pmtud_state::disabled), "disabled");
+    EXPECT_STREQ(quic::pmtud_state_to_string(quic::pmtud_state::base), "base");
+    EXPECT_STREQ(quic::pmtud_state_to_string(quic::pmtud_state::searching), "searching");
+    EXPECT_STREQ(quic::pmtud_state_to_string(quic::pmtud_state::search_complete),
+                 "search_complete");
+    EXPECT_STREQ(quic::pmtud_state_to_string(quic::pmtud_state::error), "error");
+}
+
+// ============================================================================
+// Re-validation Tests
+// ============================================================================
+
+class PmtudRevalidationTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        pmtud_.enable();
+        while (!pmtud_.is_search_complete())
+        {
+            auto probe_size = pmtud_.probe_size();
+            if (!probe_size.has_value())
+            {
+                break;
+            }
+            pmtud_.on_probe_sent(probe_size.value(), std::chrono::steady_clock::now());
+            pmtud_.on_probe_acked(probe_size.value());
+        }
+    }
+
+    quic::pmtud_controller pmtud_;
+};
+
+TEST_F(PmtudRevalidationTest, ProbeSizeEqualsCurrentMtu)
+{
+    ASSERT_TRUE(pmtud_.is_search_complete());
+
+    auto probe_size = pmtud_.probe_size();
+    ASSERT_TRUE(probe_size.has_value());
+    EXPECT_EQ(probe_size.value(), pmtud_.current_mtu());
+}
+
+TEST_F(PmtudRevalidationTest, FailureDuringRevalidation)
+{
+    ASSERT_TRUE(pmtud_.is_search_complete());
+    auto mtu_before = pmtud_.current_mtu();
+
+    pmtud_.on_probe_sent(mtu_before, std::chrono::steady_clock::now());
+    pmtud_.on_probe_lost(mtu_before);
+
+    EXPECT_EQ(pmtud_.state(), quic::pmtud_state::error);
+    EXPECT_EQ(pmtud_.current_mtu(), pmtud_.min_mtu());
+}

--- a/tests/unit/quic_socket_construction_test.cpp
+++ b/tests/unit/quic_socket_construction_test.cpp
@@ -1,0 +1,296 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+*****************************************************************************/
+
+#include "internal/quic_socket.h"
+#include <gtest/gtest.h>
+
+#include <asio.hpp>
+
+namespace internal = kcenon::network::internal;
+
+/**
+ * @file quic_socket_construction_test.cpp
+ * @brief Unit tests for quic_socket construction and initial state
+ *
+ * Tests validate:
+ * - Construction with client and server role
+ * - state() returns idle initially
+ * - is_connected() returns false initially
+ * - role() returns correct role
+ * - Callback setters do not throw
+ * - Move construction preserves role and connection ID
+ * - Connection ID generation produces unique IDs
+ * - Socket access
+ * - Role-based restrictions (connect/accept)
+ * - Close on idle socket
+ */
+
+// ============================================================================
+// Test Fixture
+// ============================================================================
+
+class QuicSocketConstructionTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        io_context_ = std::make_unique<asio::io_context>();
+    }
+
+    void TearDown() override
+    {
+        io_context_->stop();
+        io_context_.reset();
+    }
+
+    std::unique_ptr<asio::io_context> io_context_;
+};
+
+// ============================================================================
+// Client Construction Tests
+// ============================================================================
+
+TEST_F(QuicSocketConstructionTest, ClientRoleIsCorrect)
+{
+    asio::ip::udp::socket socket(*io_context_, asio::ip::udp::v4());
+
+    auto quic = std::make_shared<internal::quic_socket>(
+        std::move(socket), internal::quic_role::client);
+
+    EXPECT_EQ(quic->role(), internal::quic_role::client);
+}
+
+TEST_F(QuicSocketConstructionTest, ClientStateIsIdle)
+{
+    asio::ip::udp::socket socket(*io_context_, asio::ip::udp::v4());
+
+    auto quic = std::make_shared<internal::quic_socket>(
+        std::move(socket), internal::quic_role::client);
+
+    EXPECT_EQ(quic->state(), internal::quic_connection_state::idle);
+}
+
+TEST_F(QuicSocketConstructionTest, ClientIsNotConnected)
+{
+    asio::ip::udp::socket socket(*io_context_, asio::ip::udp::v4());
+
+    auto quic = std::make_shared<internal::quic_socket>(
+        std::move(socket), internal::quic_role::client);
+
+    EXPECT_FALSE(quic->is_connected());
+}
+
+TEST_F(QuicSocketConstructionTest, ClientHandshakeNotComplete)
+{
+    asio::ip::udp::socket socket(*io_context_, asio::ip::udp::v4());
+
+    auto quic = std::make_shared<internal::quic_socket>(
+        std::move(socket), internal::quic_role::client);
+
+    EXPECT_FALSE(quic->is_handshake_complete());
+}
+
+// ============================================================================
+// Server Construction Tests
+// ============================================================================
+
+TEST_F(QuicSocketConstructionTest, ServerRoleIsCorrect)
+{
+    asio::ip::udp::socket socket(*io_context_, asio::ip::udp::v4());
+
+    auto quic = std::make_shared<internal::quic_socket>(
+        std::move(socket), internal::quic_role::server);
+
+    EXPECT_EQ(quic->role(), internal::quic_role::server);
+}
+
+TEST_F(QuicSocketConstructionTest, ServerStateIsIdle)
+{
+    asio::ip::udp::socket socket(*io_context_, asio::ip::udp::v4());
+
+    auto quic = std::make_shared<internal::quic_socket>(
+        std::move(socket), internal::quic_role::server);
+
+    EXPECT_EQ(quic->state(), internal::quic_connection_state::idle);
+}
+
+TEST_F(QuicSocketConstructionTest, ServerIsNotConnected)
+{
+    asio::ip::udp::socket socket(*io_context_, asio::ip::udp::v4());
+
+    auto quic = std::make_shared<internal::quic_socket>(
+        std::move(socket), internal::quic_role::server);
+
+    EXPECT_FALSE(quic->is_connected());
+}
+
+// ============================================================================
+// Callback Registration Tests
+// ============================================================================
+
+TEST_F(QuicSocketConstructionTest, SetStreamDataCallbackNoThrow)
+{
+    asio::ip::udp::socket socket(*io_context_, asio::ip::udp::v4());
+
+    auto quic = std::make_shared<internal::quic_socket>(
+        std::move(socket), internal::quic_role::client);
+
+    EXPECT_NO_THROW(quic->set_stream_data_callback(
+        [](uint64_t, std::span<const uint8_t>, bool) {}));
+}
+
+TEST_F(QuicSocketConstructionTest, SetConnectedCallbackNoThrow)
+{
+    asio::ip::udp::socket socket(*io_context_, asio::ip::udp::v4());
+
+    auto quic = std::make_shared<internal::quic_socket>(
+        std::move(socket), internal::quic_role::client);
+
+    EXPECT_NO_THROW(quic->set_connected_callback([]() {}));
+}
+
+TEST_F(QuicSocketConstructionTest, SetErrorCallbackNoThrow)
+{
+    asio::ip::udp::socket socket(*io_context_, asio::ip::udp::v4());
+
+    auto quic = std::make_shared<internal::quic_socket>(
+        std::move(socket), internal::quic_role::client);
+
+    EXPECT_NO_THROW(quic->set_error_callback([](std::error_code) {}));
+}
+
+TEST_F(QuicSocketConstructionTest, SetCloseCallbackNoThrow)
+{
+    asio::ip::udp::socket socket(*io_context_, asio::ip::udp::v4());
+
+    auto quic = std::make_shared<internal::quic_socket>(
+        std::move(socket), internal::quic_role::client);
+
+    EXPECT_NO_THROW(quic->set_close_callback([](uint64_t, const std::string&) {}));
+}
+
+// ============================================================================
+// Move Construction Tests
+// ============================================================================
+
+TEST_F(QuicSocketConstructionTest, MoveConstructionPreservesRole)
+{
+    asio::ip::udp::socket socket(*io_context_, asio::ip::udp::v4());
+
+    auto quic1 = std::make_shared<internal::quic_socket>(
+        std::move(socket), internal::quic_role::client);
+
+    auto cid1 = quic1->local_connection_id();
+
+    internal::quic_socket quic2(std::move(*quic1));
+
+    EXPECT_EQ(quic2.role(), internal::quic_role::client);
+    EXPECT_EQ(quic2.local_connection_id().to_string(), cid1.to_string());
+}
+
+// ============================================================================
+// Connection ID Generation Tests
+// ============================================================================
+
+TEST_F(QuicSocketConstructionTest, ConnectionIdIsNonEmpty)
+{
+    asio::ip::udp::socket socket(*io_context_, asio::ip::udp::v4());
+
+    auto quic = std::make_shared<internal::quic_socket>(
+        std::move(socket), internal::quic_role::client);
+
+    auto& cid = quic->local_connection_id();
+    EXPECT_GT(cid.length(), 0u);
+    EXPECT_LE(cid.length(), 20u);
+}
+
+TEST_F(QuicSocketConstructionTest, TwoSocketsHaveUniqueConnectionIds)
+{
+    asio::ip::udp::socket socket1(*io_context_, asio::ip::udp::v4());
+    asio::ip::udp::socket socket2(*io_context_, asio::ip::udp::v4());
+
+    auto quic1 = std::make_shared<internal::quic_socket>(
+        std::move(socket1), internal::quic_role::client);
+    auto quic2 = std::make_shared<internal::quic_socket>(
+        std::move(socket2), internal::quic_role::client);
+
+    EXPECT_NE(quic1->local_connection_id().to_string(),
+              quic2->local_connection_id().to_string());
+}
+
+// ============================================================================
+// Socket Access Tests
+// ============================================================================
+
+TEST_F(QuicSocketConstructionTest, UnderlyingSocketIsOpen)
+{
+    asio::ip::udp::socket socket(*io_context_, asio::ip::udp::v4());
+
+    auto quic = std::make_shared<internal::quic_socket>(
+        std::move(socket), internal::quic_role::client);
+
+    auto& sock = quic->socket();
+    EXPECT_TRUE(sock.is_open());
+}
+
+// ============================================================================
+// Role-Based Restriction Tests
+// ============================================================================
+
+TEST_F(QuicSocketConstructionTest, ServerCannotConnect)
+{
+    asio::ip::udp::socket socket(*io_context_, asio::ip::udp::v4());
+
+    auto quic = std::make_shared<internal::quic_socket>(
+        std::move(socket), internal::quic_role::server);
+
+    asio::ip::udp::endpoint endpoint(
+        asio::ip::make_address("127.0.0.1"), 12345);
+
+    auto result = quic->connect(endpoint);
+    EXPECT_FALSE(result.is_ok());
+}
+
+TEST_F(QuicSocketConstructionTest, ClientCannotAccept)
+{
+    asio::ip::udp::socket socket(*io_context_, asio::ip::udp::v4());
+
+    auto quic = std::make_shared<internal::quic_socket>(
+        std::move(socket), internal::quic_role::client);
+
+    auto result = quic->accept("cert.pem", "key.pem");
+    EXPECT_FALSE(result.is_ok());
+}
+
+// ============================================================================
+// Close Tests
+// ============================================================================
+
+TEST_F(QuicSocketConstructionTest, CloseIdleSocket)
+{
+    asio::ip::udp::socket socket(*io_context_, asio::ip::udp::v4());
+
+    auto quic = std::make_shared<internal::quic_socket>(
+        std::move(socket), internal::quic_role::client);
+
+    auto result = quic->close(0, "test close");
+    EXPECT_TRUE(result.is_ok());
+}
+
+TEST_F(QuicSocketConstructionTest, DoubleCloseSucceeds)
+{
+    asio::ip::udp::socket socket(*io_context_, asio::ip::udp::v4());
+
+    auto quic = std::make_shared<internal::quic_socket>(
+        std::move(socket), internal::quic_role::client);
+
+    auto result1 = quic->close(0, "first close");
+    auto result2 = quic->close(0, "second close");
+
+    EXPECT_TRUE(result1.is_ok());
+    EXPECT_TRUE(result2.is_ok());
+}

--- a/tests/unit/session_ticket_store_test.cpp
+++ b/tests/unit/session_ticket_store_test.cpp
@@ -1,0 +1,356 @@
+/*****************************************************************************
+BSD 3-Clause License
+
+Copyright (c) 2025, 🍀☀🌕🌥 🌊
+All rights reserved.
+*****************************************************************************/
+
+#include "internal/protocols/quic/session_ticket_store.h"
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <thread>
+#include <vector>
+
+namespace quic = kcenon::network::protocols::quic;
+
+using namespace std::chrono_literals;
+
+/**
+ * @file session_ticket_store_test.cpp
+ * @brief Unit tests for QUIC session ticket store and replay filter
+ *
+ * Tests validate:
+ * - session_ticket_info: is_valid(), get_obfuscated_age()
+ * - session_ticket_store: default construction, store/retrieve round-trip,
+ *   expired ticket handling, remove(), cleanup_expired(), clear(),
+ *   has_ticket(), size()
+ * - replay_filter: check_and_record() accepts first, rejects duplicate nonce,
+ *   cleanup(), clear(), custom configuration
+ */
+
+// ============================================================================
+// session_ticket_info Tests
+// ============================================================================
+
+class SessionTicketInfoTest : public ::testing::Test
+{
+protected:
+    quic::session_ticket_info create_valid_ticket()
+    {
+        quic::session_ticket_info info;
+        info.ticket_data = {0x01, 0x02, 0x03, 0x04, 0x05};
+        info.expiry = std::chrono::system_clock::now() + 1h;
+        info.server_name = "example.com";
+        info.port = 443;
+        info.max_early_data_size = 16384;
+        info.ticket_age_add = 12345;
+        info.received_time = std::chrono::system_clock::now();
+        return info;
+    }
+};
+
+TEST_F(SessionTicketInfoTest, DefaultTicketIsInvalid)
+{
+    quic::session_ticket_info info;
+    EXPECT_FALSE(info.is_valid());
+}
+
+TEST_F(SessionTicketInfoTest, ValidTicketIsValid)
+{
+    auto info = create_valid_ticket();
+    EXPECT_TRUE(info.is_valid());
+}
+
+TEST_F(SessionTicketInfoTest, ExpiredTicketIsInvalid)
+{
+    auto info = create_valid_ticket();
+    info.expiry = std::chrono::system_clock::now() - 1h;
+    EXPECT_FALSE(info.is_valid());
+}
+
+TEST_F(SessionTicketInfoTest, FutureExpiryIsValid)
+{
+    auto info = create_valid_ticket();
+    info.expiry = std::chrono::system_clock::now() + 24h;
+    EXPECT_TRUE(info.is_valid());
+}
+
+TEST_F(SessionTicketInfoTest, ObfuscatedAgeCalculation)
+{
+    quic::session_ticket_info info;
+    info.ticket_data = {0x01};
+    info.ticket_age_add = 1000;
+    info.received_time = std::chrono::system_clock::now() - 100ms;
+
+    auto age = info.get_obfuscated_age();
+    // Age should be ~100ms + 1000 = ~1100
+    EXPECT_GT(age, 1000u);
+    EXPECT_LT(age, 2000u);
+}
+
+TEST_F(SessionTicketInfoTest, ObfuscatedAgeWithZeroAddValue)
+{
+    quic::session_ticket_info info;
+    info.ticket_data = {0x01};
+    info.ticket_age_add = 0;
+    info.received_time = std::chrono::system_clock::now() - 200ms;
+
+    auto age = info.get_obfuscated_age();
+    // Age should be ~200ms with no offset
+    EXPECT_GT(age, 100u);
+    EXPECT_LT(age, 500u);
+}
+
+// ============================================================================
+// session_ticket_store Default State Tests
+// ============================================================================
+
+class SessionTicketStoreDefaultTest : public ::testing::Test
+{
+};
+
+TEST_F(SessionTicketStoreDefaultTest, InitialSizeIsZero)
+{
+    quic::session_ticket_store store;
+    EXPECT_EQ(store.size(), 0);
+}
+
+TEST_F(SessionTicketStoreDefaultTest, RetrieveFromEmptyReturnsNullopt)
+{
+    quic::session_ticket_store store;
+    auto result = store.retrieve("example.com", 443);
+    EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(SessionTicketStoreDefaultTest, HasTicketReturnsFalseForEmpty)
+{
+    quic::session_ticket_store store;
+    EXPECT_FALSE(store.has_ticket("example.com", 443));
+}
+
+// ============================================================================
+// session_ticket_store Store/Retrieve Tests
+// ============================================================================
+
+class SessionTicketStoreTest : public ::testing::Test
+{
+protected:
+    quic::session_ticket_store store;
+
+    quic::session_ticket_info create_ticket(const std::string& server,
+                                             unsigned short port,
+                                             int expiry_hours = 1)
+    {
+        quic::session_ticket_info info;
+        info.ticket_data = {0x01, 0x02, 0x03, 0x04};
+        info.expiry = std::chrono::system_clock::now()
+                      + std::chrono::hours(expiry_hours);
+        info.server_name = server;
+        info.port = port;
+        info.received_time = std::chrono::system_clock::now();
+        return info;
+    }
+};
+
+TEST_F(SessionTicketStoreTest, StoreAndRetrieveRoundTrip)
+{
+    auto ticket = create_ticket("example.com", 443);
+    store.store("example.com", 443, ticket);
+
+    EXPECT_EQ(store.size(), 1);
+    EXPECT_TRUE(store.has_ticket("example.com", 443));
+
+    auto retrieved = store.retrieve("example.com", 443);
+    ASSERT_TRUE(retrieved.has_value());
+    EXPECT_EQ(retrieved->server_name, "example.com");
+    EXPECT_EQ(retrieved->port, 443);
+}
+
+TEST_F(SessionTicketStoreTest, RetrieveNonExistentReturnsNullopt)
+{
+    auto retrieved = store.retrieve("nonexistent.com", 443);
+    EXPECT_FALSE(retrieved.has_value());
+}
+
+TEST_F(SessionTicketStoreTest, ExpiredTicketRetrieveReturnsNullopt)
+{
+    auto expired_ticket = create_ticket("expired.com", 443, -1);
+    store.store("expired.com", 443, expired_ticket);
+
+    auto retrieved = store.retrieve("expired.com", 443);
+    EXPECT_FALSE(retrieved.has_value());
+}
+
+TEST_F(SessionTicketStoreTest, RemoveExistingReturnsTrue)
+{
+    store.store("example.com", 443, create_ticket("example.com", 443));
+
+    EXPECT_TRUE(store.remove("example.com", 443));
+    EXPECT_EQ(store.size(), 0);
+    EXPECT_FALSE(store.has_ticket("example.com", 443));
+}
+
+TEST_F(SessionTicketStoreTest, RemoveNonExistentReturnsFalse)
+{
+    EXPECT_FALSE(store.remove("nonexistent.com", 443));
+}
+
+TEST_F(SessionTicketStoreTest, CleanupExpiredRemovesOnlyExpired)
+{
+    auto valid_ticket = create_ticket("valid.com", 443, 1);
+    auto expired_ticket = create_ticket("expired.com", 443, -1);
+
+    store.store("valid.com", 443, valid_ticket);
+    store.store("expired.com", 443, expired_ticket);
+
+    EXPECT_EQ(store.size(), 2);
+
+    auto removed = store.cleanup_expired();
+    EXPECT_EQ(removed, 1);
+    EXPECT_EQ(store.size(), 1);
+    EXPECT_TRUE(store.has_ticket("valid.com", 443));
+    EXPECT_FALSE(store.has_ticket("expired.com", 443));
+}
+
+TEST_F(SessionTicketStoreTest, ClearEmptiesStore)
+{
+    store.store("server1.com", 443, create_ticket("server1.com", 443));
+    store.store("server2.com", 443, create_ticket("server2.com", 443));
+
+    EXPECT_EQ(store.size(), 2);
+
+    store.clear();
+    EXPECT_EQ(store.size(), 0);
+}
+
+TEST_F(SessionTicketStoreTest, HasTicketCorrectness)
+{
+    store.store("example.com", 443, create_ticket("example.com", 443));
+
+    EXPECT_TRUE(store.has_ticket("example.com", 443));
+    EXPECT_FALSE(store.has_ticket("example.com", 8443));
+    EXPECT_FALSE(store.has_ticket("other.com", 443));
+}
+
+TEST_F(SessionTicketStoreTest, ReplaceExistingTicket)
+{
+    auto ticket1 = create_ticket("example.com", 443);
+    ticket1.ticket_data = {0x01};
+    store.store("example.com", 443, ticket1);
+
+    auto ticket2 = create_ticket("example.com", 443);
+    ticket2.ticket_data = {0x02};
+    store.store("example.com", 443, ticket2);
+
+    EXPECT_EQ(store.size(), 1);
+
+    auto retrieved = store.retrieve("example.com", 443);
+    ASSERT_TRUE(retrieved.has_value());
+    ASSERT_EQ(retrieved->ticket_data.size(), 1);
+    EXPECT_EQ(retrieved->ticket_data[0], 0x02);
+}
+
+TEST_F(SessionTicketStoreTest, MultipleServersDistinctByPort)
+{
+    store.store("server.com", 443, create_ticket("server.com", 443));
+    store.store("server.com", 8443, create_ticket("server.com", 8443));
+
+    EXPECT_EQ(store.size(), 2);
+    EXPECT_TRUE(store.has_ticket("server.com", 443));
+    EXPECT_TRUE(store.has_ticket("server.com", 8443));
+}
+
+// ============================================================================
+// replay_filter Tests
+// ============================================================================
+
+class ReplayFilterTest : public ::testing::Test
+{
+protected:
+    quic::replay_filter filter;
+
+    std::vector<uint8_t> create_nonce(uint8_t value)
+    {
+        return std::vector<uint8_t>(32, value);
+    }
+};
+
+TEST_F(ReplayFilterTest, InitiallyEmpty)
+{
+    EXPECT_EQ(filter.size(), 0);
+}
+
+TEST_F(ReplayFilterTest, FirstNonceAccepted)
+{
+    auto nonce = create_nonce(0x01);
+    EXPECT_TRUE(filter.check_and_record(nonce));
+    EXPECT_EQ(filter.size(), 1);
+}
+
+TEST_F(ReplayFilterTest, DuplicateNonceRejected)
+{
+    auto nonce = create_nonce(0x01);
+    EXPECT_TRUE(filter.check_and_record(nonce));
+    EXPECT_FALSE(filter.check_and_record(nonce));
+}
+
+TEST_F(ReplayFilterTest, DifferentNoncesAccepted)
+{
+    auto nonce1 = create_nonce(0x01);
+    auto nonce2 = create_nonce(0x02);
+    auto nonce3 = create_nonce(0x03);
+
+    EXPECT_TRUE(filter.check_and_record(nonce1));
+    EXPECT_TRUE(filter.check_and_record(nonce2));
+    EXPECT_TRUE(filter.check_and_record(nonce3));
+    EXPECT_EQ(filter.size(), 3);
+}
+
+TEST_F(ReplayFilterTest, ClearAllowsReuse)
+{
+    auto nonce = create_nonce(0x01);
+    filter.check_and_record(nonce);
+
+    filter.clear();
+    EXPECT_EQ(filter.size(), 0);
+
+    // After clear, the same nonce should be accepted again
+    EXPECT_TRUE(filter.check_and_record(nonce));
+}
+
+TEST_F(ReplayFilterTest, CleanupRemovesOldEntries)
+{
+    quic::replay_filter::config cfg;
+    cfg.window_size = 1s;
+    cfg.max_entries = 100;
+
+    quic::replay_filter short_window_filter(cfg);
+
+    auto nonce = create_nonce(0x01);
+    auto past_time = std::chrono::system_clock::now() - 2s;
+    short_window_filter.check_and_record(nonce, past_time);
+
+    EXPECT_EQ(short_window_filter.size(), 1);
+
+    auto removed = short_window_filter.cleanup();
+    EXPECT_EQ(removed, 1);
+    EXPECT_EQ(short_window_filter.size(), 0);
+}
+
+TEST_F(ReplayFilterTest, CustomConfiguration)
+{
+    quic::replay_filter::config cfg;
+    cfg.window_size = 5s;
+    cfg.max_entries = 10;
+
+    quic::replay_filter custom_filter(cfg);
+
+    for (uint8_t i = 0; i < 10; ++i)
+    {
+        auto nonce = create_nonce(i);
+        EXPECT_TRUE(custom_filter.check_and_record(nonce));
+    }
+
+    EXPECT_EQ(custom_filter.size(), 10);
+}


### PR DESCRIPTION
Closes #974

## Summary
- Add dedicated unit tests for 5 remaining untested QUIC protocol modules
- Part of epic #953 to raise test coverage from ~48% to 80%

## New Test Files
| File | Module | Tests |
|------|--------|-------|
| `session_ticket_store_test.cpp` | session_ticket_store, replay_filter | Store/retrieve, expiry, cleanup, thread safety |
| `quic_pmtud_controller_test.cpp` | pmtud_controller | State machine, binary search, probe ack/loss, black hole detection |
| `quic_crypto_test.cpp` | crypto (HKDF, initial_keys, packet_protection, quic_crypto) | Key derivation, encrypt/decrypt round-trip, move semantics |
| `quic_connection_test.cpp` | connection | Construction, state transitions, CID management, transport params, statistics |
| `quic_socket_construction_test.cpp` | quic_socket | Construction, role queries, callbacks, move semantics, role restrictions |

## Test Plan
- All tests registered via `add_network_test` macro in `tests/CMakeLists.txt`
- No `GTEST_SKIP()` markers
- Tests cover construction, public methods, and error paths
- CI will verify build and test execution on Ubuntu and macOS