### PR TITLE
test(grpc): drive connected-state paths via mock_h2_server_peer (Part of #1063)

### DIFF
--- a/tests/unit/grpc_client_branch_test.cpp
+++ b/tests/unit/grpc_client_branch_test.cpp
@@ -56,6 +56,7 @@
 #include "kcenon/network/detail/protocols/grpc/status.h"
 
 #include "hermetic_transport_fixture.h"
+#include "mock_h2_server_peer.h"
 #include "mock_tls_socket.h"
 
 #include <gtest/gtest.h>
@@ -875,4 +876,320 @@ TEST_F(GrpcClientHermeticTransportTest, ConnectAttemptsHandshakeAgainstLoopbackT
     client->disconnect();
     connector.join();
     EXPECT_TRUE(connect_returned.load());
+}
+
+// ============================================================================
+// Phase 2A follow-up: drive grpc_client post-connect paths via mock_h2_server_peer
+// (Part of #1063, follow-up to PR #1075/#1076)
+//
+// grpc_client::impl::connect() instantiates an internal http2::http2_client and
+// delegates to its connect(host, port). Once the SETTINGS exchange against
+// mock_h2_server_peer completes, http2_client::is_connected() flips true and
+// grpc_client::is_connected() (which AND-s its own connected_ flag with the
+// http2 client's state) follows. With that gate satisfied, public methods that
+// previously short-circuited on the not-connected path can be driven into
+// their post-connect branches: header build, metadata loop, deadline header,
+// http2_client::post / start_stream forwarding, and the timeout-error branch.
+// HEADERS+DATA reply paths are still gated on Phase 2A.2 of #1074; this PR
+// is incremental progress and uses `Part of`, not `Closes`.
+// ============================================================================
+
+namespace
+{
+
+struct connected_grpc_client_setup
+{
+    std::shared_ptr<grpc_client> client;
+    std::thread connector;
+};
+
+inline connected_grpc_client_setup make_connected_grpc_client(
+    kcenon::network::tests::support::mock_h2_server_peer& peer,
+    std::chrono::milliseconds default_timeout = std::chrono::milliseconds(2000))
+{
+    grpc_channel_config cfg;
+    cfg.use_tls = true;
+    cfg.default_timeout = default_timeout;
+
+    const std::string target =
+        "127.0.0.1:" + std::to_string(static_cast<unsigned>(peer.port()));
+
+    auto client = std::make_shared<grpc_client>(target, cfg);
+    std::thread connector([client]() {
+        (void)client->connect();
+    });
+    return {std::move(client), std::move(connector)};
+}
+
+} // namespace
+
+TEST_F(GrpcClientHermeticTransportTest, IsConnectedTrueAfterSettingsExchange)
+{
+    using namespace kcenon::network::tests::support;
+
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_grpc_client(peer);
+
+    EXPECT_TRUE(wait_for([&]() { return peer.settings_exchanged(); },
+                         std::chrono::seconds(3)));
+    EXPECT_TRUE(setup.client->is_connected());
+
+    setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(GrpcClientHermeticTransportTest, WaitForConnectedReturnsTrueAfterHandshake)
+{
+    using namespace kcenon::network::tests::support;
+
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_grpc_client(peer);
+
+    EXPECT_TRUE(wait_for([&]() { return peer.settings_exchanged(); },
+                         std::chrono::seconds(3)));
+    EXPECT_TRUE(setup.client->wait_for_connected(std::chrono::milliseconds(2000)));
+
+    setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(GrpcClientHermeticTransportTest, SecondConnectReturnsOkOnAlreadyConnected)
+{
+    using namespace kcenon::network::tests::support;
+
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_grpc_client(peer);
+
+    EXPECT_TRUE(wait_for([&]() { return peer.settings_exchanged(); },
+                         std::chrono::seconds(3)));
+    ASSERT_TRUE(setup.client->is_connected());
+
+    // Second connect() short-circuits via the already_connected branch.
+    auto second = setup.client->connect();
+    EXPECT_TRUE(second.is_ok());
+
+    setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(GrpcClientHermeticTransportTest, TargetReturnsConfiguredAddressAfterHandshake)
+{
+    using namespace kcenon::network::tests::support;
+
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_grpc_client(peer);
+
+    EXPECT_TRUE(wait_for([&]() { return peer.settings_exchanged(); },
+                         std::chrono::seconds(3)));
+
+    const auto& target = setup.client->target();
+    EXPECT_NE(target.find("127.0.0.1:"), std::string::npos);
+
+    setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(GrpcClientHermeticTransportTest, CallRawConnectedTimesOutWhenPeerSendsNoResponse)
+{
+    using namespace kcenon::network::tests::support;
+
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_grpc_client(peer, std::chrono::milliseconds(150));
+
+    EXPECT_TRUE(wait_for([&]() { return peer.settings_exchanged(); },
+                         std::chrono::seconds(3)));
+    ASSERT_TRUE(setup.client->is_connected());
+
+    // call_raw drives is_connected() check, method validation, header build,
+    // grpc_message::serialize, and finally http2_client::post which times out
+    // because the mock peer does not yet reply with HEADERS+DATA (Phase 2A.2
+    // of #1074 will unblock that). We assert only on the error outcome.
+    auto result = setup.client->call_raw("/svc/Method", std::vector<uint8_t>{});
+    EXPECT_TRUE(result.is_err());
+
+    setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(GrpcClientHermeticTransportTest,
+       CallRawWithCustomMetadataAndDeadlineDrivesTimeoutHeader)
+{
+    using namespace kcenon::network::tests::support;
+
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_grpc_client(peer, std::chrono::milliseconds(150));
+
+    EXPECT_TRUE(wait_for([&]() { return peer.settings_exchanged(); },
+                         std::chrono::seconds(3)));
+    ASSERT_TRUE(setup.client->is_connected());
+
+    call_options options;
+    options.metadata.emplace_back("x-custom-trace", "abc-123");
+    options.metadata.emplace_back("x-tenant-id", "tenant-7");
+    options.set_timeout(std::chrono::milliseconds(120));
+
+    // Drives the metadata-loop and grpc-timeout header build paths in addition
+    // to the post-timeout branch covered above.
+    auto result = setup.client->call_raw(
+        "/v1/Echo", std::vector<uint8_t>{0x01, 0x02, 0x03}, options);
+    EXPECT_TRUE(result.is_err());
+
+    setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(GrpcClientHermeticTransportTest,
+       CallRawWithExpiredDeadlineAfterHandshakeReturnsDeadlineExceeded)
+{
+    using namespace kcenon::network::tests::support;
+
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_grpc_client(peer);
+
+    EXPECT_TRUE(wait_for([&]() { return peer.settings_exchanged(); },
+                         std::chrono::seconds(3)));
+    ASSERT_TRUE(setup.client->is_connected());
+
+    call_options options;
+    options.deadline = std::chrono::system_clock::now() - std::chrono::seconds(1);
+
+    // Drives the post-connect deadline-exceeded branch (after is_connected()
+    // and method validation, before the http2 POST is attempted).
+    auto result = setup.client->call_raw(
+        "/svc/Method", std::vector<uint8_t>{}, options);
+    EXPECT_TRUE(result.is_err());
+
+    setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(GrpcClientHermeticTransportTest, ServerStreamRawConnectedReturnsValidReader)
+{
+    using namespace kcenon::network::tests::support;
+
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_grpc_client(peer);
+
+    EXPECT_TRUE(wait_for([&]() { return peer.settings_exchanged(); },
+                         std::chrono::seconds(3)));
+    ASSERT_TRUE(setup.client->is_connected());
+
+    // Drives is_connected() check, method validation, header build, then
+    // start_stream + write_stream + shared_holder allocation. The reader is
+    // returned successfully even though the peer never replies; the client
+    // owns the read-side state machine until disconnect.
+    auto result = setup.client->server_stream_raw(
+        "/svc/ListEvents", std::vector<uint8_t>{0xff});
+    EXPECT_TRUE(result.is_ok());
+    if (result.is_ok())
+    {
+        EXPECT_NE(result.value().get(), nullptr);
+    }
+
+    setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(GrpcClientHermeticTransportTest, ClientStreamRawConnectedReturnsValidWriter)
+{
+    using namespace kcenon::network::tests::support;
+
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_grpc_client(peer);
+
+    EXPECT_TRUE(wait_for([&]() { return peer.settings_exchanged(); },
+                         std::chrono::seconds(3)));
+    ASSERT_TRUE(setup.client->is_connected());
+
+    // Drives the connected client_stream_raw path: header build,
+    // start_stream forwarding, shared_writer_holder allocation.
+    auto result = setup.client->client_stream_raw("/svc/Upload");
+    EXPECT_TRUE(result.is_ok());
+    if (result.is_ok())
+    {
+        EXPECT_NE(result.value().get(), nullptr);
+    }
+
+    setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(GrpcClientHermeticTransportTest, BidiStreamRawConnectedReturnsValidStream)
+{
+    using namespace kcenon::network::tests::support;
+
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_grpc_client(peer);
+
+    EXPECT_TRUE(wait_for([&]() { return peer.settings_exchanged(); },
+                         std::chrono::seconds(3)));
+    ASSERT_TRUE(setup.client->is_connected());
+
+    call_options options;
+    options.set_timeout(std::chrono::milliseconds(500));
+    options.metadata.emplace_back("x-trace", "bidi-1");
+
+    // Drives bidi_stream_raw post-connect path including grpc-timeout header
+    // formatting and metadata-loop iteration before start_stream is called.
+    auto result = setup.client->bidi_stream_raw("/svc/Chat", options);
+    EXPECT_TRUE(result.is_ok());
+    if (result.is_ok())
+    {
+        EXPECT_NE(result.value().get(), nullptr);
+    }
+
+    setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(GrpcClientHermeticTransportTest, CallRawAsyncDeliversTimeoutErrorToCallback)
+{
+    using namespace kcenon::network::tests::support;
+
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_grpc_client(peer, std::chrono::milliseconds(150));
+
+    EXPECT_TRUE(wait_for([&]() { return peer.settings_exchanged(); },
+                         std::chrono::seconds(3)));
+    ASSERT_TRUE(setup.client->is_connected());
+
+    std::promise<bool> received;
+    auto received_future = received.get_future();
+    setup.client->call_raw_async(
+        "/svc/Method",
+        std::vector<uint8_t>{},
+        [&received](kcenon::network::Result<grpc_message> r) {
+            received.set_value(r.is_err());
+        });
+
+    EXPECT_EQ(received_future.wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+    EXPECT_TRUE(received_future.get());
+
+    setup.client->disconnect();
+    setup.connector.join();
+}
+
+TEST_F(GrpcClientHermeticTransportTest, DisconnectIsIdempotentAfterFullHandshake)
+{
+    using namespace kcenon::network::tests::support;
+
+    mock_h2_server_peer peer(io());
+    auto setup = make_connected_grpc_client(peer);
+
+    EXPECT_TRUE(wait_for([&]() { return peer.settings_exchanged(); },
+                         std::chrono::seconds(3)));
+    ASSERT_TRUE(setup.client->is_connected());
+
+    // First disconnect — drives http2_client_->disconnect() in the connected
+    // path, then resets the http2_client_ shared_ptr.
+    setup.client->disconnect();
+    EXPECT_FALSE(setup.client->is_connected());
+
+    // Second disconnect — connected_ is already false and http2_client_ is
+    // null, so the inner branch is skipped and the call is a no-op.
+    setup.client->disconnect();
+    EXPECT_FALSE(setup.client->is_connected());
+
+    setup.connector.join();
 }


### PR DESCRIPTION
## What

Adds 12 new `TEST_F` cases under the existing `GrpcClientHermeticTransportTest` fixture in `tests/unit/grpc_client_branch_test.cpp` (+317 LOC, no new test files) that compose the Phase 2A `mock_h2_server_peer` shipped in PR #1075 to bring `grpc_client` into a fully SETTINGS-exchanged state, then exercise public methods that previously early-returned via `is_connected()` in the existing disconnected-state suites.

### Newly reached paths in `src/protocols/grpc/client.cpp`

- `is_connected()` compound condition after the inner http2 SETTINGS exchange completes (lines 1120-1122)
- `wait_for_connected()` polling loop hitting the success branch (lines 1125-1139)
- second `connect()` short-circuit through the `already_connected` branch (lines 1035-1042)
- `target()` getter post-handshake (lines 1141-1144)
- `call_raw()` connected path: header build, `grpc-timeout` header formatting, metadata copy loop, `http2_client::post` forwarding, future-timeout error branch (lines 1146-1245)
- `call_raw()` post-connect deadline-exceeded branch (lines 1188-1202)
- `call_raw_async()` connected submit_task path with callback delivery (lines 1340-1350)
- `server_stream_raw()` / `client_stream_raw()` / `bidi_stream_raw()` connected paths: header build, `start_stream` forwarding, `shared_*_holder` allocation, `ok()` unique_ptr return (lines 1352-1611)
- `disconnect()` second-call idempotent path after a real handshake (lines 1107-1118)

## Why

`Part of #1063` and `Part of #953` (epic: 40% → 80% coverage).

`grpc_client.cpp` line coverage stood at **22.6% line / 9.5% branch** as of the 2026-04-26 lcov run (workflow [24947193873](https://github.com/kcenon/network_system/actions/runs/24947193873)). PR #1069 added 36 disconnected-state `TEST_F` / `TEST` cases, but the remaining gap was concentrated in the post-handshake code path that needed an in-process HTTP/2 peer to drive `is_connected() == true` in CI.

Because `grpc_client::impl` instantiates an internal `http2::http2_client` and delegates `connect()` to its `connect(host, port)`, the Phase 2A `mock_h2_server_peer` shipped in PR #1075 is sufficient to push `grpc_client` past the connection gate without requiring a separate `mock_grpc_server_peer` to be built first. This PR consumes that infrastructure to actually expand `grpc_client.cpp` coverage.

The acceptance criteria of `>= 80% line / >= 70% branch` is **not** reached by this PR alone — it cannot be, until Phase 2A.2 of #1074 lands `mock_h2_server_peer` HEADERS+DATA reply support. Without server replies, the `server_stream_reader_impl::on_data` / `on_headers` / `on_complete` callback wiring, the `client_stream_writer_impl` round-trip, the `bidi_stream_impl` read/write/finish round-trip, the `call_raw` happy-path completion (HTTP/2 200 → trailer parse → status code extraction → `ok(grpc_message)`), and the official-grpcpp wrapper paths all remain unreachable from a hermetic test. This PR therefore uses `Part of #1063`, not `Closes`.

## Where

| Path | Change |
|------|--------|
| `tests/unit/grpc_client_branch_test.cpp` | +317 LOC: anonymous-namespace helper `make_connected_grpc_client(peer, default_timeout)` plus 12 new `TEST_F` cases appended after the existing Phase 2A demo. One new include: `mock_h2_server_peer.h`. |

No changes under `src/`, no new test files, no CMake change (the file is already at `tests/CMakeLists.txt:4916-4918` linked to `network::test_support`, which already statically links `mock_h2_server_peer.cpp` from PR #1075).

## How

Each new `TEST_F`:
1. Constructs a `mock_h2_server_peer peer(io())` on the fixture's shared `io_context`.
2. Calls `make_connected_grpc_client(peer, default_timeout)` which spawns a worker thread that runs `client->connect()` synchronously against `127.0.0.1:peer.port()`.
3. Waits on `wait_for([&]() { return peer.settings_exchanged(); }, std::chrono::seconds(3))` — by which time the peer has read the preface, sent server SETTINGS, read client SETTINGS, and sent SETTINGS-ACK; the inner `http2_client` has flipped `is_connected_` to true and `grpc_client::is_connected()` returns true.
4. Drives the targeted post-connect public method, asserting the expected `Result<T>` outcome.
5. Calls `disconnect()` which tears down the inner http2 client (emitting GOAWAY, drained by the peer), then joins the connector thread.

Tests reaching the `call_raw` post-timeout branch use a 150 ms `default_timeout` to bound execution time. Streaming methods use the default 2 s timeout for the connect path; their post-connect calls return immediately since they only forward to `http2_client::start_stream` which allocates a stream id without waiting on a future.

### Coverage Scope (Honest Assessment)

Local C++ toolchain (cmake/g++/ninja) is not available in this dev environment; the `coverage.yml` workflow is the authoritative verification surface (PR #1071 / #1075 / #1076 precedent). Expected outcome:
- `grpc_client.cpp` line coverage **strictly increases** above the 22.6% baseline.
- HEADERS+DATA reply paths (callbacks, trailer parsing, happy-path completion) remain uncovered — Phase 2A.2 of #1074 will unblock.
- Issue #1063 stays open (`Part of`, not `Closes`); the issue's `>= 80% line / >= 70% branch` acceptance criteria becomes reachable only after Phase 2A.2 lands and a final follow-up test PR drives the success paths.

Part of #1063
Part of #953
