### PR TITLE
test(http): expand http_parser.cpp coverage with 112 cases

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4703,6 +4703,14 @@ add_network_test(network_http2_client_coverage_test unit/http2_client_coverage_t
 add_network_test(network_http2_client_extended_coverage_test
                  unit/http2_client_extended_coverage_test.cpp)
 
+# HTTP parser extended coverage: url_encode/decode edge cases (percent
+# truncation, high-bit bytes, hex case), query string delimiter handling
+# (leading/trailing '&', duplicate keys, URL-encoded delimiters), cookie
+# malformed-pair handling, parse_request_line / parse_status_line error
+# branches, multipart form-data edge cases, chunked encoding boundary
+# conditions (Issue #1013)
+add_network_test(network_http_parser_coverage_test unit/http_parser_coverage_test.cpp)
+
 # Secure transport module tests
 add_network_test(network_secure_tcp_socket_module_test unit/secure_tcp_socket_test.cpp)
 # secure_messaging_udp_client/server excluded: depend on dtls_socket from

--- a/tests/unit/http_parser_coverage_test.cpp
+++ b/tests/unit/http_parser_coverage_test.cpp
@@ -1,0 +1,1257 @@
+// BSD 3-Clause License
+// Copyright (c) 2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+// Coverage-expansion tests for src/internal/http_parser.cpp targeting branches
+// not reached by tests/unit/http_parser_test.cpp: URL decode truncation,
+// query string delimiter edge cases, cookie malformed-pair handling, header
+// edge cases, chunked encoding boundary conditions, multipart edge cases,
+// and parse_request_line / parse_status_line error paths.
+//
+// Part of epic #953 (expand unit test coverage from 40% to 80%). Single-file
+// sub-issue #1013.
+
+#include "internal/http/http_parser.h"
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <vector>
+
+using namespace kcenon::network::internal;
+
+namespace {
+
+auto vec_from(std::string_view s) -> std::vector<uint8_t>
+{
+    return std::vector<uint8_t>(s.begin(), s.end());
+}
+
+auto str_from(const std::vector<uint8_t>& bytes) -> std::string
+{
+    return std::string(bytes.begin(), bytes.end());
+}
+
+auto contains(const std::vector<uint8_t>& haystack, std::string_view needle) -> bool
+{
+    return str_from(haystack).find(needle) != std::string::npos;
+}
+
+}  // namespace
+
+// ============================================================================
+// url_encode coverage — safe character matrix, high-bit bytes, null byte
+// ============================================================================
+
+class HttpParserUrlEncodeCoverageTest : public ::testing::Test
+{
+};
+
+TEST_F(HttpParserUrlEncodeCoverageTest, SafeHyphenPreserved)
+{
+    EXPECT_EQ(http_parser::url_encode("a-b"), "a-b");
+}
+
+TEST_F(HttpParserUrlEncodeCoverageTest, SafeUnderscorePreserved)
+{
+    EXPECT_EQ(http_parser::url_encode("a_b"), "a_b");
+}
+
+TEST_F(HttpParserUrlEncodeCoverageTest, SafeDotPreserved)
+{
+    EXPECT_EQ(http_parser::url_encode("a.b"), "a.b");
+}
+
+TEST_F(HttpParserUrlEncodeCoverageTest, SafeTildePreserved)
+{
+    EXPECT_EQ(http_parser::url_encode("a~b"), "a~b");
+}
+
+TEST_F(HttpParserUrlEncodeCoverageTest, HighBitByteEncoded)
+{
+    std::string input(1, static_cast<char>(0xFF));
+    EXPECT_EQ(http_parser::url_encode(input), "%FF");
+}
+
+TEST_F(HttpParserUrlEncodeCoverageTest, NullByteEncoded)
+{
+    std::string input(1, '\0');
+    EXPECT_EQ(http_parser::url_encode(input), "%00");
+}
+
+TEST_F(HttpParserUrlEncodeCoverageTest, LowByteEncodedWithLeadingZero)
+{
+    std::string input(1, '\x01');
+    EXPECT_EQ(http_parser::url_encode(input), "%01");
+}
+
+TEST_F(HttpParserUrlEncodeCoverageTest, UppercaseHexDigitsInOutput)
+{
+    std::string input(1, '\xAB');
+    auto result = http_parser::url_encode(input);
+    EXPECT_EQ(result, "%AB");
+    EXPECT_NE(result, "%ab");
+}
+
+TEST_F(HttpParserUrlEncodeCoverageTest, UnreservedRfc3986Preserved)
+{
+    EXPECT_EQ(http_parser::url_encode("abcXYZ0123456789-_.~"),
+              "abcXYZ0123456789-_.~");
+}
+
+TEST_F(HttpParserUrlEncodeCoverageTest, ReservedCharactersEncoded)
+{
+    EXPECT_EQ(http_parser::url_encode("!*'();:@&=+$,/?#[]"),
+              "%21%2A%27%28%29%3B%3A%40%26%3D%2B%24%2C%2F%3F%23%5B%5D");
+}
+
+TEST_F(HttpParserUrlEncodeCoverageTest, Utf8MultibyteByteByByte)
+{
+    // "가" in UTF-8 is EA B0 80
+    std::string input = "\xEA\xB0\x80";
+    EXPECT_EQ(http_parser::url_encode(input), "%EA%B0%80");
+}
+
+// ============================================================================
+// url_decode coverage — truncation, hex case, high-bit and null bytes
+// ============================================================================
+
+class HttpParserUrlDecodeCoverageTest : public ::testing::Test
+{
+};
+
+TEST_F(HttpParserUrlDecodeCoverageTest, TruncatedTrailingPercentDropped)
+{
+    // When input ends with '%' and no two chars follow, the '%' is silently
+    // dropped because the `i + 2 < length` guard is false.
+    EXPECT_EQ(http_parser::url_decode("foo%"), "foo");
+}
+
+TEST_F(HttpParserUrlDecodeCoverageTest, TruncatedPercentOneCharDropped)
+{
+    // 'foo%A' — only one char after '%', i+2 == length, guard false.
+    EXPECT_EQ(http_parser::url_decode("foo%A"), "foo");
+}
+
+TEST_F(HttpParserUrlDecodeCoverageTest, LowercaseHexAccepted)
+{
+    // std::stoi(..., 16) accepts lowercase a-f.
+    std::string expected(1, '\xAB');
+    EXPECT_EQ(http_parser::url_decode("%ab"), expected);
+}
+
+TEST_F(HttpParserUrlDecodeCoverageTest, MixedHexCaseAccepted)
+{
+    std::string expected(1, '\xAB');
+    EXPECT_EQ(http_parser::url_decode("%aB"), expected);
+    EXPECT_EQ(http_parser::url_decode("%Ab"), expected);
+}
+
+TEST_F(HttpParserUrlDecodeCoverageTest, NullByteDecoded)
+{
+    std::string expected(1, '\0');
+    EXPECT_EQ(http_parser::url_decode("%00"), expected);
+}
+
+TEST_F(HttpParserUrlDecodeCoverageTest, HighBitByteDecoded)
+{
+    std::string expected(1, '\xFF');
+    EXPECT_EQ(http_parser::url_decode("%FF"), expected);
+}
+
+TEST_F(HttpParserUrlDecodeCoverageTest, PlusAtStart)
+{
+    EXPECT_EQ(http_parser::url_decode("+foo"), " foo");
+}
+
+TEST_F(HttpParserUrlDecodeCoverageTest, PlusAtEnd)
+{
+    EXPECT_EQ(http_parser::url_decode("foo+"), "foo ");
+}
+
+TEST_F(HttpParserUrlDecodeCoverageTest, OnlyPlusSigns)
+{
+    EXPECT_EQ(http_parser::url_decode("+++"), "   ");
+}
+
+TEST_F(HttpParserUrlDecodeCoverageTest, ConsecutivePercentEncoded)
+{
+    std::string expected = "\x41\x42\x43";  // ABC
+    EXPECT_EQ(http_parser::url_decode("%41%42%43"), expected);
+}
+
+TEST_F(HttpParserUrlDecodeCoverageTest, RoundTripForEveryUnreservedByte)
+{
+    for (int b = 0; b < 256; ++b) {
+        // Skip '+' because url_decode treats '+' as space (intentional
+        // form-encoding behavior), breaking the simple round-trip.
+        if (b == '+') continue;
+        std::string input(1, static_cast<char>(b));
+        auto encoded = http_parser::url_encode(input);
+        auto decoded = http_parser::url_decode(encoded);
+        EXPECT_EQ(decoded, input) << "byte=0x" << std::hex << b;
+    }
+}
+
+// ============================================================================
+// parse_query_string / build_query_string coverage
+// ============================================================================
+
+class HttpParserQueryStringCoverageTest : public ::testing::Test
+{
+};
+
+TEST_F(HttpParserQueryStringCoverageTest, LeadingAmpersandProducesEmptyKey)
+{
+    auto params = http_parser::parse_query_string("&a=1");
+    EXPECT_EQ(params["a"], "1");
+    // Leading '&' creates an empty-key pair with no '=' -> params[""] = ""
+    auto it = params.find("");
+    EXPECT_NE(it, params.end());
+}
+
+TEST_F(HttpParserQueryStringCoverageTest, TrailingAmpersandProducesEmptyKey)
+{
+    auto params = http_parser::parse_query_string("a=1&");
+    EXPECT_EQ(params["a"], "1");
+    auto it = params.find("");
+    EXPECT_NE(it, params.end());
+}
+
+TEST_F(HttpParserQueryStringCoverageTest, DoubleAmpersandSkipsEmptyMiddle)
+{
+    auto params = http_parser::parse_query_string("a=1&&b=2");
+    EXPECT_EQ(params["a"], "1");
+    EXPECT_EQ(params["b"], "2");
+}
+
+TEST_F(HttpParserQueryStringCoverageTest, EmptyKeyWithValue)
+{
+    auto params = http_parser::parse_query_string("=value");
+    EXPECT_EQ(params[""], "value");
+}
+
+TEST_F(HttpParserQueryStringCoverageTest, MultipleEqualsKeepsFirstAsSeparator)
+{
+    auto params = http_parser::parse_query_string("a=b=c");
+    EXPECT_EQ(params["a"], "b=c");
+}
+
+TEST_F(HttpParserQueryStringCoverageTest, UrlEncodedAmpersandPreservedInValue)
+{
+    auto params = http_parser::parse_query_string("a=%26other");
+    EXPECT_EQ(params["a"], "&other");
+}
+
+TEST_F(HttpParserQueryStringCoverageTest, UrlEncodedEqualsPreservedInValue)
+{
+    auto params = http_parser::parse_query_string("a=%3Dvalue");
+    EXPECT_EQ(params["a"], "=value");
+}
+
+TEST_F(HttpParserQueryStringCoverageTest, DuplicateKeyLastValueWins)
+{
+    auto params = http_parser::parse_query_string("k=1&k=2");
+    EXPECT_EQ(params["k"], "2");
+    EXPECT_EQ(params.size(), 1u);
+}
+
+TEST_F(HttpParserQueryStringCoverageTest, EmptyValueAfterEquals)
+{
+    auto params = http_parser::parse_query_string("a=");
+    EXPECT_EQ(params["a"], "");
+    EXPECT_EQ(params.size(), 1u);
+}
+
+TEST_F(HttpParserQueryStringCoverageTest, OnlyAmpersandsYieldsSingleEmptyKey)
+{
+    // "&&&" — getline with '&' delimiter produces three empty tokens, each
+    // without '=' -> every one inserts/overwrites params[""] = "".
+    auto params = http_parser::parse_query_string("&&&");
+    EXPECT_EQ(params.size(), 1u);
+    EXPECT_EQ(params[""], "");
+}
+
+TEST_F(HttpParserQueryStringCoverageTest, BuildEmptyMapReturnsEmptyString)
+{
+    std::map<std::string, std::string> params;
+    EXPECT_EQ(http_parser::build_query_string(params), "");
+}
+
+TEST_F(HttpParserQueryStringCoverageTest, BuildEncodesKeyWithSpace)
+{
+    std::map<std::string, std::string> params = {{"a b", "1"}};
+    EXPECT_EQ(http_parser::build_query_string(params), "a%20b=1");
+}
+
+TEST_F(HttpParserQueryStringCoverageTest, BuildEncodesValueWithSpecialChars)
+{
+    std::map<std::string, std::string> params = {{"k", "hello world&"}};
+    EXPECT_EQ(http_parser::build_query_string(params), "k=hello%20world%26");
+}
+
+TEST_F(HttpParserQueryStringCoverageTest, BuildOmitsEqualsForEmptyValue)
+{
+    std::map<std::string, std::string> params = {{"a", ""}};
+    // Current implementation emits "a" with no '=' when value is empty.
+    EXPECT_EQ(http_parser::build_query_string(params), "a");
+}
+
+TEST_F(HttpParserQueryStringCoverageTest, BuildMultipleParamsJoinedByAmpersand)
+{
+    std::map<std::string, std::string> params = {{"a", "1"}, {"b", "2"}};
+    auto result = http_parser::build_query_string(params);
+    // std::map iterates in key order -> "a=1&b=2"
+    EXPECT_EQ(result, "a=1&b=2");
+}
+
+TEST_F(HttpParserQueryStringCoverageTest, RoundTripWithEncodableChars)
+{
+    std::map<std::string, std::string> original = {
+        {"name", "John Doe"},
+        {"email", "john@example.com"},
+        {"tags", "a&b&c"}};
+    auto built = http_parser::build_query_string(original);
+    auto parsed = http_parser::parse_query_string(built);
+    EXPECT_EQ(parsed, original);
+}
+
+// ============================================================================
+// parse_request_line error branches (exercised via parse_request)
+// ============================================================================
+
+class HttpParserRequestLineCoverageTest : public ::testing::Test
+{
+};
+
+TEST_F(HttpParserRequestLineCoverageTest, NoSpacesReturnsError)
+{
+    auto result = http_parser::parse_request("GETPATHVERSION\r\n\r\n");
+    EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(HttpParserRequestLineCoverageTest, MissingVersionReturnsError)
+{
+    auto result = http_parser::parse_request("GET /path\r\n\r\n");
+    EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(HttpParserRequestLineCoverageTest, UnknownMethodReturnsError)
+{
+    auto result = http_parser::parse_request("FOOBAR /path HTTP/1.1\r\n\r\n");
+    EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(HttpParserRequestLineCoverageTest, UnknownVersionReturnsError)
+{
+    auto result = http_parser::parse_request("GET /path HTTP/9.9\r\n\r\n");
+    EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(HttpParserRequestLineCoverageTest, UriWithMultipleQuestionMarksSplitsAtFirst)
+{
+    auto result = http_parser::parse_request("GET /p?a=1?b=2 HTTP/1.1\r\n\r\n");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().uri, "/p");
+    // parse_query_string treats "a=1?b=2" as single token with '=' at pos 1.
+    EXPECT_EQ(result.value().query_params["a"], "1?b=2");
+}
+
+TEST_F(HttpParserRequestLineCoverageTest, UriWithTrailingQuestionMarkEmptyQuery)
+{
+    auto result = http_parser::parse_request("GET /path? HTTP/1.1\r\n\r\n");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().uri, "/path");
+    EXPECT_TRUE(result.value().query_params.empty());
+}
+
+TEST_F(HttpParserRequestLineCoverageTest, UriWithOnlyQuestionMark)
+{
+    auto result = http_parser::parse_request("GET ? HTTP/1.1\r\n\r\n");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().uri, "");
+    EXPECT_TRUE(result.value().query_params.empty());
+}
+
+TEST_F(HttpParserRequestLineCoverageTest, EmptyQueryKeyPreserved)
+{
+    auto result = http_parser::parse_request("GET /path?=v HTTP/1.1\r\n\r\n");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().query_params[""], "v");
+}
+
+// ============================================================================
+// parse_status_line error branches (exercised via parse_response)
+// ============================================================================
+
+class HttpParserStatusLineCoverageTest : public ::testing::Test
+{
+};
+
+TEST_F(HttpParserStatusLineCoverageTest, NonNumericStatusCodeReturnsError)
+{
+    auto result = http_parser::parse_response("HTTP/1.1 ABC OK\r\n\r\n");
+    EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(HttpParserStatusLineCoverageTest, NoSpacesInStatusLineReturnsError)
+{
+    auto result = http_parser::parse_response("HTTP/1.1\r\n\r\n");
+    EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(HttpParserStatusLineCoverageTest, UnknownVersionReturnsError)
+{
+    auto result = http_parser::parse_response("HTTP/9.9 200 OK\r\n\r\n");
+    EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(HttpParserStatusLineCoverageTest, StatusCodeZeroAccepted)
+{
+    auto result = http_parser::parse_response("HTTP/1.1 0 Bogus\r\n\r\n");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().status_code, 0);
+}
+
+TEST_F(HttpParserStatusLineCoverageTest, ThreeDigitStatusCodeWithoutMessageUsesCanonical)
+{
+    auto result = http_parser::parse_response("HTTP/1.1 200\r\n\r\n");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().status_code, 200);
+    EXPECT_FALSE(result.value().status_message.empty());
+}
+
+TEST_F(HttpParserStatusLineCoverageTest, StatusMessageWithMultipleWordsPreserved)
+{
+    auto result = http_parser::parse_response(
+        "HTTP/1.1 200 OK All Good\r\n\r\n");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().status_code, 200);
+    EXPECT_EQ(result.value().status_message, "OK All Good");
+}
+
+TEST_F(HttpParserStatusLineCoverageTest, LargeStatusCodeStillParses)
+{
+    auto result = http_parser::parse_response("HTTP/1.1 99999 X\r\n\r\n");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().status_code, 99999);
+}
+
+TEST_F(HttpParserStatusLineCoverageTest, EmptyStatusMessageFallsBackToCanonical)
+{
+    auto result = http_parser::parse_response("HTTP/1.1 404 \r\n\r\n");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().status_code, 404);
+    // When status message is trimmed-empty, the default canonical text is used.
+    EXPECT_FALSE(result.value().status_message.empty());
+}
+
+TEST_F(HttpParserStatusLineCoverageTest, InformationalStatus1xx)
+{
+    auto result = http_parser::parse_response("HTTP/1.1 100 Continue\r\n\r\n");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().status_code, 100);
+    EXPECT_EQ(result.value().status_message, "Continue");
+}
+
+// ============================================================================
+// parse_headers edge cases (exercised via parse_request)
+// ============================================================================
+
+class HttpParserHeadersCoverageTest : public ::testing::Test
+{
+};
+
+TEST_F(HttpParserHeadersCoverageTest, HeaderWithMultipleColonsKeepsValueAsIs)
+{
+    auto result = http_parser::parse_request(
+        "GET / HTTP/1.1\r\n"
+        "X-Forward: proto: https\r\n"
+        "\r\n");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().headers["X-Forward"], "proto: https");
+}
+
+TEST_F(HttpParserHeadersCoverageTest, HeaderWithEmptyValueAfterColon)
+{
+    auto result = http_parser::parse_request(
+        "GET / HTTP/1.1\r\n"
+        "X-Empty:\r\n"
+        "\r\n");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().headers["X-Empty"], "");
+}
+
+TEST_F(HttpParserHeadersCoverageTest, HeaderWithValueSpaces)
+{
+    auto result = http_parser::parse_request(
+        "GET / HTTP/1.1\r\n"
+        "X-Spaces:    hello   \r\n"
+        "\r\n");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().headers["X-Spaces"], "hello");
+}
+
+TEST_F(HttpParserHeadersCoverageTest, HeaderWithOnlyColonEmptyNameAndValue)
+{
+    auto result = http_parser::parse_request(
+        "GET / HTTP/1.1\r\n"
+        ":\r\n"
+        "\r\n");
+    ASSERT_TRUE(result.is_ok());
+    auto it = result.value().headers.find("");
+    EXPECT_NE(it, result.value().headers.end());
+}
+
+TEST_F(HttpParserHeadersCoverageTest, HeaderWithoutColonReturnsError)
+{
+    auto result = http_parser::parse_request(
+        "GET / HTTP/1.1\r\n"
+        "NotAnHeaderLine\r\n"
+        "\r\n");
+    EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(HttpParserHeadersCoverageTest, DuplicateHeaderLastWinsInMap)
+{
+    auto result = http_parser::parse_request(
+        "GET / HTTP/1.1\r\n"
+        "X-Dup: first\r\n"
+        "X-Dup: second\r\n"
+        "\r\n");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().headers["X-Dup"], "second");
+}
+
+TEST_F(HttpParserHeadersCoverageTest, ManyHeadersParsedInOrder)
+{
+    auto result = http_parser::parse_request(
+        "GET / HTTP/1.1\r\n"
+        "A: 1\r\n"
+        "B: 2\r\n"
+        "C: 3\r\n"
+        "D: 4\r\n"
+        "E: 5\r\n"
+        "\r\n");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().headers.size(), 5u);
+}
+
+TEST_F(HttpParserHeadersCoverageTest, HeaderFollowedByOnlyHeadersNoBody)
+{
+    // No "\r\n\r\n" terminator -- all remaining data treated as headers block.
+    auto result = http_parser::parse_request(
+        "GET / HTTP/1.1\r\n"
+        "X: y\r\n");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().headers["X"], "y");
+    EXPECT_TRUE(result.value().body.empty());
+}
+
+// ============================================================================
+// parse_cookies edge cases
+// ============================================================================
+
+class HttpParserCookieCoverageTest : public ::testing::Test
+{
+};
+
+TEST_F(HttpParserCookieCoverageTest, PairWithoutEqualsIgnored)
+{
+    http_request request;
+    request.headers["Cookie"] = "just_name";
+    http_parser::parse_cookies(request);
+    EXPECT_TRUE(request.cookies.empty());
+}
+
+TEST_F(HttpParserCookieCoverageTest, ValueWithEqualsSignKeptPastFirstEquals)
+{
+    http_request request;
+    request.headers["Cookie"] = "a=b=c";
+    http_parser::parse_cookies(request);
+    EXPECT_EQ(request.cookies["a"], "b=c");
+}
+
+TEST_F(HttpParserCookieCoverageTest, LeadingSemicolonSkipsEmpty)
+{
+    http_request request;
+    request.headers["Cookie"] = "; a=b";
+    http_parser::parse_cookies(request);
+    EXPECT_EQ(request.cookies["a"], "b");
+    EXPECT_EQ(request.cookies.size(), 1u);
+}
+
+TEST_F(HttpParserCookieCoverageTest, TrailingSemicolonIgnoresEmpty)
+{
+    http_request request;
+    request.headers["Cookie"] = "a=b;";
+    http_parser::parse_cookies(request);
+    EXPECT_EQ(request.cookies["a"], "b");
+    EXPECT_EQ(request.cookies.size(), 1u);
+}
+
+TEST_F(HttpParserCookieCoverageTest, DoubleSemicolonSkipsEmptyBetween)
+{
+    http_request request;
+    request.headers["Cookie"] = "a=b;; c=d";
+    http_parser::parse_cookies(request);
+    EXPECT_EQ(request.cookies["a"], "b");
+    EXPECT_EQ(request.cookies["c"], "d");
+    EXPECT_EQ(request.cookies.size(), 2u);
+}
+
+TEST_F(HttpParserCookieCoverageTest, TabWhitespaceStripped)
+{
+    http_request request;
+    request.headers["Cookie"] = "a=b;\tc=d";
+    http_parser::parse_cookies(request);
+    EXPECT_EQ(request.cookies["a"], "b");
+    EXPECT_EQ(request.cookies["c"], "d");
+}
+
+TEST_F(HttpParserCookieCoverageTest, QuotedValueNotStripped)
+{
+    http_request request;
+    request.headers["Cookie"] = "a=\"quoted\"";
+    http_parser::parse_cookies(request);
+    // parse_cookies does not strip surrounding quotes in value.
+    EXPECT_EQ(request.cookies["a"], "\"quoted\"");
+}
+
+TEST_F(HttpParserCookieCoverageTest, EmptyValueAfterEquals)
+{
+    http_request request;
+    request.headers["Cookie"] = "a=";
+    http_parser::parse_cookies(request);
+    EXPECT_EQ(request.cookies["a"], "");
+}
+
+TEST_F(HttpParserCookieCoverageTest, EmptyNameBeforeEqualsIgnored)
+{
+    http_request request;
+    request.headers["Cookie"] = "=value";
+    http_parser::parse_cookies(request);
+    EXPECT_TRUE(request.cookies.empty());
+}
+
+TEST_F(HttpParserCookieCoverageTest, MultipleNameValuePairsParsed)
+{
+    http_request request;
+    request.headers["Cookie"] = "sid=abc; pref=dark; lang=en-US";
+    http_parser::parse_cookies(request);
+    EXPECT_EQ(request.cookies["sid"], "abc");
+    EXPECT_EQ(request.cookies["pref"], "dark");
+    EXPECT_EQ(request.cookies["lang"], "en-US");
+    EXPECT_EQ(request.cookies.size(), 3u);
+}
+
+// ============================================================================
+// parse_multipart_form_data edge cases
+// ============================================================================
+
+class HttpParserMultipartCoverageTest : public ::testing::Test
+{
+protected:
+    static auto make_request(const std::string& body,
+                              const std::string& content_type) -> http_request
+    {
+        http_request req;
+        req.headers["Content-Type"] = content_type;
+        req.body = vec_from(body);
+        return req;
+    }
+};
+
+TEST_F(HttpParserMultipartCoverageTest, PartWithoutContentDispositionSkipped)
+{
+    std::string body =
+        "--BOUNDARY\r\n"
+        "X-Custom: value\r\n"
+        "\r\n"
+        "data without disposition\r\n"
+        "--BOUNDARY--\r\n";
+    auto req = make_request(body, "multipart/form-data; boundary=BOUNDARY");
+    auto result = http_parser::parse_multipart_form_data(req);
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_TRUE(req.form_data.empty());
+    EXPECT_TRUE(req.files.empty());
+}
+
+TEST_F(HttpParserMultipartCoverageTest, BoundaryWithQuotesStripped)
+{
+    std::string body =
+        "--ABC\r\n"
+        "Content-Disposition: form-data; name=\"field\"\r\n"
+        "\r\n"
+        "value\r\n"
+        "--ABC--\r\n";
+    auto req = make_request(body, "multipart/form-data; boundary=\"ABC\"");
+    auto result = http_parser::parse_multipart_form_data(req);
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(req.form_data["field"], "value");
+}
+
+TEST_F(HttpParserMultipartCoverageTest, EmptyBodyYieldsNoFormData)
+{
+    auto req = make_request("", "multipart/form-data; boundary=X");
+    auto result = http_parser::parse_multipart_form_data(req);
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_TRUE(req.form_data.empty());
+    EXPECT_TRUE(req.files.empty());
+}
+
+TEST_F(HttpParserMultipartCoverageTest, BodyWithoutAnyBoundaryYieldsNoFormData)
+{
+    auto req = make_request("garbage with no boundary markers",
+                            "multipart/form-data; boundary=X");
+    auto result = http_parser::parse_multipart_form_data(req);
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_TRUE(req.form_data.empty());
+}
+
+TEST_F(HttpParserMultipartCoverageTest, EmptyFieldValueAccepted)
+{
+    std::string body =
+        "--B\r\n"
+        "Content-Disposition: form-data; name=\"empty\"\r\n"
+        "\r\n"
+        "\r\n"
+        "--B--\r\n";
+    auto req = make_request(body, "multipart/form-data; boundary=B");
+    auto result = http_parser::parse_multipart_form_data(req);
+    ASSERT_TRUE(result.is_ok());
+    auto it = req.form_data.find("empty");
+    ASSERT_NE(it, req.form_data.end());
+    EXPECT_EQ(it->second, "");
+}
+
+TEST_F(HttpParserMultipartCoverageTest, FileUploadWithoutContentTypeUsesDefault)
+{
+    std::string body =
+        "--B\r\n"
+        "Content-Disposition: form-data; name=\"f\"; filename=\"a.bin\"\r\n"
+        "\r\n"
+        "raw bytes\r\n"
+        "--B--\r\n";
+    auto req = make_request(body, "multipart/form-data; boundary=B");
+    auto result = http_parser::parse_multipart_form_data(req);
+    ASSERT_TRUE(result.is_ok());
+    ASSERT_EQ(req.files.count("f"), 1u);
+    EXPECT_EQ(req.files["f"].filename, "a.bin");
+    EXPECT_EQ(req.files["f"].content_type, "application/octet-stream");
+    EXPECT_EQ(str_from(req.files["f"].content), "raw bytes");
+}
+
+TEST_F(HttpParserMultipartCoverageTest, FileUploadWithExplicitContentType)
+{
+    std::string body =
+        "--B\r\n"
+        "Content-Disposition: form-data; name=\"f\"; filename=\"data.txt\"\r\n"
+        "Content-Type: text/plain\r\n"
+        "\r\n"
+        "hello\r\n"
+        "--B--\r\n";
+    auto req = make_request(body, "multipart/form-data; boundary=B");
+    auto result = http_parser::parse_multipart_form_data(req);
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(req.files["f"].content_type, "text/plain");
+}
+
+TEST_F(HttpParserMultipartCoverageTest, MixedFieldsAndFilesParsed)
+{
+    std::string body =
+        "--B\r\n"
+        "Content-Disposition: form-data; name=\"text\"\r\n"
+        "\r\n"
+        "value1\r\n"
+        "--B\r\n"
+        "Content-Disposition: form-data; name=\"upload\"; filename=\"a.txt\"\r\n"
+        "Content-Type: text/plain\r\n"
+        "\r\n"
+        "file content\r\n"
+        "--B--\r\n";
+    auto req = make_request(body, "multipart/form-data; boundary=B");
+    auto result = http_parser::parse_multipart_form_data(req);
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(req.form_data["text"], "value1");
+    EXPECT_EQ(req.files["upload"].filename, "a.txt");
+    EXPECT_EQ(str_from(req.files["upload"].content), "file content");
+}
+
+// ============================================================================
+// serialize_chunked_response boundary conditions
+// ============================================================================
+
+class HttpParserChunkedCoverageTest : public ::testing::Test
+{
+};
+
+TEST_F(HttpParserChunkedCoverageTest, EmptyBodyProducesTerminatorOnly)
+{
+    http_response resp;
+    resp.version = http_version::HTTP_1_1;
+    resp.status_code = 200;
+    resp.status_message = "OK";
+    resp.use_chunked_encoding = true;
+
+    auto bytes = http_parser::serialize_response(resp);
+    auto s = str_from(bytes);
+    EXPECT_NE(s.find("Transfer-Encoding: chunked"), std::string::npos);
+    // With an empty body, the only chunk is the zero-size terminator.
+    EXPECT_NE(s.rfind("0\r\n\r\n"), std::string::npos);
+    // There must not be any non-terminator chunks.
+    EXPECT_EQ(s.find("\r\n\r\n") + 4, s.find("0\r\n\r\n"));
+}
+
+TEST_F(HttpParserChunkedCoverageTest, BodyExactlyChunkSizeProducesSingleChunk)
+{
+    http_response resp;
+    resp.version = http_version::HTTP_1_1;
+    resp.status_code = 200;
+    resp.status_message = "OK";
+    resp.use_chunked_encoding = true;
+    resp.body.assign(8192u, 'A');
+
+    auto bytes = http_parser::serialize_response(resp);
+    auto s = str_from(bytes);
+    // 8192 in hex is "2000"
+    EXPECT_NE(s.find("2000\r\n"), std::string::npos);
+    EXPECT_NE(s.rfind("0\r\n\r\n"), std::string::npos);
+    // There should be no 0x2000-and-something-bigger encoding: no two chunks.
+    EXPECT_EQ(s.find("2000\r\n"), s.rfind("2000\r\n"));
+}
+
+TEST_F(HttpParserChunkedCoverageTest, BodyExceedingChunkSizeSplitsIntoMultiple)
+{
+    http_response resp;
+    resp.version = http_version::HTTP_1_1;
+    resp.status_code = 200;
+    resp.status_message = "OK";
+    resp.use_chunked_encoding = true;
+    resp.body.assign(10000u, 'X');
+
+    auto bytes = http_parser::serialize_response(resp);
+    auto s = str_from(bytes);
+    // First chunk: 8192 bytes -> "2000"
+    EXPECT_NE(s.find("2000\r\n"), std::string::npos);
+    // Second chunk: 10000 - 8192 = 1808 = 0x710
+    EXPECT_NE(s.find("710\r\n"), std::string::npos);
+    EXPECT_NE(s.rfind("0\r\n\r\n"), std::string::npos);
+}
+
+TEST_F(HttpParserChunkedCoverageTest, LowercaseContentLengthHeaderRemoved)
+{
+    http_response resp;
+    resp.version = http_version::HTTP_1_1;
+    resp.status_code = 200;
+    resp.status_message = "OK";
+    resp.use_chunked_encoding = true;
+    resp.headers["content-length"] = "42";  // lowercase variant
+    resp.body = vec_from("abc");
+
+    auto bytes = http_parser::serialize_response(resp);
+    auto s = str_from(bytes);
+    EXPECT_EQ(s.find("content-length"), std::string::npos);
+    EXPECT_NE(s.find("Transfer-Encoding: chunked"), std::string::npos);
+}
+
+TEST_F(HttpParserChunkedCoverageTest, MixedCaseContentLengthHeaderRemoved)
+{
+    http_response resp;
+    resp.version = http_version::HTTP_1_1;
+    resp.status_code = 200;
+    resp.status_message = "OK";
+    resp.use_chunked_encoding = true;
+    resp.headers["Content-Length"] = "42";
+    resp.body = vec_from("abc");
+
+    auto bytes = http_parser::serialize_response(resp);
+    auto s = str_from(bytes);
+    EXPECT_EQ(s.find("Content-Length"), std::string::npos);
+}
+
+TEST_F(HttpParserChunkedCoverageTest, SetCookiePreservedInChunkedResponse)
+{
+    http_response resp;
+    resp.version = http_version::HTTP_1_1;
+    resp.status_code = 200;
+    resp.status_message = "OK";
+    resp.use_chunked_encoding = true;
+    cookie c;
+    c.name = "sid";
+    c.value = "abc";
+    resp.set_cookies.push_back(c);
+    resp.body = vec_from("x");
+
+    auto bytes = http_parser::serialize_response(resp);
+    auto s = str_from(bytes);
+    EXPECT_NE(s.find("Set-Cookie"), std::string::npos);
+    EXPECT_NE(s.find("sid"), std::string::npos);
+}
+
+TEST_F(HttpParserChunkedCoverageTest, Http10UseChunkedFlagFallsBackToPlain)
+{
+    http_response resp;
+    resp.version = http_version::HTTP_1_0;
+    resp.status_code = 200;
+    resp.status_message = "OK";
+    resp.use_chunked_encoding = true;
+    resp.body = vec_from("hello");
+
+    auto bytes = http_parser::serialize_response(resp);
+    auto s = str_from(bytes);
+    // HTTP/1.0 + use_chunked_encoding -> plain serializer, no
+    // Transfer-Encoding header emitted.
+    EXPECT_EQ(s.find("Transfer-Encoding"), std::string::npos);
+    EXPECT_NE(s.find("hello"), std::string::npos);
+}
+
+// ============================================================================
+// Flow-level coverage (byte vector parity, binary bodies, no-separator)
+// ============================================================================
+
+class HttpParserFlowCoverageTest : public ::testing::Test
+{
+};
+
+TEST_F(HttpParserFlowCoverageTest, ParseRequestByteVectorMatchesStringView)
+{
+    std::string raw =
+        "POST /api HTTP/1.1\r\n"
+        "Host: example.com\r\n"
+        "Content-Type: application/json\r\n"
+        "\r\n"
+        "{\"k\":\"v\"}";
+    auto vec_result = http_parser::parse_request(vec_from(raw));
+    auto sv_result = http_parser::parse_request(std::string_view(raw));
+    ASSERT_TRUE(vec_result.is_ok());
+    ASSERT_TRUE(sv_result.is_ok());
+    EXPECT_EQ(vec_result.value().uri, sv_result.value().uri);
+    EXPECT_EQ(vec_result.value().headers, sv_result.value().headers);
+    EXPECT_EQ(vec_result.value().body, sv_result.value().body);
+}
+
+TEST_F(HttpParserFlowCoverageTest, ParseResponseByteVectorMatchesStringView)
+{
+    std::string raw =
+        "HTTP/1.1 201 Created\r\n"
+        "Location: /new\r\n"
+        "\r\n";
+    auto vec_result = http_parser::parse_response(vec_from(raw));
+    auto sv_result = http_parser::parse_response(std::string_view(raw));
+    ASSERT_TRUE(vec_result.is_ok());
+    ASSERT_TRUE(sv_result.is_ok());
+    EXPECT_EQ(vec_result.value().status_code, sv_result.value().status_code);
+    EXPECT_EQ(vec_result.value().status_message,
+              sv_result.value().status_message);
+}
+
+TEST_F(HttpParserFlowCoverageTest, RequestWithBinaryBodyPreserved)
+{
+    std::vector<uint8_t> body_bytes = {
+        0x00, 0x01, 0xFF, 0xFE, 0x7F, 0x80, 0x00, 0xAA};
+
+    std::string header =
+        "POST /upload HTTP/1.1\r\n"
+        "Content-Length: 8\r\n"
+        "\r\n";
+    std::vector<uint8_t> raw(header.begin(), header.end());
+    raw.insert(raw.end(), body_bytes.begin(), body_bytes.end());
+
+    auto result = http_parser::parse_request(raw);
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().body, body_bytes);
+}
+
+TEST_F(HttpParserFlowCoverageTest, ResponseWithBinaryBodyPreserved)
+{
+    std::vector<uint8_t> body_bytes = {0xCA, 0xFE, 0xBA, 0xBE};
+
+    std::string header =
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Length: 4\r\n"
+        "\r\n";
+    std::vector<uint8_t> raw(header.begin(), header.end());
+    raw.insert(raw.end(), body_bytes.begin(), body_bytes.end());
+
+    auto result = http_parser::parse_response(raw);
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().body, body_bytes);
+}
+
+TEST_F(HttpParserFlowCoverageTest, EmptyStringReturnsError)
+{
+    auto req = http_parser::parse_request(std::string_view(""));
+    EXPECT_TRUE(req.is_err());
+    auto resp = http_parser::parse_response(std::string_view(""));
+    EXPECT_TRUE(resp.is_err());
+}
+
+TEST_F(HttpParserFlowCoverageTest, EmptyByteVectorReturnsError)
+{
+    std::vector<uint8_t> empty;
+    auto req = http_parser::parse_request(empty);
+    EXPECT_TRUE(req.is_err());
+    auto resp = http_parser::parse_response(empty);
+    EXPECT_TRUE(resp.is_err());
+}
+
+TEST_F(HttpParserFlowCoverageTest, LfOnlyLineTerminatorNotAccepted)
+{
+    // split_line looks for "\r\n"; a line with only "\n" won't split, so the
+    // whole blob becomes the request line, which then lacks a version field.
+    auto result = http_parser::parse_request(std::string_view(
+        "GET / HTTP/1.1\nHost: x\n\n"));
+    EXPECT_TRUE(result.is_err());
+}
+
+TEST_F(HttpParserFlowCoverageTest, ResponseWithoutHeadersBodyOk)
+{
+    auto result = http_parser::parse_response("HTTP/1.1 204 No Content\r\n");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_EQ(result.value().status_code, 204);
+    EXPECT_TRUE(result.value().body.empty());
+}
+
+TEST_F(HttpParserFlowCoverageTest, RequestWithHeaderSeparatorButNoBody)
+{
+    auto result = http_parser::parse_request(
+        "GET / HTTP/1.1\r\n"
+        "X: y\r\n"
+        "\r\n");
+    ASSERT_TRUE(result.is_ok());
+    EXPECT_TRUE(result.value().body.empty());
+    EXPECT_EQ(result.value().headers["X"], "y");
+}
+
+// ============================================================================
+// Round-trip coverage (serialize then re-parse)
+// ============================================================================
+
+class HttpParserRoundTripCoverageTest : public ::testing::Test
+{
+};
+
+TEST_F(HttpParserRoundTripCoverageTest, RequestNoHeadersNoBody)
+{
+    http_request original;
+    original.method = http_method::HTTP_GET;
+    original.uri = "/";
+    original.version = http_version::HTTP_1_1;
+
+    auto bytes = http_parser::serialize_request(original);
+    auto parsed = http_parser::parse_request(bytes);
+    ASSERT_TRUE(parsed.is_ok());
+    EXPECT_EQ(parsed.value().method, original.method);
+    EXPECT_EQ(parsed.value().uri, original.uri);
+    EXPECT_EQ(parsed.value().version, original.version);
+    EXPECT_TRUE(parsed.value().body.empty());
+}
+
+TEST_F(HttpParserRoundTripCoverageTest, RequestWithManyHeadersRoundTrip)
+{
+    http_request original;
+    original.method = http_method::HTTP_POST;
+    original.uri = "/api";
+    original.version = http_version::HTTP_1_1;
+    original.headers["Content-Type"] = "application/json";
+    original.headers["Accept"] = "*/*";
+    original.headers["X-Custom-A"] = "valueA";
+    original.headers["X-Custom-B"] = "valueB";
+    original.body = vec_from("{}");
+
+    auto bytes = http_parser::serialize_request(original);
+    auto parsed = http_parser::parse_request(bytes);
+    ASSERT_TRUE(parsed.is_ok());
+    EXPECT_EQ(parsed.value().uri, original.uri);
+    EXPECT_EQ(parsed.value().headers, original.headers);
+    EXPECT_EQ(parsed.value().body, original.body);
+}
+
+TEST_F(HttpParserRoundTripCoverageTest, ResponseInformationalStatusRoundTrip)
+{
+    http_response original;
+    original.version = http_version::HTTP_1_1;
+    original.status_code = 100;
+    original.status_message = "Continue";
+
+    auto bytes = http_parser::serialize_response(original);
+    auto parsed = http_parser::parse_response(bytes);
+    ASSERT_TRUE(parsed.is_ok());
+    EXPECT_EQ(parsed.value().status_code, 100);
+    EXPECT_EQ(parsed.value().status_message, "Continue");
+}
+
+TEST_F(HttpParserRoundTripCoverageTest, ResponseStatusMessageWithMultipleWords)
+{
+    http_response original;
+    original.version = http_version::HTTP_1_1;
+    original.status_code = 200;
+    original.status_message = "OK Very Fine";
+
+    auto bytes = http_parser::serialize_response(original);
+    auto parsed = http_parser::parse_response(bytes);
+    ASSERT_TRUE(parsed.is_ok());
+    EXPECT_EQ(parsed.value().status_code, 200);
+    EXPECT_EQ(parsed.value().status_message, "OK Very Fine");
+}
+
+TEST_F(HttpParserRoundTripCoverageTest, QueryParamsSurviveRoundTrip)
+{
+    http_request original;
+    original.method = http_method::HTTP_GET;
+    original.uri = "/search";
+    original.version = http_version::HTTP_1_1;
+    original.query_params["q"] = "hello world";
+    original.query_params["n"] = "10";
+
+    auto bytes = http_parser::serialize_request(original);
+    auto parsed = http_parser::parse_request(bytes);
+    ASSERT_TRUE(parsed.is_ok());
+    EXPECT_EQ(parsed.value().query_params, original.query_params);
+}
+
+TEST_F(HttpParserRoundTripCoverageTest, CommaSeparatedHeaderValueKept)
+{
+    http_request original;
+    original.method = http_method::HTTP_GET;
+    original.uri = "/";
+    original.version = http_version::HTTP_1_1;
+    original.headers["Accept-Language"] = "en-US,en;q=0.9,fr;q=0.8";
+
+    auto bytes = http_parser::serialize_request(original);
+    auto parsed = http_parser::parse_request(bytes);
+    ASSERT_TRUE(parsed.is_ok());
+    EXPECT_EQ(parsed.value().headers["Accept-Language"],
+              "en-US,en;q=0.9,fr;q=0.8");
+}
+
+TEST_F(HttpParserRoundTripCoverageTest, ColonInHeaderValueSurvives)
+{
+    http_request original;
+    original.method = http_method::HTTP_GET;
+    original.uri = "/";
+    original.version = http_version::HTTP_1_1;
+    original.headers["X-Forwarded"] = "proto: https";
+
+    auto bytes = http_parser::serialize_request(original);
+    auto parsed = http_parser::parse_request(bytes);
+    ASSERT_TRUE(parsed.is_ok());
+    EXPECT_EQ(parsed.value().headers["X-Forwarded"], "proto: https");
+}
+
+// ============================================================================
+// serialize_request / serialize_response byte-level invariants
+// ============================================================================
+
+class HttpParserSerializeInvariantTest : public ::testing::Test
+{
+};
+
+TEST_F(HttpParserSerializeInvariantTest, RequestStartsWithMethod)
+{
+    http_request r;
+    r.method = http_method::HTTP_GET;
+    r.uri = "/";
+    r.version = http_version::HTTP_1_1;
+    auto bytes = http_parser::serialize_request(r);
+    auto s = str_from(bytes);
+    EXPECT_EQ(s.substr(0, 4), "GET ");
+}
+
+TEST_F(HttpParserSerializeInvariantTest, ResponseStartsWithVersion)
+{
+    http_response r;
+    r.version = http_version::HTTP_1_1;
+    r.status_code = 200;
+    r.status_message = "OK";
+    auto bytes = http_parser::serialize_response(r);
+    auto s = str_from(bytes);
+    EXPECT_EQ(s.substr(0, 9), "HTTP/1.1 ");
+}
+
+TEST_F(HttpParserSerializeInvariantTest, HeadersTerminatedByDoubleCrlf)
+{
+    http_request r;
+    r.method = http_method::HTTP_GET;
+    r.uri = "/";
+    r.version = http_version::HTTP_1_1;
+    r.headers["X"] = "y";
+    auto bytes = http_parser::serialize_request(r);
+    auto s = str_from(bytes);
+    EXPECT_NE(s.find("\r\n\r\n"), std::string::npos);
+}
+
+TEST_F(HttpParserSerializeInvariantTest, QueryParamsAppendedAfterQuestionMark)
+{
+    http_request r;
+    r.method = http_method::HTTP_GET;
+    r.uri = "/search";
+    r.version = http_version::HTTP_1_1;
+    r.query_params["q"] = "cpp";
+
+    auto bytes = http_parser::serialize_request(r);
+    auto s = str_from(bytes);
+    EXPECT_NE(s.find("/search?q=cpp"), std::string::npos);
+}
+
+TEST_F(HttpParserSerializeInvariantTest, BodyAppendedAfterHeaderSeparator)
+{
+    http_request r;
+    r.method = http_method::HTTP_POST;
+    r.uri = "/data";
+    r.version = http_version::HTTP_1_1;
+    r.body = vec_from("payload");
+
+    auto bytes = http_parser::serialize_request(r);
+    auto s = str_from(bytes);
+    auto sep_pos = s.find("\r\n\r\n");
+    ASSERT_NE(sep_pos, std::string::npos);
+    EXPECT_EQ(s.substr(sep_pos + 4), "payload");
+}
+
+TEST_F(HttpParserSerializeInvariantTest, ResponseWithoutBodyEndsAtSeparator)
+{
+    http_response r;
+    r.version = http_version::HTTP_1_1;
+    r.status_code = 204;
+    r.status_message = "No Content";
+
+    auto bytes = http_parser::serialize_response(r);
+    auto s = str_from(bytes);
+    // Must end with \r\n\r\n and nothing after.
+    EXPECT_TRUE(s.size() >= 4);
+    EXPECT_EQ(s.substr(s.size() - 4), "\r\n\r\n");
+}
+
+TEST_F(HttpParserSerializeInvariantTest, SetCookieEmittedInSerializeResponse)
+{
+    http_response r;
+    r.version = http_version::HTTP_1_1;
+    r.status_code = 200;
+    r.status_message = "OK";
+    cookie c;
+    c.name = "sid";
+    c.value = "xyz";
+    r.set_cookies.push_back(c);
+
+    auto bytes = http_parser::serialize_response(r);
+    EXPECT_TRUE(contains(bytes, "Set-Cookie"));
+    EXPECT_TRUE(contains(bytes, "sid"));
+    EXPECT_TRUE(contains(bytes, "xyz"));
+}
+
+TEST_F(HttpParserSerializeInvariantTest, RequestSerializationEndsCorrectlyWithNoBody)
+{
+    http_request r;
+    r.method = http_method::HTTP_HEAD;
+    r.uri = "/ping";
+    r.version = http_version::HTTP_1_1;
+
+    auto bytes = http_parser::serialize_request(r);
+    auto s = str_from(bytes);
+    EXPECT_EQ(s.substr(s.size() - 4), "\r\n\r\n");
+}


