### PR TITLE
chore(includes): migrate vcpkg-consumer to canonical kcenon/thread path

### DIFF
--- a/tests/vcpkg-consumer/main.cpp
+++ b/tests/vcpkg-consumer/main.cpp
@@ -22,7 +22,7 @@
 
 // Tier 1: thread_system (transitive dependency)
 #ifdef HAS_THREAD_SYSTEM
-#include <thread_system/utilities/formatter.h>
+#include <kcenon/thread/utils/formatter.h>
 #endif
 
 int main()


### PR DESCRIPTION
Closes #1097

## Summary

Migrate the single remaining legacy `<thread_system/...>` include in the
vcpkg-consumer build-chain validation test to the canonical
`<kcenon/thread/...>` path established by `thread_system` EPIC
[kcenon/thread_system#683](https://github.com/kcenon/thread_system/issues/683).

## What changed

| File | Old | New |
|------|-----|-----|
| `tests/vcpkg-consumer/main.cpp:25` | `#include <thread_system/utilities/formatter.h>` | `#include <kcenon/thread/utils/formatter.h>` |

The legacy path resolves to a forwarding header that emits a `#pragma GCC warning`
flagging the symbol as deprecated. The new path is the canonical install
destination and emits no deprecation warning.

## Why

`thread_system` standardized its public include layout under
`<kcenon/thread/...>`. The legacy install path was preserved as a forwarding
header marked `[[deprecated]]` for backward compatibility, scheduled for
removal in the next minor release of `thread_system`. A static audit
against `thread_system develop` (post sub-issues #684, #685, #686) found
this single legacy include in `network_system`. All other thread_system
include sites already use canonical paths.

## Verification

Local C++ toolchain (cmake/vcpkg/g++) is unavailable in the sandbox, so
local build was skipped. The `validate-vcpkg-chain.yml` workflow normally
runs on PRs targeting `main` only; it has been triggered manually via
`workflow_dispatch` against this branch to verify the build chain on a
release-grade environment before merging.

## Acceptance criteria

- [x] No `#include` statements use the legacy `<thread_system/...>` path
      (verified with `grep -rn '#include\s*[<"]thread_system/'`)
- [ ] vcpkg consumer integration test still finds and links
      `kcenon-thread-system` correctly (verified by manual
      `validate-vcpkg-chain` dispatch)
- [ ] Build emits zero deprecation warnings originating from
      `thread_system` forwarding headers (verified by manual dispatch)