### PR TITLE
test(quic): expand experimental/quic_server.cpp coverage

### DIFF
--- a/tests/test_messaging_quic_server.cpp
+++ b/tests/test_messaging_quic_server.cpp
@@ -5,8 +5,12 @@
 #include <gtest/gtest.h>
 #include <atomic>
 #include <chrono>
-#include <thread>
+#include <cstdint>
 #include <future>
+#include <limits>
+#include <string>
+#include <thread>
+#include <vector>
 
 #define NETWORK_USE_EXPERIMENTAL
 #include "internal/experimental/quic_server.h"
@@ -470,6 +474,490 @@ TEST_F(MessagingQuicServerTest, TypeAliasSecureQuicServer)
 	auto server = std::make_shared<secure_quic_server>("secure_alias_test");
 	EXPECT_FALSE(server->is_running());
 	EXPECT_EQ(server->server_id(), "secure_alias_test");
+}
+
+// =============================================================================
+// Constructor Variation Tests
+// =============================================================================
+
+TEST_F(MessagingQuicServerTest, ConstructWithEmptyServerId)
+{
+	auto server = std::make_shared<messaging_quic_server>("");
+	EXPECT_FALSE(server->is_running());
+	EXPECT_EQ(server->server_id(), "");
+	EXPECT_EQ(server->session_count(), 0);
+	EXPECT_EQ(server->connection_count(), 0);
+}
+
+TEST_F(MessagingQuicServerTest, ConstructWithLongServerId)
+{
+	const std::string long_id(1024, 'x');
+	auto server = std::make_shared<messaging_quic_server>(long_id);
+	EXPECT_FALSE(server->is_running());
+	EXPECT_EQ(server->server_id(), long_id);
+}
+
+TEST_F(MessagingQuicServerTest, ConstructWithSpecialCharactersInId)
+{
+	auto server = std::make_shared<messaging_quic_server>("server-1.2_test/A:B");
+	EXPECT_EQ(server->server_id(), "server-1.2_test/A:B");
+	EXPECT_FALSE(server->is_running());
+}
+
+TEST_F(MessagingQuicServerTest, ConstructFromStringView)
+{
+	std::string id = "view_id_test";
+	std::string_view sv(id);
+	auto server = std::make_shared<messaging_quic_server>(sv);
+	EXPECT_EQ(server->server_id(), "view_id_test");
+}
+
+// =============================================================================
+// Server-not-running Guard Tests
+// =============================================================================
+
+TEST_F(MessagingQuicServerTest, ConnectionCountIsZeroBeforeStart)
+{
+	auto server = std::make_shared<messaging_quic_server>("guard_conn_count");
+	EXPECT_EQ(server->connection_count(), 0);
+	EXPECT_EQ(server->session_count(), 0);
+}
+
+TEST_F(MessagingQuicServerTest, SessionsListEmptyBeforeStart)
+{
+	auto server = std::make_shared<messaging_quic_server>("guard_sessions");
+	auto list = server->sessions();
+	EXPECT_TRUE(list.empty());
+}
+
+TEST_F(MessagingQuicServerTest, GetSessionEmptyIdReturnsNull)
+{
+	auto server = std::make_shared<messaging_quic_server>("guard_empty_id");
+	EXPECT_EQ(server->get_session(""), nullptr);
+}
+
+TEST_F(MessagingQuicServerTest, GetSessionLongIdReturnsNull)
+{
+	auto server = std::make_shared<messaging_quic_server>("guard_long_id");
+	const std::string long_id(2048, 'q');
+	EXPECT_EQ(server->get_session(long_id), nullptr);
+}
+
+TEST_F(MessagingQuicServerTest, DisconnectAllBeforeStartDoesNotThrow)
+{
+	auto server = std::make_shared<messaging_quic_server>("guard_disc_all");
+	EXPECT_NO_THROW(server->disconnect_all(0));
+	EXPECT_NO_THROW(server->disconnect_all(42));
+	EXPECT_EQ(server->session_count(), 0);
+}
+
+// =============================================================================
+// Interface (i_quic_server) Alias Tests
+// =============================================================================
+
+TEST_F(MessagingQuicServerTest, StartStopAliasMethods)
+{
+	auto server = std::make_shared<messaging_quic_server>("alias_methods");
+	auto port = get_available_port();
+
+	auto start_result = server->start(port);
+	EXPECT_TRUE(start_result.is_ok());
+	EXPECT_TRUE(server->is_running());
+
+	auto stop_result = server->stop();
+	EXPECT_TRUE(stop_result.is_ok());
+	EXPECT_FALSE(server->is_running());
+}
+
+TEST_F(MessagingQuicServerTest, StopAliasWhenNotRunning)
+{
+	auto server = std::make_shared<messaging_quic_server>("alias_stop_idle");
+	auto result = server->stop();
+	EXPECT_TRUE(result.is_err());
+	EXPECT_EQ(result.error().code,
+		error_codes::network_system::server_not_started);
+}
+
+// =============================================================================
+// Interface Callback Setter Tests (i_quic_server)
+// =============================================================================
+
+TEST_F(MessagingQuicServerTest, SetInterfaceConnectionCallback)
+{
+	auto server = std::make_shared<messaging_quic_server>("iface_conn_cb");
+	bool invoked = false;
+	interfaces::i_quic_server::connection_callback_t cb =
+		[&](std::shared_ptr<interfaces::i_quic_session>) { invoked = true; };
+	server->set_connection_callback(std::move(cb));
+	EXPECT_FALSE(invoked);
+}
+
+TEST_F(MessagingQuicServerTest, SetInterfaceDisconnectionCallback)
+{
+	auto server = std::make_shared<messaging_quic_server>("iface_disc_cb");
+	bool invoked = false;
+	interfaces::i_quic_server::disconnection_callback_t cb =
+		[&](std::string_view) { invoked = true; };
+	server->set_disconnection_callback(std::move(cb));
+	EXPECT_FALSE(invoked);
+}
+
+TEST_F(MessagingQuicServerTest, SetInterfaceReceiveCallback)
+{
+	auto server = std::make_shared<messaging_quic_server>("iface_recv_cb");
+	bool invoked = false;
+	interfaces::i_quic_server::receive_callback_t cb =
+		[&](std::string_view, const std::vector<uint8_t>&) { invoked = true; };
+	server->set_receive_callback(std::move(cb));
+	EXPECT_FALSE(invoked);
+}
+
+TEST_F(MessagingQuicServerTest, SetInterfaceStreamCallback)
+{
+	auto server = std::make_shared<messaging_quic_server>("iface_stream_cb");
+	bool invoked = false;
+	interfaces::i_quic_server::stream_callback_t cb =
+		[&](std::string_view, uint64_t,
+			const std::vector<uint8_t>&, bool) { invoked = true; };
+	server->set_stream_callback(std::move(cb));
+	EXPECT_FALSE(invoked);
+}
+
+TEST_F(MessagingQuicServerTest, SetInterfaceErrorCallback)
+{
+	auto server = std::make_shared<messaging_quic_server>("iface_err_cb");
+	bool invoked = false;
+	interfaces::i_quic_server::error_callback_t cb =
+		[&](std::string_view, std::error_code) { invoked = true; };
+	server->set_error_callback(std::move(cb));
+	EXPECT_FALSE(invoked);
+}
+
+TEST_F(MessagingQuicServerTest, NullInterfaceCallbacksAreSafe)
+{
+	auto server = std::make_shared<messaging_quic_server>("iface_null_cb");
+	server->set_connection_callback(
+		interfaces::i_quic_server::connection_callback_t{});
+	server->set_disconnection_callback(
+		interfaces::i_quic_server::disconnection_callback_t{});
+	server->set_receive_callback(
+		interfaces::i_quic_server::receive_callback_t{});
+	server->set_stream_callback(
+		interfaces::i_quic_server::stream_callback_t{});
+	server->set_error_callback(
+		interfaces::i_quic_server::error_callback_t{});
+	SUCCEED();
+}
+
+TEST_F(MessagingQuicServerTest, NullLegacyCallbacksAreSafe)
+{
+	auto server = std::make_shared<messaging_quic_server>("legacy_null_cb");
+	server->set_connection_callback(messaging_quic_server::connection_callback_t{});
+	server->set_disconnection_callback(messaging_quic_server::disconnection_callback_t{});
+	server->set_receive_callback(messaging_quic_server::receive_callback_t{});
+	server->set_stream_receive_callback(messaging_quic_server::stream_receive_callback_t{});
+	server->set_error_callback(messaging_quic_server::error_callback_t{});
+	SUCCEED();
+}
+
+// =============================================================================
+// Configuration Boundary Tests
+// =============================================================================
+
+TEST_F(MessagingQuicServerTest, ConfigZeroMaxConnections)
+{
+	quic_server_config config;
+	config.max_connections = 0;
+	EXPECT_EQ(config.max_connections, 0u);
+
+	auto server = std::make_shared<messaging_quic_server>("cfg_zero_max");
+	auto port = get_available_port();
+	auto start_result = server->start_server(port, config);
+	EXPECT_TRUE(start_result.is_ok());
+	EXPECT_EQ(server->session_count(), 0);
+	auto stop_result = server->stop_server();
+	EXPECT_TRUE(stop_result.is_ok());
+}
+
+TEST_F(MessagingQuicServerTest, ConfigMaxUint64Timeouts)
+{
+	quic_server_config config;
+	config.max_idle_timeout_ms = std::numeric_limits<uint64_t>::max();
+	config.initial_max_data = std::numeric_limits<uint64_t>::max();
+	config.initial_max_stream_data = std::numeric_limits<uint64_t>::max();
+	config.initial_max_streams_bidi = std::numeric_limits<uint64_t>::max();
+	config.initial_max_streams_uni = std::numeric_limits<uint64_t>::max();
+
+	EXPECT_EQ(config.max_idle_timeout_ms, std::numeric_limits<uint64_t>::max());
+	EXPECT_EQ(config.initial_max_data, std::numeric_limits<uint64_t>::max());
+	EXPECT_EQ(config.initial_max_stream_data, std::numeric_limits<uint64_t>::max());
+}
+
+TEST_F(MessagingQuicServerTest, ConfigZeroTimeouts)
+{
+	quic_server_config config;
+	config.max_idle_timeout_ms = 0;
+	config.initial_max_data = 0;
+	config.initial_max_stream_data = 0;
+	config.initial_max_streams_bidi = 0;
+	config.initial_max_streams_uni = 0;
+
+	EXPECT_EQ(config.max_idle_timeout_ms, 0u);
+	EXPECT_EQ(config.initial_max_data, 0u);
+	EXPECT_EQ(config.initial_max_streams_bidi, 0u);
+}
+
+TEST_F(MessagingQuicServerTest, ConfigManyAlpnProtocols)
+{
+	quic_server_config config;
+	for (int i = 0; i < 32; ++i)
+	{
+		config.alpn_protocols.push_back("proto-" + std::to_string(i));
+	}
+	EXPECT_EQ(config.alpn_protocols.size(), 32u);
+	EXPECT_EQ(config.alpn_protocols.front(), "proto-0");
+	EXPECT_EQ(config.alpn_protocols.back(), "proto-31");
+}
+
+TEST_F(MessagingQuicServerTest, ConfigRetryDisabledWithKey)
+{
+	quic_server_config config;
+	config.enable_retry = false;
+	config.retry_key = std::vector<uint8_t>(32, 0xAB);
+	EXPECT_FALSE(config.enable_retry);
+	EXPECT_EQ(config.retry_key.size(), 32u);
+	EXPECT_EQ(config.retry_key[0], 0xAB);
+}
+
+TEST_F(MessagingQuicServerTest, ConfigCopyAssignment)
+{
+	quic_server_config a;
+	a.cert_file = "/etc/ssl/cert.pem";
+	a.key_file = "/etc/ssl/key.pem";
+	a.max_connections = 1234;
+	a.alpn_protocols = {"h3"};
+
+	quic_server_config b = a;
+	EXPECT_EQ(b.cert_file, "/etc/ssl/cert.pem");
+	EXPECT_EQ(b.key_file, "/etc/ssl/key.pem");
+	EXPECT_EQ(b.max_connections, 1234u);
+	ASSERT_EQ(b.alpn_protocols.size(), 1u);
+	EXPECT_EQ(b.alpn_protocols[0], "h3");
+}
+
+TEST_F(MessagingQuicServerTest, ConfigCaCertOptionalEmptyAndPresent)
+{
+	quic_server_config a;
+	EXPECT_FALSE(a.ca_cert_file.has_value());
+
+	quic_server_config b;
+	b.ca_cert_file = "";
+	EXPECT_TRUE(b.ca_cert_file.has_value());
+	EXPECT_TRUE(b.ca_cert_file->empty());
+
+	quic_server_config c;
+	c.ca_cert_file = "/path/to/ca.pem";
+	EXPECT_TRUE(c.ca_cert_file.has_value());
+	EXPECT_EQ(*c.ca_cert_file, "/path/to/ca.pem");
+}
+
+// =============================================================================
+// Multi-Instance State Isolation Tests
+// =============================================================================
+
+TEST_F(MessagingQuicServerTest, IndependentServerIds)
+{
+	auto a = std::make_shared<messaging_quic_server>("alpha");
+	auto b = std::make_shared<messaging_quic_server>("beta");
+	EXPECT_EQ(a->server_id(), "alpha");
+	EXPECT_EQ(b->server_id(), "beta");
+	EXPECT_NE(a->server_id(), b->server_id());
+}
+
+TEST_F(MessagingQuicServerTest, IndependentRunStates)
+{
+	auto a = std::make_shared<messaging_quic_server>("rs_a");
+	auto b = std::make_shared<messaging_quic_server>("rs_b");
+	auto port_a = get_available_port();
+
+	auto start_a = a->start_server(port_a);
+	EXPECT_TRUE(start_a.is_ok());
+	EXPECT_TRUE(a->is_running());
+	EXPECT_FALSE(b->is_running());
+
+	auto stop_a = a->stop_server();
+	EXPECT_TRUE(stop_a.is_ok());
+	EXPECT_FALSE(a->is_running());
+	EXPECT_FALSE(b->is_running());
+}
+
+TEST_F(MessagingQuicServerTest, ManyServersConstructable)
+{
+	std::vector<std::shared_ptr<messaging_quic_server>> servers;
+	servers.reserve(50);
+	for (int i = 0; i < 50; ++i)
+	{
+		servers.push_back(std::make_shared<messaging_quic_server>(
+			"bulk_" + std::to_string(i)));
+	}
+	for (size_t i = 0; i < servers.size(); ++i)
+	{
+		EXPECT_FALSE(servers[i]->is_running());
+		EXPECT_EQ(servers[i]->session_count(), 0);
+	}
+}
+
+// =============================================================================
+// Broadcast / Multicast Edge Cases (no sessions)
+// =============================================================================
+
+TEST_F(MessagingQuicServerTest, BroadcastEmptyDataNoSessions)
+{
+	auto server = std::make_shared<messaging_quic_server>("bcast_empty");
+	auto port = get_available_port();
+	ASSERT_TRUE(server->start_server(port).is_ok());
+
+	std::vector<uint8_t> data;
+	auto result = server->broadcast(std::move(data));
+	EXPECT_TRUE(result.is_ok());
+
+	ASSERT_TRUE(server->stop_server().is_ok());
+}
+
+TEST_F(MessagingQuicServerTest, MulticastEmptyIdListNoSessions)
+{
+	auto server = std::make_shared<messaging_quic_server>("mcast_empty_ids");
+	auto port = get_available_port();
+	ASSERT_TRUE(server->start_server(port).is_ok());
+
+	std::vector<std::string> ids;
+	std::vector<uint8_t> data{0xAA, 0xBB};
+	auto result = server->multicast(ids, std::move(data));
+	EXPECT_TRUE(result.is_ok());
+
+	ASSERT_TRUE(server->stop_server().is_ok());
+}
+
+TEST_F(MessagingQuicServerTest, MulticastUnknownIdsNoSessions)
+{
+	auto server = std::make_shared<messaging_quic_server>("mcast_unknown");
+	auto port = get_available_port();
+	ASSERT_TRUE(server->start_server(port).is_ok());
+
+	std::vector<std::string> ids{"missing-1", "missing-2", ""};
+	std::vector<uint8_t> data(64, 0xCC);
+	auto result = server->multicast(ids, std::move(data));
+	EXPECT_TRUE(result.is_ok());
+
+	ASSERT_TRUE(server->stop_server().is_ok());
+}
+
+TEST_F(MessagingQuicServerTest, BroadcastLargeDataNoSessions)
+{
+	auto server = std::make_shared<messaging_quic_server>("bcast_large");
+	auto port = get_available_port();
+	ASSERT_TRUE(server->start_server(port).is_ok());
+
+	std::vector<uint8_t> data(64 * 1024, 0x55);
+	auto result = server->broadcast(std::move(data));
+	EXPECT_TRUE(result.is_ok());
+
+	ASSERT_TRUE(server->stop_server().is_ok());
+}
+
+// =============================================================================
+// Disconnect Edge Cases
+// =============================================================================
+
+TEST_F(MessagingQuicServerTest, DisconnectSessionWithCustomErrorCode)
+{
+	auto server = std::make_shared<messaging_quic_server>("disc_custom_err");
+	auto port = get_available_port();
+	ASSERT_TRUE(server->start_server(port).is_ok());
+
+	auto result = server->disconnect_session("nope", 0xDEADBEEFull);
+	EXPECT_TRUE(result.is_err());
+	EXPECT_EQ(result.error().code, error_codes::common_errors::not_found);
+
+	ASSERT_TRUE(server->stop_server().is_ok());
+}
+
+TEST_F(MessagingQuicServerTest, DisconnectAllNonZeroErrorCode)
+{
+	auto server = std::make_shared<messaging_quic_server>("disc_all_err");
+	auto port = get_available_port();
+	ASSERT_TRUE(server->start_server(port).is_ok());
+
+	server->disconnect_all(123);
+	EXPECT_EQ(server->session_count(), 0);
+
+	ASSERT_TRUE(server->stop_server().is_ok());
+}
+
+// =============================================================================
+// Restart Lifecycle Tests
+// =============================================================================
+
+TEST_F(MessagingQuicServerTest, RestartAfterStop)
+{
+	auto server = std::make_shared<messaging_quic_server>("restart_test");
+
+	auto port1 = get_available_port();
+	ASSERT_TRUE(server->start_server(port1).is_ok());
+	ASSERT_TRUE(server->is_running());
+	ASSERT_TRUE(server->stop_server().is_ok());
+	ASSERT_FALSE(server->is_running());
+
+	auto port2 = get_available_port();
+	auto start2 = server->start_server(port2);
+	EXPECT_TRUE(start2.is_ok());
+	EXPECT_TRUE(server->is_running());
+
+	ASSERT_TRUE(server->stop_server().is_ok());
+}
+
+TEST_F(MessagingQuicServerTest, ServerIdStableAcrossLifecycle)
+{
+	auto server = std::make_shared<messaging_quic_server>("stable_id");
+	EXPECT_EQ(server->server_id(), "stable_id");
+
+	auto port = get_available_port();
+	ASSERT_TRUE(server->start_server(port).is_ok());
+	EXPECT_EQ(server->server_id(), "stable_id");
+
+	ASSERT_TRUE(server->stop_server().is_ok());
+	EXPECT_EQ(server->server_id(), "stable_id");
+}
+
+// =============================================================================
+// quic_connection_stats Edge Cases
+// =============================================================================
+
+TEST_F(MessagingQuicServerTest, QuicConnectionStatsAccumulators)
+{
+	quic_connection_stats stats;
+	stats.bytes_sent = 1024;
+	stats.bytes_received = 2048;
+	stats.packets_sent = 16;
+	stats.packets_received = 32;
+	stats.packets_lost = 1;
+	stats.cwnd = 65536;
+
+	EXPECT_EQ(stats.bytes_sent, 1024u);
+	EXPECT_EQ(stats.bytes_received, 2048u);
+	EXPECT_EQ(stats.packets_sent, 16u);
+	EXPECT_EQ(stats.packets_received, 32u);
+	EXPECT_EQ(stats.packets_lost, 1u);
+	EXPECT_EQ(stats.cwnd, 65536u);
+}
+
+TEST_F(MessagingQuicServerTest, QuicConnectionStatsRttFields)
+{
+	quic_connection_stats stats;
+	stats.smoothed_rtt = std::chrono::microseconds(12345);
+	stats.min_rtt = std::chrono::microseconds(987);
+	EXPECT_EQ(stats.smoothed_rtt.count(), 12345);
+	EXPECT_EQ(stats.min_rtt.count(), 987);
 }
 
 } // namespace kcenon::network::core::test


