### PR TITLE
test(http2): drive connected-state paths via mock_h2_server_peer (Part of #1062)

### DIFF
--- a/tests/unit/http2_client_branch_test.cpp
+++ b/tests/unit/http2_client_branch_test.cpp
@@ -823,7 +823,7 @@ TEST_F(Http2ClientHermeticTransportTest,
         "/stream",
         {},
         [](std::vector<uint8_t>) {},
-        [](std::vector<http_header>) {},
+        [](std::vector<http2::http_header>) {},
         [](int) {});
     EXPECT_TRUE(stream_result.is_ok());
     if (stream_result.is_ok())
@@ -851,7 +851,7 @@ TEST_F(Http2ClientHermeticTransportTest,
         "/streaming-write",
         {},
         [](std::vector<uint8_t>) {},
-        [](std::vector<http_header>) {},
+        [](std::vector<http2::http_header>) {},
         [](int) {});
     ASSERT_TRUE(stream_result.is_ok());
     auto stream_id = stream_result.value();
@@ -951,7 +951,7 @@ TEST_F(Http2ClientHermeticTransportTest,
         "/cancel-target",
         {},
         [](std::vector<uint8_t>) {},
-        [](std::vector<http_header>) {},
+        [](std::vector<http2::http_header>) {},
         [](int) {});
     ASSERT_TRUE(stream_result.is_ok());
 
@@ -981,7 +981,7 @@ TEST_F(Http2ClientHermeticTransportTest,
         "/idempotent-close",
         {},
         [](std::vector<uint8_t>) {},
-        [](std::vector<http_header>) {},
+        [](std::vector<http2::http_header>) {},
         [](int) {});
     ASSERT_TRUE(stream_result.is_ok());
     auto stream_id = stream_result.value();

--- a/tests/unit/http2_client_branch_test.cpp
+++ b/tests/unit/http2_client_branch_test.cpp
@@ -688,3 +688,370 @@ TEST_F(Http2ClientHermeticTransportTest,
 
     connector.join();
 }
+
+// ============================================================================
+// Phase 2A connected-state coverage expansion (Issue #1062)
+//
+// All TEST_F below assume mock_h2_server_peer has completed the SETTINGS
+// exchange so http2_client is in a fully-connected state. They drive the
+// post-connect public methods (set_settings, send_request timeout path,
+// start_stream, write_stream, cancel_stream, close_stream_writer) plus
+// previously-unreachable error branches (write_stream / cancel_stream /
+// close_stream_writer on an unknown stream id, second connect() returning
+// already_exists, idempotent disconnect after a full handshake).
+//
+// HEADERS+DATA reply paths remain unreachable until Phase 2A.2 of #1074
+// lands. Tests below are therefore scoped to verify timeout / not-found /
+// state-transition branches that the disconnected-state tests in
+// tests/test_http2_client.cpp cannot cover.
+// ============================================================================
+
+namespace
+{
+
+struct connected_client_setup
+{
+    std::shared_ptr<http2::http2_client> client;
+    std::thread connector;
+};
+
+inline connected_client_setup make_connected_client(
+    kcenon::network::tests::support::mock_h2_server_peer& peer,
+    const char* client_id,
+    std::chrono::milliseconds request_timeout = std::chrono::milliseconds(2000))
+{
+    auto client = std::make_shared<http2::http2_client>(client_id);
+    client->set_timeout(request_timeout);
+    auto port = peer.port();
+    std::thread connector([client, port]() {
+        (void)client->connect("127.0.0.1", port);
+    });
+    return {std::move(client), std::move(connector)};
+}
+
+} // namespace
+
+TEST_F(Http2ClientHermeticTransportTest,
+       SecondConnectReturnsAlreadyExistsAfterFirstSucceeds)
+{
+    using namespace kcenon::network::tests::support;
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_client(peer, "second-connect-test");
+
+    EXPECT_TRUE(wait_for(
+        [&]() { return peer.settings_exchanged(); },
+        std::chrono::seconds(3)));
+    EXPECT_TRUE(setup.client->is_connected());
+
+    // The first connect() succeeded; a second invocation must short-circuit
+    // through the already_exists branch documented at
+    // http2_client.cpp:81-88. Pre-Phase 2A this branch was only reachable
+    // via DISABLED_ConnectToHttpbin against an external server.
+    auto second = setup.client->connect("127.0.0.1", peer.port());
+    EXPECT_TRUE(second.is_err());
+
+    (void)setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(Http2ClientHermeticTransportTest,
+       SendRequestTimesOutWhenPeerSendsNoHeaders)
+{
+    using namespace kcenon::network::tests::support;
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_client(
+        peer, "request-timeout-test", std::chrono::milliseconds(150));
+
+    EXPECT_TRUE(wait_for(
+        [&]() { return peer.settings_exchanged(); },
+        std::chrono::seconds(3)));
+    EXPECT_TRUE(setup.client->is_connected());
+
+    // mock_h2_server_peer (Phase 2A) does not reply with HEADERS+DATA, so
+    // the future inside send_request() never resolves. The 150 ms request
+    // timeout drives the timeout error branch at http2_client.cpp:817-826,
+    // which also exercises create_stream / build_headers / encoder_.encode
+    // / send_frame on the connected path.
+    auto response = setup.client->get("/timeout-path", {});
+    EXPECT_TRUE(response.is_err());
+
+    (void)setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(Http2ClientHermeticTransportTest,
+       PostWithBodyTimesOutAfterDataFrameIsSent)
+{
+    using namespace kcenon::network::tests::support;
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_client(
+        peer, "post-timeout-test", std::chrono::milliseconds(150));
+
+    EXPECT_TRUE(wait_for(
+        [&]() { return peer.settings_exchanged(); },
+        std::chrono::seconds(3)));
+    EXPECT_TRUE(setup.client->is_connected());
+
+    // POST drives both the HEADERS frame transmit and the body-bearing DATA
+    // frame transmit (http2_client.cpp:790-807) before reaching the
+    // timeout branch — coverage that GET cannot exercise.
+    std::string body = "hello phase2a";
+    auto response = setup.client->post("/upload", body, {});
+    EXPECT_TRUE(response.is_err());
+
+    (void)setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(Http2ClientHermeticTransportTest,
+       StartStreamReturnsValidIdAfterHandshake)
+{
+    using namespace kcenon::network::tests::support;
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_client(peer, "start-stream-test");
+
+    EXPECT_TRUE(wait_for(
+        [&]() { return peer.settings_exchanged(); },
+        std::chrono::seconds(3)));
+    EXPECT_TRUE(setup.client->is_connected());
+
+    // start_stream returns the allocated stream_id when is_connected() is
+    // true. Without a HEADERS+DATA reply the on_data / on_complete
+    // callbacks are not invoked, but the HEADERS frame is sent and the
+    // stream is registered (http2_client.cpp:306-350).
+    auto stream_result = setup.client->start_stream(
+        "/stream",
+        {},
+        [](std::vector<uint8_t>) {},
+        [](std::vector<http_header>) {},
+        [](int) {});
+    EXPECT_TRUE(stream_result.is_ok());
+    if (stream_result.is_ok())
+    {
+        EXPECT_GT(stream_result.value(), 0u);
+    }
+
+    (void)setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(Http2ClientHermeticTransportTest,
+       WriteStreamSucceedsAfterStartStream)
+{
+    using namespace kcenon::network::tests::support;
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_client(peer, "write-stream-test");
+
+    EXPECT_TRUE(wait_for(
+        [&]() { return peer.settings_exchanged(); },
+        std::chrono::seconds(3)));
+    EXPECT_TRUE(setup.client->is_connected());
+
+    auto stream_result = setup.client->start_stream(
+        "/streaming-write",
+        {},
+        [](std::vector<uint8_t>) {},
+        [](std::vector<http_header>) {},
+        [](int) {});
+    ASSERT_TRUE(stream_result.is_ok());
+    auto stream_id = stream_result.value();
+
+    // Drive write_stream() with a non-empty chunk; then close it with an
+    // empty DATA frame carrying END_STREAM. This exercises both the
+    // open-state write branch and the open -> half_closed_local transition
+    // at http2_client.cpp:386-392.
+    std::vector<uint8_t> chunk{'a', 'b', 'c'};
+    auto wr = setup.client->write_stream(stream_id, chunk, false);
+    EXPECT_TRUE(wr.is_ok());
+    auto fin = setup.client->write_stream(stream_id, {}, true);
+    EXPECT_TRUE(fin.is_ok());
+
+    (void)setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(Http2ClientHermeticTransportTest,
+       WriteStreamWithUnknownStreamIdReturnsNotFound)
+{
+    using namespace kcenon::network::tests::support;
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_client(peer, "write-not-found-test");
+
+    EXPECT_TRUE(wait_for(
+        [&]() { return peer.settings_exchanged(); },
+        std::chrono::seconds(3)));
+    EXPECT_TRUE(setup.client->is_connected());
+
+    // 99'999 is far above any stream id allocated by start_stream and is
+    // therefore guaranteed not to exist in the streams_ map. Drives the
+    // not_found branch at http2_client.cpp:367-369 — distinct from the
+    // connection_closed branch covered by disconnected-state tests.
+    std::vector<uint8_t> payload{1, 2, 3};
+    auto wr = setup.client->write_stream(99999u, payload, false);
+    EXPECT_TRUE(wr.is_err());
+
+    (void)setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(Http2ClientHermeticTransportTest,
+       CancelStreamWithUnknownStreamIdReturnsNotFound)
+{
+    using namespace kcenon::network::tests::support;
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_client(peer, "cancel-not-found-test");
+
+    EXPECT_TRUE(wait_for(
+        [&]() { return peer.settings_exchanged(); },
+        std::chrono::seconds(3)));
+    EXPECT_TRUE(setup.client->is_connected());
+
+    // Connected + unknown stream id drives the not_found branch at
+    // http2_client.cpp:441-444.
+    auto cancel = setup.client->cancel_stream(99999u);
+    EXPECT_TRUE(cancel.is_err());
+
+    (void)setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(Http2ClientHermeticTransportTest,
+       CloseStreamWriterWithUnknownStreamIdReturnsNotFound)
+{
+    using namespace kcenon::network::tests::support;
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_client(peer, "close-not-found-test");
+
+    EXPECT_TRUE(wait_for(
+        [&]() { return peer.settings_exchanged(); },
+        std::chrono::seconds(3)));
+    EXPECT_TRUE(setup.client->is_connected());
+
+    // not_found branch at http2_client.cpp:407-409.
+    auto close = setup.client->close_stream_writer(99999u);
+    EXPECT_TRUE(close.is_err());
+
+    (void)setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(Http2ClientHermeticTransportTest,
+       CancelStreamSendsRstStreamFrame)
+{
+    using namespace kcenon::network::tests::support;
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_client(peer, "cancel-stream-test");
+
+    EXPECT_TRUE(wait_for(
+        [&]() { return peer.settings_exchanged(); },
+        std::chrono::seconds(3)));
+    EXPECT_TRUE(setup.client->is_connected());
+
+    auto stream_result = setup.client->start_stream(
+        "/cancel-target",
+        {},
+        [](std::vector<uint8_t>) {},
+        [](std::vector<http_header>) {},
+        [](int) {});
+    ASSERT_TRUE(stream_result.is_ok());
+
+    // cancel_stream sends an RST_STREAM frame and marks the stream closed
+    // (http2_client.cpp:430-462). The peer drains the frame in its
+    // post-handshake loop.
+    auto cancel = setup.client->cancel_stream(stream_result.value());
+    EXPECT_TRUE(cancel.is_ok());
+
+    (void)setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(Http2ClientHermeticTransportTest,
+       CloseStreamWriterIsIdempotentOnAlreadyClosedStream)
+{
+    using namespace kcenon::network::tests::support;
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_client(peer, "close-idempotent-test");
+
+    EXPECT_TRUE(wait_for(
+        [&]() { return peer.settings_exchanged(); },
+        std::chrono::seconds(3)));
+    EXPECT_TRUE(setup.client->is_connected());
+
+    auto stream_result = setup.client->start_stream(
+        "/idempotent-close",
+        {},
+        [](std::vector<uint8_t>) {},
+        [](std::vector<http_header>) {},
+        [](int) {});
+    ASSERT_TRUE(stream_result.is_ok());
+    auto stream_id = stream_result.value();
+
+    // First close transitions to half_closed_local and sends an empty DATA
+    // frame with END_STREAM (http2_client.cpp:418-427).
+    auto first = setup.client->close_stream_writer(stream_id);
+    EXPECT_TRUE(first.is_ok());
+
+    // Second close on a half_closed_local stream is a no-op — drives the
+    // already-closed early-return branch at http2_client.cpp:412-415.
+    auto second = setup.client->close_stream_writer(stream_id);
+    EXPECT_TRUE(second.is_ok());
+
+    (void)setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(Http2ClientHermeticTransportTest,
+       SetSettingsAfterHandshakeUpdatesEncoderTableSize)
+{
+    using namespace kcenon::network::tests::support;
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_client(peer, "set-settings-test");
+
+    EXPECT_TRUE(wait_for(
+        [&]() { return peer.settings_exchanged(); },
+        std::chrono::seconds(3)));
+    EXPECT_TRUE(setup.client->is_connected());
+
+    // set_settings updates local_settings_ and rewires the HPACK encoder /
+    // decoder table sizes (http2_client.cpp:299-304). Coverage gain over
+    // existing disconnected-state tests is the post-handshake call site.
+    auto settings = setup.client->get_settings();
+    settings.header_table_size = 8192u;
+    settings.max_concurrent_streams = 64u;
+    setup.client->set_settings(settings);
+
+    auto refreshed = setup.client->get_settings();
+    EXPECT_EQ(refreshed.header_table_size, 8192u);
+    EXPECT_EQ(refreshed.max_concurrent_streams, 64u);
+
+    (void)setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(Http2ClientHermeticTransportTest,
+       DisconnectIsIdempotentAfterFullHandshake)
+{
+    using namespace kcenon::network::tests::support;
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_client(peer, "disconnect-idempotent-test");
+
+    EXPECT_TRUE(wait_for(
+        [&]() { return peer.settings_exchanged(); },
+        std::chrono::seconds(3)));
+    EXPECT_TRUE(setup.client->is_connected());
+
+    // Two disconnect()s in a row: the first drives the GOAWAY emit +
+    // stop_io path; the second hits the early-return branch at
+    // http2_client.cpp:212-215 on a fully-handshaken-then-torn-down
+    // client. The disconnected-state tests can only cover this branch
+    // when connect() never succeeded, so the connected->disconnected
+    // transition path here is incremental.
+    auto first = setup.client->disconnect();
+    EXPECT_TRUE(first.is_ok());
+    EXPECT_FALSE(setup.client->is_connected());
+
+    auto second = setup.client->disconnect();
+    EXPECT_TRUE(second.is_ok());
+
+    setup.connector.join();
+}


### PR DESCRIPTION
## What

Adds 12 new `TEST_F` cases under the existing `Http2ClientHermeticTransportTest` fixture in `tests/unit/http2_client_branch_test.cpp` (+367 LOC, no new test files) that compose the Phase 2A `mock_h2_server_peer` shipped in PR #1075 to bring `http2_client` into a fully SETTINGS-exchanged state, then exercise public methods that previously early-returned via `is_connected()` in the existing disconnected-state suites.

### Newly reached paths in `src/protocols/http2/http2_client.cpp`

- `connect()` second-call short-circuit through the `already_exists` branch (lines 81-88)
- `send_request()` / `get()` / `post()` `create_stream` + `build_headers` + `encoder_.encode` + `send_frame` on the connected path, terminating in the `future.wait_for(timeout_)` branch (lines 723-844, especially 817-826)
- `start_stream()` / `write_stream()` / `cancel_stream()` / `close_stream_writer()` connected paths plus their `not_found` error branches with an unallocated stream id (lines 306-462)
- `close_stream_writer()` idempotent early-return on a `half_closed_local` stream (lines 412-415)
- `set_settings()` post-handshake call site updating HPACK encoder / decoder table sizes (lines 299-304)
- `disconnect()` GOAWAY emit + `stop_io` path followed by the second-call early-return on a torn-down handshaken client (lines 210-237)

## Why

`Part of #1062` and `Part of #953` (epic: 40% → 80% coverage).

`http2_client.cpp` line coverage stood at **18.8% line / 9.9% branch** as of the 2026-04-26 lcov run (workflow [24947193873](https://github.com/kcenon/network_system/actions/runs/24947193873)). PR #1068 added 30 disconnected-state TEST_F cases but the remaining gap was concentrated in the post-handshake code that needed an in-process peer to drive `is_connected() == true` in CI. PR #1075 shipped that peer (`mock_h2_server_peer` — connection preface read, server SETTINGS send, client SETTINGS read, SETTINGS-ACK send) and added one demo TEST_F. This PR is the first follow-up that uses the peer to actually expand `http2_client.cpp` coverage.

The acceptance criteria of `>= 80% line / >= 70% branch` is **not** reached by this PR alone — it cannot be, until Phase 2A.2 of #1074 lands `mock_h2_server_peer` HEADERS+DATA reply support. Without server replies, all `handle_headers_frame` / `handle_data_frame` / `handle_rst_stream_frame` / `handle_goaway_frame` / `handle_window_update_frame` / `handle_ping_frame` paths remain unreachable from a hermetic test, and the happy-path completion of `send_request()` (status code extraction, `promise.set_value(...)`) cannot be driven. This PR therefore uses `Part of #1062`, not `Closes`.

## Where

| Path | Change |
|------|--------|
| `tests/unit/http2_client_branch_test.cpp` | +367 LOC: anonymous-namespace helper `make_connected_client(peer, client_id, request_timeout)` plus 12 new `TEST_F` cases appended after the existing Phase 2A demo |

No changes under `src/`, no new test files, no CMake change (the file is already in `add_network_test(http2_client_branch_test ...)` and `network::test_support` is already linked from PR #1075).

## How

Each new `TEST_F`:
1. Constructs a `mock_h2_server_peer peer(io())` on the fixture's shared `io_context`.
2. Calls `make_connected_client(peer, client_id)` which spawns a worker thread that runs `client->connect("127.0.0.1", peer.port())` synchronously.
3. Waits on `wait_for([&]() { return peer.settings_exchanged(); }, std::chrono::seconds(3))` — by which time the peer has read the preface, sent server SETTINGS, read client SETTINGS, and sent SETTINGS-ACK; client's `is_connected_` is therefore true.
4. Drives the targeted post-connect public method, asserting the expected `Result<T>` outcome.
5. Calls `disconnect()` which emits GOAWAY (drained by peer) and tears down state, then joins the connector thread.

Tests reaching the `send_request()` timeout branch use a 150 ms `set_timeout(...)` to bound execution time. Other tests use the default 2 s timeout for the connect path; their post-connect calls return immediately since they don't wait on a future.

### Coverage Scope (Honest Assessment)

Local C++ toolchain (cmake/g++/ninja) is not available in this dev environment; the `coverage.yml` workflow is the authoritative verification surface (PR #1071 / #1075 precedent). Expected outcome:
- `http2_client.cpp` line coverage **strictly increases** above the 18.8% baseline.
- HEADERS+DATA reply paths remain uncovered (Phase 2A.2 of #1074 will unblock).
- Issue #1062 stays open (`Part of`, not `Closes`); the issue's `>= 80% line / >= 70% branch` acceptance criteria becomes reachable only after Phase 2A.2 lands.

Part of #1062
Part of #953
