### PR TITLE
feat(tests/support): add HEADERS+DATA reply for h2 mock peer (Phase 2A.2)

### DIFF
--- a/tests/support/README.md
+++ b/tests/support/README.md
@@ -29,7 +29,7 @@ follow-up tests drive those methods.
 | `mock_tls_socket.h/.cpp` | RSA-2048 self-signed cert generation, server/client `ssl::context` factories, and a `tls_loopback_listener` RAII helper. |
 | `mock_udp_peer.h/.cpp` | UDP peer wrapper for QUIC tests plus a stub QUIC long-header Initial-packet builder. |
 | `mock_ws_handshake.h/.cpp` | RFC 6455 client upgrade request and frame builders for WebSocket server tests. |
-| `mock_h2_server_peer.h/.cpp` | Server-side HTTP/2 framing peer (Phase 2A of #1074): connection preface read, server SETTINGS send, client SETTINGS read, SETTINGS-ACK send. Composes `tls_loopback_listener` and runs the exchange on a dedicated worker thread. |
+| `mock_h2_server_peer.h/.cpp` | Server-side HTTP/2 framing peer (Phase 2A + 2A.2 of #1074): connection preface read, server SETTINGS send, client SETTINGS read, SETTINGS-ACK send. With `reply_mode::echo_one`, also reads one client request stream and replies with `:status: 200` HEADERS + a small END_STREAM DATA frame. Composes `tls_loopback_listener` and runs the exchange on a dedicated worker thread. |
 
 ## Composition pattern
 
@@ -103,6 +103,37 @@ TEST_F(MyHttp2ClientTest, ConnectCompletesSettingsExchange)
 }
 ```
 
+To exercise the response success path (Phase 2A.2), construct the peer
+with `reply_mode::echo_one`. The peer will read one client request stream
+after SETTINGS and reply on the same stream_id with `:status: 200` plus a
+small body:
+
+```cpp
+TEST_F(MyHttp2ClientTest, GetReturnsResponseFromMockPeer)
+{
+    using namespace kcenon::network::tests::support;
+
+    mock_h2_server_peer peer(io(), reply_mode::echo_one);
+    auto client = std::make_shared<http2::http2_client>("test");
+    client->set_timeout(std::chrono::milliseconds(2000));
+
+    std::thread connector([&]() {
+        (void)client->connect("127.0.0.1", peer.port());
+    });
+    wait_for([&]() { return peer.settings_exchanged(); },
+             std::chrono::seconds(3));
+
+    auto response = client->get("/echo", {});
+    ASSERT_TRUE(response.is_ok());
+    EXPECT_EQ(response.value().status_code, 200);
+    EXPECT_TRUE(peer.request_received());
+    EXPECT_TRUE(peer.response_sent());
+
+    (void)client->disconnect();
+    connector.join();
+}
+```
+
 ## Linking from a test target
 
 The fixture is built as `network_test_support` (alias `network::test_support`)
@@ -140,7 +171,7 @@ Phases land as independent PRs.
 | Phase | Component | Status |
 |-------|-----------|--------|
 | 2A | `mock_h2_server_peer` (preface + SETTINGS exchange + ACK) | shipped |
-| 2A.2 | `mock_h2_server_peer` HEADERS+DATA reply for one stream | follow-up |
+| 2A.2 | `mock_h2_server_peer` HEADERS+DATA reply for one stream (`reply_mode::echo_one`) | shipped |
 | 2B | `mock_grpc_server_peer` (h2 + gRPC framing + trailers) | not started |
 | 2C | `mock_quic_peer_loop` (Initial → Handshake → 1-RTT) | not started |
 | 2D | `network_test_friends.h` (private-method injection points) | not started |

--- a/tests/support/mock_h2_server_peer.cpp
+++ b/tests/support/mock_h2_server_peer.cpp
@@ -5,7 +5,7 @@
 /**
  * @file mock_h2_server_peer.cpp
  * @brief Implementation of server-side HTTP/2 framing peer
- *        (Phase 2A of Issue #1074)
+ *        (Phase 2A + Phase 2A.2 of Issue #1074)
  */
 
 #include "mock_h2_server_peer.h"
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <span>
 #include <system_error>
+#include <utility>
 #include <vector>
 
 namespace kcenon::network::tests::support
@@ -45,8 +46,8 @@ constexpr std::uint8_t kPrefaceBytes[kPrefaceSize] = {
 
 } // namespace
 
-mock_h2_server_peer::mock_h2_server_peer(asio::io_context& io)
-    : listener_(io)
+mock_h2_server_peer::mock_h2_server_peer(asio::io_context& io, reply_mode mode)
+    : listener_(io), mode_(mode)
 {
     worker_ = std::thread([this]() { this->run(); });
 }
@@ -150,9 +151,122 @@ void mock_h2_server_peer::run()
 
     settings_exchanged_.store(true);
 
+    // Phase 2A.2: optionally read one client request stream and reply with
+    // a server HEADERS+DATA pair before falling through to the drain loop.
+    // The drain loop still runs afterwards so client GOAWAY/PING frames
+    // emitted during disconnect() are absorbed.
+    if (mode_ == reply_mode::echo_one)
+    {
+        // Read frames until we observe the client's full request stream:
+        // a HEADERS frame opens the stream, then any number of DATA frames
+        // follow until END_STREAM is seen on either HEADERS or a DATA
+        // frame. Frames on other streams or non-stream frames (PING, etc.)
+        // are silently drained.
+        std::uint32_t request_stream_id = 0;
+        bool headers_received = false;
+        bool stream_complete = false;
+        while (!stop_.load() && !stream_complete)
+        {
+            std::array<std::uint8_t, kFrameHeaderSize> req_hdr_buf{};
+            asio::read(*stream, asio::buffer(req_hdr_buf), ec);
+            if (ec)
+            {
+                io_failed_.store(true);
+                return;
+            }
+            auto req_parsed = http2::frame_header::parse(
+                std::span<const std::uint8_t>(
+                    req_hdr_buf.data(), req_hdr_buf.size()));
+            if (req_parsed.is_err())
+            {
+                io_failed_.store(true);
+                return;
+            }
+            const auto req_h = req_parsed.value();
+            if (req_h.length > 0)
+            {
+                std::vector<std::uint8_t> req_payload(req_h.length);
+                asio::read(*stream, asio::buffer(req_payload), ec);
+                if (ec)
+                {
+                    io_failed_.store(true);
+                    return;
+                }
+            }
+
+            const bool end_stream =
+                (req_h.flags & http2::frame_flags::end_stream) != 0;
+
+            if (req_h.type == http2::frame_type::headers && !headers_received)
+            {
+                request_stream_id = req_h.stream_id;
+                headers_received = true;
+                last_request_stream_id_.store(request_stream_id);
+                if (end_stream)
+                {
+                    stream_complete = true;
+                }
+            }
+            else if (req_h.type == http2::frame_type::data &&
+                     headers_received &&
+                     req_h.stream_id == request_stream_id)
+            {
+                if (end_stream)
+                {
+                    stream_complete = true;
+                }
+            }
+            // Other frames (PING, additional SETTINGS, frames on other
+            // streams) are deliberately drained without affecting state.
+        }
+
+        if (!stream_complete)
+        {
+            // Worker was asked to stop or the socket closed before we saw
+            // END_STREAM; nothing else to do.
+            return;
+        }
+
+        request_received_.store(true);
+
+        // Send response HEADERS frame: ":status: 200" encoded as the HPACK
+        // indexed header field for static-table index 8 (RFC 7541 Appendix A).
+        // A single byte 0x88 is sufficient and avoids pulling in a full
+        // HPACK encoder for this minimal reply path.
+        const std::vector<std::uint8_t> hpack_status_200{0x88};
+        http2::headers_frame response_headers(
+            request_stream_id, hpack_status_200,
+            /*end_stream=*/false, /*end_headers=*/true);
+        const auto resp_hdr_bytes = response_headers.serialize();
+        asio::write(*stream, asio::buffer(resp_hdr_bytes), ec);
+        if (ec)
+        {
+            io_failed_.store(true);
+            return;
+        }
+
+        // Send response DATA frame with a small body and END_STREAM set.
+        // The body content is intentionally short so tests can match it
+        // exactly; "ok" is the convention used elsewhere in this fixture.
+        const std::vector<std::uint8_t> body{'o', 'k'};
+        http2::data_frame response_data(
+            request_stream_id, body,
+            /*end_stream=*/true, /*padded=*/false);
+        const auto resp_data_bytes = response_data.serialize();
+        asio::write(*stream, asio::buffer(resp_data_bytes), ec);
+        if (ec)
+        {
+            io_failed_.store(true);
+            return;
+        }
+
+        response_sent_.store(true);
+    }
+
     // Step 5: Drain any subsequent frames (e.g. the GOAWAY emitted by
-    // client disconnect()) until EOF or stop_ is set. Phase 2A does not
-    // reply with HEADERS+DATA — that is deferred to Phase 2A.2.
+    // client disconnect(), or further requests on additional streams)
+    // until EOF or stop_ is set. After Phase 2A.2 the same loop also
+    // absorbs frames the client may emit after consuming the response.
     while (!stop_.load())
     {
         std::array<std::uint8_t, kFrameHeaderSize> drain_hdr{};

--- a/tests/support/mock_h2_server_peer.h
+++ b/tests/support/mock_h2_server_peer.h
@@ -7,7 +7,7 @@
 /**
  * @file mock_h2_server_peer.h
  * @brief Server-side HTTP/2 framing peer for http2_client unit tests
- *        (Phase 2A of Issue #1074, on top of Issue #1060)
+ *        (Phase 2A + Phase 2A.2 of Issue #1074, on top of Issue #1060)
  *
  * Builds on top of @ref tls_loopback_listener (which already accepts one
  * TLS-with-ALPN-h2 connection on @c 127.0.0.1:0) and adds the minimal
@@ -17,7 +17,26 @@
  * methods (e.g. @c get_settings, @c set_settings, @c disconnect) reach code
  * paths that previously timed out behind a silent peer.
  *
- * Sequence performed on a dedicated worker thread:
+ * Two operating modes are supported via @ref reply_mode:
+ *
+ * - @ref reply_mode::drain_only (default, Phase 2A behavior): after the
+ *   SETTINGS handshake, the worker loops reading any further client frames
+ *   (e.g. HEADERS for a GET, DATA for a POST body, GOAWAY emitted by
+ *   @c disconnect()) and discards their payloads. This drives the request
+ *   timeout path on @c http2_client because the client's response future
+ *   never resolves.
+ *
+ * - @ref reply_mode::echo_one (Phase 2A.2): after the SETTINGS handshake,
+ *   the worker reads exactly one request stream from the client (HEADERS,
+ *   plus any DATA frames until END_STREAM is set), then replies on the same
+ *   stream with a server HEADERS frame carrying @c :status: 200 followed by
+ *   a single DATA frame carrying a small body with END_STREAM set. After
+ *   the response is on the wire the worker continues draining client frames
+ *   until the socket closes. This drives @c http2_client's
+ *   @c handle_headers_frame / @c handle_data_frame / @c on_complete success
+ *   paths that @ref reply_mode::drain_only cannot reach.
+ *
+ * Sequence performed on a dedicated worker thread (both modes):
  *  1. Wait for the @ref tls_loopback_listener to deliver the post-handshake
  *     SSL stream (TLS 1.2+/1.3 negotiated with ALPN "h2" by the listener).
  *  2. Read the fixed 24-byte client connection preface
@@ -26,14 +45,12 @@
  *     stream_id=0).
  *  4. Read the client's SETTINGS frame (9-byte header + payload). The
  *     payload is parsed for type/flags consistency but its values are not
- *     enforced — Phase 2A intentionally accepts any client SETTINGS.
+ *     enforced — the post-connect path coverage we want does not depend on
+ *     negotiated settings.
  *  5. Send a SETTINGS-ACK frame (length=0, type=0x4, flags=0x1,
  *     stream_id=0).
  *
- * After the exchange, the worker loops reading any further client frames
- * (e.g. GOAWAY emitted by @c disconnect()) and discards their payloads
- * until the socket closes or the peer is destroyed. Phase 2A does NOT
- * reply with HEADERS+DATA — that is deferred to a Phase 2A.2 follow-up.
+ * After step 5, behavior diverges per @ref reply_mode (see above).
  *
  * Hermetic: bound to @c 127.0.0.1:0 via the underlying listener; cert is
  * regenerated per construction; no DNS, no external network, no on-disk
@@ -47,10 +64,28 @@
 #include <asio/ip/tcp.hpp>
 
 #include <atomic>
+#include <cstdint>
 #include <thread>
 
 namespace kcenon::network::tests::support
 {
+
+/**
+ * @brief Selects the post-handshake behavior of @ref mock_h2_server_peer.
+ */
+enum class reply_mode
+{
+    /// Phase 2A behavior: drain client frames after the SETTINGS exchange,
+    /// never reply with HEADERS+DATA. Drives the request-timeout path on
+    /// @c http2_client.
+    drain_only,
+
+    /// Phase 2A.2 behavior: read exactly one client request stream after the
+    /// SETTINGS exchange, then reply on the same stream_id with a HEADERS
+    /// frame (`:status: 200`) and a DATA frame (small body, END_STREAM).
+    /// Drives the response-success path on @c http2_client.
+    echo_one
+};
 
 /**
  * @brief Server-side HTTP/2 framing peer composed on top of
@@ -76,6 +111,25 @@ namespace kcenon::network::tests::support
  * (void)client->disconnect();
  * connector.join();
  * @endcode
+ *
+ * For tests that need a successful response (Phase 2A.2):
+ * @code
+ * mock_h2_server_peer peer(io(), reply_mode::echo_one);
+ *
+ * auto client = std::make_shared<http2::http2_client>("test");
+ * std::thread connector([&]() {
+ *     (void)client->connect("127.0.0.1", peer.port());
+ * });
+ * wait_for([&]() { return peer.settings_exchanged(); },
+ *          std::chrono::seconds(3));
+ *
+ * auto response = client->get("/echo", {});
+ * EXPECT_TRUE(response.is_ok());
+ * EXPECT_TRUE(peer.response_sent());
+ *
+ * (void)client->disconnect();
+ * connector.join();
+ * @endcode
  */
 class mock_h2_server_peer
 {
@@ -85,8 +139,12 @@ public:
      *        worker thread.
      * @param io io_context used by the underlying listener for accept
      *        and TLS handshake.
+     * @param mode Post-handshake behavior. Defaults to
+     *        @ref reply_mode::drain_only for backward compatibility with
+     *        Phase 2A timeout-path tests.
      */
-    explicit mock_h2_server_peer(asio::io_context& io);
+    explicit mock_h2_server_peer(asio::io_context& io,
+                                 reply_mode mode = reply_mode::drain_only);
 
     /**
      * @brief Destructor. Signals the worker to stop, closes the listener,
@@ -141,18 +199,57 @@ public:
         return io_failed_.load();
     }
 
+    /**
+     * @brief True after the worker has read a complete client request
+     *        (HEADERS + any DATA frames up to END_STREAM) on the
+     *        @ref reply_mode::echo_one path.
+     *
+     * Always false in @ref reply_mode::drain_only because the worker never
+     * makes the half-closed-remote transition.
+     */
+    [[nodiscard]] auto request_received() const -> bool
+    {
+        return request_received_.load();
+    }
+
+    /**
+     * @brief True after the worker has written the server HEADERS frame
+     *        (status: 200) and a single END_STREAM DATA frame on the
+     *        @ref reply_mode::echo_one path.
+     *
+     * Always false in @ref reply_mode::drain_only.
+     */
+    [[nodiscard]] auto response_sent() const -> bool
+    {
+        return response_sent_.load();
+    }
+
+    /**
+     * @brief Stream id observed in the first client HEADERS frame after
+     *        SETTINGS exchange (typically 1 for a fresh client).
+     *
+     * Zero until @ref request_received() returns true.
+     */
+    [[nodiscard]] auto last_request_stream_id() const -> std::uint32_t
+    {
+        return last_request_stream_id_.load();
+    }
+
 private:
     /**
-     * @brief Worker-thread entry point. Performs the 5-step exchange and
-     *        then loops draining frames until the socket closes or @c stop_
-     *        is set.
+     * @brief Worker-thread entry point. Performs the SETTINGS exchange and
+     *        then dispatches to the per-mode tail (drain or echo).
      */
     void run();
 
     tls_loopback_listener listener_;
+    reply_mode mode_;
     std::atomic<bool> settings_exchanged_{false};
     std::atomic<bool> io_failed_{false};
     std::atomic<bool> stop_{false};
+    std::atomic<bool> request_received_{false};
+    std::atomic<bool> response_sent_{false};
+    std::atomic<std::uint32_t> last_request_stream_id_{0};
     std::thread worker_;
 };
 

--- a/tests/unit/http2_client_branch_test.cpp
+++ b/tests/unit/http2_client_branch_test.cpp
@@ -1055,3 +1055,50 @@ TEST_F(Http2ClientHermeticTransportTest,
 
     setup.connector.join();
 }
+
+// ============================================================================
+// Phase 2A.2 connected-state success path (Issue #1074)
+//
+// mock_h2_server_peer in reply_mode::echo_one reads the client request
+// stream after the SETTINGS exchange and replies on the same stream_id
+// with a HEADERS frame (`:status: 200`, HPACK static index 8 = 0x88) plus
+// a single DATA frame ("ok", END_STREAM). This drives http2_client's
+// handle_headers_frame and handle_data_frame success branches that the
+// drain_only mode cannot reach — previously those paths were only
+// reachable through the DISABLED_ConnectToHttpbin integration test that
+// the coverage workflow does not run.
+// ============================================================================
+
+TEST_F(Http2ClientHermeticTransportTest,
+       GetSucceedsWhenPeerRepliesWithHeadersAndData)
+{
+    using namespace kcenon::network::tests::support;
+    mock_h2_server_peer peer(io(), reply_mode::echo_one);
+    auto setup = make_connected_client(peer, "echo-one-get-test");
+
+    EXPECT_TRUE(wait_for(
+        [&]() { return peer.settings_exchanged(); },
+        std::chrono::seconds(3)));
+    EXPECT_TRUE(setup.client->is_connected());
+
+    // GET drives create_stream / build_headers / encoder_.encode /
+    // send_frame on the connected path. The mock peer replies with status
+    // 200 and a 2-byte body, which exercises handle_headers_frame and
+    // handle_data_frame (END_STREAM branch) inside the client's
+    // process_frame dispatcher.
+    auto response = setup.client->get("/echo", {});
+    ASSERT_TRUE(response.is_ok());
+    EXPECT_EQ(response.value().status_code, 200);
+    EXPECT_EQ(response.value().get_body_string(), "ok");
+
+    // The peer observed exactly one client request stream (stream id 1
+    // for a fresh client) and wrote both response frames before the
+    // worker entered the drain loop.
+    EXPECT_TRUE(peer.request_received());
+    EXPECT_TRUE(peer.response_sent());
+    EXPECT_GT(peer.last_request_stream_id(), 0u);
+    EXPECT_FALSE(peer.io_failed());
+
+    (void)setup.client->disconnect();
+    setup.connector.join();
+}


### PR DESCRIPTION
## What

### Summary
Phase 2A.2 of #1074. Extends `mock_h2_server_peer` with an opt-in `reply_mode` parameter so tests can exercise the http2_client response-success path against a hermetic loopback peer. The default mode (`drain_only`) is unchanged.

### Change Type
- [x] Feature (test infrastructure addition)
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Test

### Affected Components
- `tests/support/mock_h2_server_peer.{h,cpp}` -- new `reply_mode::echo_one` path
- `tests/unit/http2_client_branch_test.cpp` -- new demo TEST_F
- `tests/support/README.md` -- usage example + Phase 2 progress update

## Why

### Problem Solved
`http2_client::handle_headers_frame` and `handle_data_frame` success branches were only reachable via the `DISABLED_ConnectToHttpbin` integration test that requires an external network. The Phase 2A `mock_h2_server_peer` only performed the SETTINGS exchange and then drained client frames -- `http2_client::get()` always timed out, so the post-SETTINGS success paths were unreachable from CI.

### Related Issues
- Part of #1074 (Phase 2 of #1060: protocol-aware loopback peers + error injection)
- Unblocks coverage expansion for `http2_client.cpp` in #1062

## Where

### Files Changed
| File | Change |
|------|--------|
| `tests/support/mock_h2_server_peer.h` | new `reply_mode` enum, constructor parameter, three new getters |
| `tests/support/mock_h2_server_peer.cpp` | echo_one branch in `run()` reads one request stream and writes HEADERS+DATA reply |
| `tests/unit/http2_client_branch_test.cpp` | new `GetSucceedsWhenPeerRepliesWithHeadersAndData` TEST_F |
| `tests/support/README.md` | usage example + Phase 2 progress table update |

### API Changes
- `mock_h2_server_peer` constructor gains a defaulted `reply_mode mode = reply_mode::drain_only` parameter (backward compatible -- all existing callers compile unchanged)
- New public getters: `request_received()`, `response_sent()`, `last_request_stream_id()`

## How

### Implementation Details
1. New `reply_mode` enum with two values: `drain_only` (Phase 2A behavior, default) and `echo_one` (Phase 2A.2).
2. After the SETTINGS exchange, `run()` checks the mode. In `echo_one`:
   - Loop reading client frames until a HEADERS frame opens a stream and END_STREAM is observed (either on HEADERS or on a subsequent DATA frame on the same stream_id).
   - Send response HEADERS frame with `:status: 200` (HPACK indexed header field 0x88, RFC 7541 Appendix A static-table index 8) on the same stream_id.
   - Send response DATA frame with body `"ok"` and END_STREAM set.
   - Set `request_received_` and `response_sent_` atomic flags.
3. The drain loop after the mode-specific block continues to absorb GOAWAY/PING frames emitted during `disconnect()`.

### Testing Done
- [ ] Local build verification -- toolchain unavailable in dev environment; relying on CI
- [x] Static review of frame_type / frame_flags / frame_header members against `src/internal/protocols/http2/frame.h`
- [x] Backward compatibility verified by inspection: every existing `mock_h2_server_peer peer(io())` call retains the Phase 2A drain_only behavior via the default argument

### Test Plan for Reviewers
1. CI must pass on Ubuntu / macOS / Windows (build, sanitizers, ctest)
2. New test `Http2ClientHermeticTransportTest.GetSucceedsWhenPeerRepliesWithHeadersAndData` should pass
3. All existing Phase 2A tests in `http2_client_branch_test.cpp` and `grpc_client_branch_test.cpp` should continue to pass unchanged

### Breaking Changes
None -- `reply_mode` parameter has a default value matching prior behavior.