### PR DESCRIPTION
## What

Append 38 focused unit tests to `tests/test_messaging_quic_server.cpp` that exercise reachable surface in `src/experimental/quic_server.cpp` without an active QUIC client.

### Change Type
- [x] Test (no production behavior change)

### Affected Components
- `tests/test_messaging_quic_server.cpp` — +489 LOC, +38 test cases (no source/build changes)

## Why

`Part of #1066` (and the parent epic `Part of #953`) — narrow test-expansion across worst-coverage protocol files.

Pre-PR baseline (2026-04-26 lcov): `experimental/quic_server.cpp` 43.7% line / 17.5% branch — priority #5 in the 2026-04-26 re-measurement. Existing tests cover the basic lifecycle and config; this PR fills in surface that does not require an active QUIC peer (input variations, callback wiring, struct boundary values, multi-instance state isolation).

## Where

| Test category | Tests added | Targets |
|---------------|-------------|---------|
| Constructor variations | 4 | empty / long / special-char / `string_view` ids |
| Server-not-running guard paths | 5 | `connection_count`, `sessions`, `get_session`, `disconnect_all` |
| `i_quic_server` interface aliases | 2 | `start`, `stop` (alias methods) |
| Interface callback setters | 7 | i_quic_server callbacks + null-callback safety + null-legacy safety |
| Configuration boundary values | 7 | zero / `uint64::max` timeouts, big alpn list, retry-key, copy/optional |
| Multi-instance state isolation | 3 | independent ids / run states / 50 servers constructable |
| Broadcast / multicast (no sessions) | 4 | empty data, empty id list, unknown ids, 64 KB payload |
| Disconnect edge cases | 2 | custom error code, non-zero broadcast code |
| Restart lifecycle | 2 | restart after stop, server_id stability |
| `quic_connection_stats` edges | 2 | accumulators, RTT fields |