### PR DESCRIPTION
Closes #1013

## What

### Summary
Adds `tests/unit/http_parser_coverage_test.cpp` — 112 `TEST_F` cases targeting
the error-path and edge-case branches in `src/internal/http_parser.cpp` that
the existing `http_parser_test.cpp` (88 happy-path / basic-error cases) does
not reach.

### Change Type
- [x] Test (new functionality)
- [ ] Feature / bugfix / refactor / docs / chore

### Affected Components
- `tests/unit/http_parser_coverage_test.cpp` — new file (1257 lines)
- `tests/CMakeLists.txt` — register `network_http_parser_coverage_test`
  adjacent to other HTTP coverage tests (`network_hpack_coverage_test`,
  `network_http2_{client,server}_coverage_test`)

## Why

### Problem Solved
`src/internal/http_parser.cpp` (752 lines) is the single largest remaining
low-coverage translation unit under EPIC #953:

| File | LOC | Baseline coverage (2026-04-13) |
|------|-----|-------------------------------|
| `internal/http_parser.cpp` | 752 | **6.0% — largest absolute gap** |
| `protocols/quic/transport_params.cpp` | 680 | 4.2% |
| `protocols/quic/packet.cpp` | 639 | 11.0% |
| `protocols/http2/frame.cpp` | 593 | 12.9% |

