### PR TITLE
ci(coverage): enable full-ecosystem coverage build

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,7 @@ jobs:
   coverage:
     name: Coverage Analysis
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
 
     steps:
     - name: Checkout code
@@ -151,7 +152,7 @@ jobs:
     - name: Run tests
       run: |
         cd build
-        ctest -C Debug --output-on-failure --verbose || true
+        ctest -C Debug --output-on-failure --verbose --timeout 300 || true
 
     - name: Generate coverage report
       run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,9 +2,9 @@ name: Code Coverage
 
 on:
   push:
-    branches: [ main, phase-* ]
+    branches: [ main, develop, phase-* ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
   workflow_dispatch:
 
 permissions:
@@ -29,21 +29,107 @@ jobs:
         path: common_system
         token: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Checkout thread_system
+      uses: actions/checkout@v6
+      with:
+        repository: kcenon/thread_system
+        path: thread_system
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Checkout logger_system
+      uses: actions/checkout@v6
+      with:
+        repository: kcenon/logger_system
+        path: logger_system
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Checkout container_system
+      uses: actions/checkout@v6
+      with:
+        repository: kcenon/container_system
+        path: container_system
+        token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Install dependencies
       run: |
         sudo apt-get update
         sudo apt-get install -y cmake ninja-build g++ libgtest-dev libgmock-dev libasio-dev libfmt-dev libssl-dev liblz4-dev zlib1g-dev lcov
 
-    - name: Build common_system dependency
+    - name: Build ecosystem dependencies
+      shell: bash
       run: |
-        cd common_system
-        cmake -B build -G Ninja \
-          -DCMAKE_BUILD_TYPE=Debug \
-          -DBUILD_TESTS=OFF \
-          -DBUILD_EXAMPLES=OFF \
-          -DBUILD_SAMPLES=OFF
-        cmake --build build
-        cmake --install build --prefix ${{ github.workspace }}/deps/install
+        # Build dependencies in tier order so each layer can find the previous one.
+        # Matches the pattern used by ci.yml (sanitizer job) minus sanitizer-specific
+        # compiler flags — coverage uses default gcc with --coverage.
+
+        # common_system (Tier 0)
+        if [ -d "common_system" ]; then
+          echo "::group::Build common_system"
+          cd common_system
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DBUILD_TESTS=OFF \
+            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_SAMPLES=OFF
+          cmake --build build
+          cmake --install build --prefix ${{ github.workspace }}/deps/install
+          cd ..
+          echo "::endgroup::"
+        fi
+
+        # thread_system (Tier 1)
+        if [ -d "thread_system" ]; then
+          echo "::group::Build thread_system"
+          cd thread_system
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/install \
+            -DCOMMON_SYSTEM_INCLUDE_DIR=${{ github.workspace }}/deps/install/include \
+            -DBUILD_TESTS=OFF \
+            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_SAMPLES=OFF \
+            -DBUILD_INTEGRATION_TESTS=OFF
+          cmake --build build --target thread_system
+          cmake --install build --prefix ${{ github.workspace }}/deps/install
+          cd ..
+          echo "::endgroup::"
+        fi
+
+        # logger_system (Tier 2)
+        if [ -d "logger_system" ]; then
+          echo "::group::Build logger_system"
+          cd logger_system
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/install \
+            -DCOMMON_SYSTEM_INCLUDE_DIR=${{ github.workspace }}/deps/install/include \
+            -DBUILD_TESTS=OFF \
+            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_SAMPLES=OFF \
+            -DLOGGER_BUILD_INTEGRATION_TESTS=OFF
+          cmake --build build
+          cmake --install build --prefix ${{ github.workspace }}/deps/install
+          cd ..
+          echo "::endgroup::"
+        fi
+
+        # container_system (Tier 1)
+        if [ -d "container_system" ]; then
+          echo "::group::Build container_system"
+          cd container_system
+          cmake -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/install \
+            -DCOMMON_SYSTEM_INCLUDE_DIR=${{ github.workspace }}/deps/install/include \
+            -DBUILD_TESTS=OFF \
+            -DBUILD_EXAMPLES=OFF \
+            -DBUILD_SAMPLES=OFF
+          cmake --build build
+          # Install may fail due to missing files in container_system CMake config
+          cmake --install build --prefix ${{ github.workspace }}/deps/install || true
+          cd ..
+          echo "::endgroup::"
+        fi
 
     - name: Configure CMake with coverage
       run: |
@@ -52,9 +138,9 @@ jobs:
           -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/install \
           -DENABLE_COVERAGE=ON \
           -DBUILD_WITH_COMMON_SYSTEM=ON \
-          -DBUILD_WITH_LOGGER_SYSTEM=OFF \
-          -DBUILD_WITH_THREAD_SYSTEM=OFF \
-          -DBUILD_WITH_CONTAINER_SYSTEM=OFF \
+          -DBUILD_WITH_LOGGER_SYSTEM=ON \
+          -DBUILD_WITH_THREAD_SYSTEM=ON \
+          -DBUILD_WITH_CONTAINER_SYSTEM=ON \
           -DBUILD_MESSAGING_BRIDGE=OFF \
           -DBUILD_TESTS=ON \
           -DBUILD_SAMPLES=OFF


### PR DESCRIPTION
## Summary

Addresses Step 1 of epic #953 — "Fix the measurement (prerequisite)".

The coverage workflow currently disables `BUILD_WITH_LOGGER_SYSTEM`, `BUILD_WITH_THREAD_SYSTEM`, and `BUILD_WITH_CONTAINER_SYSTEM`, so large sections of protocol code that depend on those integrations are compiled out. The resulting 62.4% line coverage recorded on the epic is a **structural lower bound**, not a real measurement.

## What changed

- Checkout `thread_system`, `logger_system`, and `container_system` alongside `common_system`.
- Replace the single `Build common_system dependency` step with a consolidated `Build ecosystem dependencies` step that builds all four in tier order. The pattern mirrors `ci.yml`'s sanitizer job (L269-410), minus sanitizer-specific compiler flags.
- Flip `BUILD_WITH_LOGGER_SYSTEM`, `BUILD_WITH_THREAD_SYSTEM`, `BUILD_WITH_CONTAINER_SYSTEM` from `OFF` to `ON` in the coverage CMake configuration.
- Extend `push` and `pull_request` triggers to cover the `develop` branch so post-merge coverage runs on the integration branch without waiting for a release cut.

## Deviation from epic body

Epic #953 asks for `BUILD_MESSAGING_BRIDGE=ON` as well. This PR keeps it `OFF` because enabling it compiles `src/integration/messaging_bridge.cpp`, which depends on `messaging_system` headers that no CI workflow in this repo currently checks out. Every other workflow (`ci.yml`, `sanitizers.yml`, `performance-regression.yml`) consistently keeps this flag `OFF` for the same reason. Enabling it would require first adding messaging_system checkout and install to every dependent workflow — a separate scope.

I'll add a follow-up comment to #953 documenting this.

## Test plan

- [ ] CI runs successfully on this PR against `develop` (coverage workflow will trigger because of the new trigger addition).
- [ ] Resulting line/branch coverage percentages are recorded in the workflow step summary.
- [ ] After merge, post a new-baseline comment on #953 citing the measured line/branch coverage on `develop`.

## Out of scope

- Expanding tests to actually reach 80% — that's downstream narrow follow-ups per epic's Step 2.
- Enabling `BUILD_MESSAGING_BRIDGE` — separate dependency work as noted above.

Relates to #953