## How

### Implementation Approach
- Append tests to existing `tests/test_messaging_quic_server.cpp` (no parallel suite)
- Reuse the existing `MessagingQuicServerTest` GTest fixture
- Add only `<cstdint>`, `<future>`, `<limits>`, `<string>`, `<vector>` to test-file includes
- No changes to production source, build files, or CMake

### Coverage Scope (Honest Assessment)

This PR **does not** reach the `>=80% line / >=70% branch` acceptance criteria of #1066. The remaining gap is concentrated in the accept-loop / packet-handling code (`start_receive`, `handle_packet`, `find_or_create_session`) and in the per-connection error-fan-out path. Those paths require an **in-process QUIC loopback fixture** (UDP socket pair, version-negotiation, retry-token validation) that does not currently exist in the test tree.

Building the loopback fixture is a **larger, separate piece of work** and is tracked under #953. This PR therefore uses `Part of #1066` rather than `Closes #1066` and the issue stays open.

### Test Plan
- CI build on Ubuntu / macOS / Windows must pass
- Sanitizer builds (ASAN, TSAN, UBSAN) must pass
- Coverage workflow run after merge will record the new line/branch baseline as a comment on #953

### Breaking Changes
None — test-only addition.

### Rollback Plan
Revert this single commit; no schema, ABI, or build surface affected.

Part of #1066
Part of #953
