### PR TITLE
ci(coverage): enable branch coverage and manual run

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main, phase-* ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -71,10 +72,11 @@ jobs:
         cd build
         mkdir -p coverage
 
-        # Capture coverage data
+        # Capture coverage data (line + branch)
         lcov --directory . --capture --output-file coverage.info \
           --ignore-errors mismatch,gcov,source,unused \
-          --rc geninfo_gcov_all_blocks=0 || true
+          --rc geninfo_gcov_all_blocks=0 \
+          --rc lcov_branch_coverage=1 || true
 
         # Filter out non-project sources
         lcov --remove coverage.info \
@@ -96,27 +98,36 @@ jobs:
           '*/lz4/*' \
           '*/zlib/*' \
           --output-file coverage_filtered.info \
-          --ignore-errors unused,mismatch || true
+          --ignore-errors unused,mismatch \
+          --rc lcov_branch_coverage=1 || true
 
-        # Generate HTML report
+        # Generate HTML report (with branch coverage pages)
         genhtml coverage_filtered.info --output-directory coverage_html \
-          --ignore-errors source,unmapped || true
+          --ignore-errors source,unmapped \
+          --branch-coverage || true
 
-        # Print summary
-        lcov --list coverage_filtered.info --ignore-errors unused || true
+        # Print summary (line + branch)
+        lcov --list coverage_filtered.info \
+          --ignore-errors unused \
+          --rc lcov_branch_coverage=1 || true
 
     - name: Extract coverage percentage
       id: coverage
       run: |
         if [ -f build/coverage_filtered.info ]; then
-          # Extract line coverage percentage
-          COVERAGE=$(lcov --summary build/coverage_filtered.info 2>&1 \
+          # Extract line and branch coverage percentages
+          SUMMARY=$(lcov --summary build/coverage_filtered.info 2>&1 \
             --ignore-errors empty \
-            | grep -oP 'lines\.*:\s*\K[0-9.]+' || echo "0")
+            --rc lcov_branch_coverage=1 || true)
+          COVERAGE=$(echo "$SUMMARY" | grep -oP 'lines\.*:\s*\K[0-9.]+' || echo "0")
+          BRANCH_COVERAGE=$(echo "$SUMMARY" | grep -oP 'branches\.*:\s*\K[0-9.]+' || echo "0")
           echo "percentage=${COVERAGE}" >> $GITHUB_OUTPUT
-          echo "Coverage: ${COVERAGE}%"
+          echo "branch_percentage=${BRANCH_COVERAGE}" >> $GITHUB_OUTPUT
+          echo "Line coverage: ${COVERAGE}%"
+          echo "Branch coverage: ${BRANCH_COVERAGE}%"
         else
           echo "percentage=0" >> $GITHUB_OUTPUT
+          echo "branch_percentage=0" >> $GITHUB_OUTPUT
           echo "No coverage data available"
         fi
 
@@ -138,12 +149,14 @@ jobs:
       with:
         script: |
           const coverage = '${{ steps.coverage.outputs.percentage }}';
+          const branchCoverage = '${{ steps.coverage.outputs.branch_percentage }}';
           const body = `## Coverage Report
 
           | Metric | Value |
           |--------|-------|
           | **Line Coverage** | ${coverage}% |
-          | **Target** | 75% (stretch: 80%) |
+          | **Branch Coverage** | ${branchCoverage}% |
+          | **Target** | 80% lines / 70% branches |
 
           <details>
           <summary>Coverage Details</summary>
@@ -194,13 +207,15 @@ jobs:
       if: always()
       run: |
         COVERAGE="${{ steps.coverage.outputs.percentage }}"
+        BRANCH_COVERAGE="${{ steps.coverage.outputs.branch_percentage }}"
         echo "## Coverage Summary" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         if [ -f build/coverage_filtered.info ] && [ "$COVERAGE" != "0" ]; then
           echo "| Metric | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| **Line Coverage** | ${COVERAGE}% |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Target** | 75% (stretch: 80%) |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Branch Coverage** | ${BRANCH_COVERAGE}% |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Target** | 80% lines / 70% branches |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Coverage report uploaded as artifact (retained for 30 days)." >> $GITHUB_STEP_SUMMARY
         else


### PR DESCRIPTION
Part of #953 — Step 1 of the re-baseline plan.

## Summary

- `coverage.yml`: pass `--rc lcov_branch_coverage=1` to every lcov invocation (capture, filter, summary, extraction)
- `genhtml`: pass `--branch-coverage` so the HTML artifact shows per-branch annotations
- Emit a second GitHub Actions output `branch_percentage`, surface it in the PR comment and step summary
- Add `workflow_dispatch:` so the workflow can be run manually on `develop` after this merges (since the existing triggers only fire on `main`/`phase-*` pushes and PRs targeting `main`)

## Why

The 2026-04-13 run reported `branches...: no data found`. Without branch coverage we can't measure the 70% branch-coverage criterion the parent epic was updated to target on 2026-04-16. This PR makes the measurement possible; it does not change what code is built.

## What this PR does NOT do

Flipping `BUILD_WITH_LOGGER_SYSTEM` / `THREAD_SYSTEM` / `CONTAINER_SYSTEM` / `MESSAGING_BRIDGE` from OFF to ON is also called out as Step 1 in #953, but it requires adding `Checkout` + `Build and install` steps for each repo (analogous to the existing `common_system` steps). That is a separate, larger PR and is deliberately out of scope here to keep this change low risk.

## Test Plan

- CI does not fire on PRs targeting `develop` (per project policy), so nothing runs automatically on this PR
- After merge to `develop`, invoke the workflow manually via the new `workflow_dispatch` trigger and confirm:
  - `Extract coverage percentage` step prints both `Line coverage: X%` and `Branch coverage: Y%` (not "0%")
  - `Coverage summary` step summary shows both rows
  - Uploaded `coverage-report` artifact contains HTML with branch annotations
- A second validation path: the change fires on the next `develop` → `main` release PR

## Risk

Low. All lcov/genhtml flags added here are additive (branch-coverage-related). If lcov rejects the flag on an edge case the `|| true` fallthrough in the existing shell blocks prevents a hard failure.