Existing `tests/unit/http_parser_test.cpp` covers build/parse round-trips
and basic errors but skips:

- Parser error branches — unknown HTTP method, unknown version, truncated
  fields, non-numeric status code (which triggers `std::stoi` throw path)
- URL decode edge cases — trailing `%`, truncated `%X`, lowercase hex
- URL encode safe-character matrix and high-bit / null byte encoding
- `parse_query_string` delimiter edge cases — leading / trailing / double
  `&`, empty key, multi-`=` in values, URL-encoded delimiter preserved in
  value, duplicate keys
- `parse_cookies` edge cases — pair without `=`, value containing `=`,
  empty name, tab separator, quoted value (not stripped)
- `parse_multipart_form_data` edge cases beyond the 2 existing error tests
  — part without Content-Disposition, `boundary="quoted"`, body with no
  boundary, empty body, file without explicit Content-Type
- `serialize_chunked_response` boundary conditions — empty body, body
  exactly at 8192, body > 8192 (multi-chunk), lowercase `content-length`
  header removal, Set-Cookie preservation, HTTP/1.0 fallback
- Binary body preservation, byte-vector vs `string_view` overload parity

### Related Issues
- Closes #1013 (test expansion for `src/internal/http_parser.cpp`)
- Part of #953 (EPIC — expand unit test coverage from 40% to 80%)

Follows the pattern established by prior sub-issues:
#990 (connection), #991 (http2_client), #992 (http2_server), #993 (crypto),
#994 (grpc client), #1003 (http_error), #1005 (exporters), #1007
(loss_detector), #1009 (hpack), #1011 (quic frame).

## Who

### Reviewers
- Repository maintainers

### Required Approvals
- [ ] Code review
- [ ] CI pipeline (Ubuntu/macOS/Windows + ASAN/TSAN/UBSAN + coverage)

## When

### Urgency
Normal — follows standard review process.

### Target
EPIC #953 makes this a v1.0 readiness dependency (see #964).

## Where

### Files Changed
| File | Type | Lines |
|------|------|-------|
| `tests/unit/http_parser_coverage_test.cpp` | New | +1257 |
| `tests/CMakeLists.txt` | Modified | +8 |

### Test Coverage Targeted

| Area | Existing tests | New coverage |
|------|----------------|--------------|
| `url_encode` | 6 cases | Safe-char sweep, high-bit/null bytes, UTF-8 multi-byte, exhaustive reserved-char mapping (11 new) |
| `url_decode` | 6 cases | Truncated `%` at end, `%X` one-char-after, lowercase hex, mixed case, null / high-bit decode, `+` at start/end, 255-byte round-trip sweep (11 new) |
| `parse_query_string` | 5 cases | Leading/trailing/double `&`, empty key, multi-`=` values, URL-encoded delimiters in value, duplicate keys (10 new) |
| `build_query_string` | 4 cases | Empty map, key/value encoding, empty-value omission, multi-param ordering, round-trip (6 new) |
| `parse_request_line` | 4 basic errors | Unknown method/version, multi-`?` URI, trailing-`?` URI, URI with only `?`, empty query key (8 new) |
| `parse_status_line` | 3 basic errors | Non-numeric status, no spaces, unknown version, status code 0, no message defaults to canonical, multi-word message, 5-digit status, empty message trim, 1xx (9 new) |
| `parse_headers` | Basic | Multi-colon value, empty value, colon-only line, trailing whitespace, header without colon → error, duplicate last-wins, no header terminator (8 new) |
| `parse_cookies` | 4 cases | Pair without `=` ignored, value with `=`, leading/trailing/double `;`, tab separator, quoted value preserved, empty value, empty name ignored, multi-pair (10 new) |
| `parse_multipart_form_data` | 5 cases | Part without Content-Disposition, quoted boundary, empty body, body with no boundary, empty field value, file without Content-Type, file with explicit Content-Type, mixed fields + files (8 new) |
| `serialize_chunked_response` | 3 cases | Empty body (terminator only), body = 8192 (single chunk), body > 8192 (multi-chunk), lowercase `content-length` removal, mixed-case removal, Set-Cookie preserved, HTTP/1.0 fallback (7 new) |
| Flow (byte-vector / binary body / LF-only / no-separator) | Basic | `std::vector<uint8_t>` vs `string_view` parity (request + response), binary body preservation, empty inputs, LF-only rejection, response without headers body, request with separator but no body (9 new) |
| Round-trip serialize → parse | 3 cases | No-headers-no-body, many-headers, informational 1xx, multi-word status message, query-param survival, comma-separated header, colon-in-value survival (7 new) |
| Serialize byte-level invariants | Implicit | Request starts with method, response starts with version, `\r\n\r\n` present, query appended after `?`, body after separator, no-body ends at separator, Set-Cookie emitted, HEAD ending (8 new) |

## How

### Implementation Details

1. Every new test constructs malformed or edge-case inputs by hand against
   the RFC 7230/7231 (HTTP/1.1) wire format and the parser's documented
   error contract. The failure being tested is the parser, not the builder.
2. No private/friend access — all tests use the public API of `http_parser`,
   and populate `http_request::headers` directly where the test exercises a
   post-parse helper such as `parse_cookies` or `parse_multipart_form_data`.
3. No network I/O or external peer; every test runs in memory.
4. Test groups are organised by method-under-test in dedicated fixture
   classes (`HttpParserUrlEncodeCoverageTest`,
   `HttpParserQueryStringCoverageTest`, etc.) so that coverage regressions
   surface against a specific surface area.

### Testing Done

- [x] Static symbol verification (all referenced types exist in
  `http_types.h`: `http_method` uses `HTTP_` prefix, `cookie` struct has
  `name`/`value`/`path`/... fields, `http_version` uses `HTTP_1_1` etc.;
  all includes match existing coverage tests)
- [ ] Local build — **CMake/ninja/compiler not available in this
  environment**; relying on CI
- [ ] Ubuntu GCC/Clang, macOS, Windows MSVC + sanitizer builds via CI

### Test Plan for Reviewers

1. `cmake --preset release && cmake --build build`
2. `./build/bin/network_http_parser_coverage_test`
3. Expect all 112 cases to pass
4. Regenerate coverage: `cmake --preset default -DENABLE_COVERAGE=ON &&
   cmake --build build && ctest --test-dir build && lcov ...`
5. Verify line + branch coverage on `src/internal/http_parser.cpp`
   improves meaningfully (targeting the 6.0% → 70%+ range)

### Breaking Changes
None — test-only change, additive.

### Rollback Plan
Revert this PR. No production code affected.

### Observations (for potential follow-up)

`http_parser::url_decode` silently drops a trailing `%` (or `%X` with only
one character after) because the guard `i + 2 < value.length()` is false in
those cases — no error is signalled. This matches lenient RFC 3986 §2.1
behavior (malformed percent encoding is implementation-defined) but may be
undesirable for strict parsing; if the project wants stricter handling,
file a separate issue. Additionally, `url_decode` calls `std::stoi(hex,
nullptr, 16)` on a two-character substring without validating it contains
only hex digits — inputs such as `"%XY"` will trigger
`std::invalid_argument`. Both observations are out of scope for #1013
(test-expansion-only).
