### PR TITLE
chore(deps): verify against container_system EPIC #531

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: kcenon/container_system
+        ref: develop  # see #1095: pin until EPIC #531 reaches main
         path: container_system
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,6 +48,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         repository: kcenon/container_system
+        ref: develop  # see #1095: pin until EPIC #531 reaches main
         path: container_system
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: kcenon/container_system
+          ref: develop  # see #1095: pin until EPIC #531 reaches main
           path: container_system
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -285,6 +286,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: kcenon/container_system
+          ref: develop  # see #1095: pin until EPIC #531 reaches main
           path: container_system
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -49,6 +49,11 @@ if(benchmark_FOUND OR BENCHMARK_FOUND)
         target_compile_definitions(network_benchmarks PRIVATE WITH_CONTAINER_SYSTEM)
     endif()
 
+    # See issue #1095: required for transitive <kcenon/container/...> includes via network_system headers.
+    if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+        target_include_directories(network_benchmarks PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
+    endif()
+
     if(THREAD_SYSTEM_INCLUDE_DIR)
         target_include_directories(network_benchmarks PRIVATE ${THREAD_SYSTEM_INCLUDE_DIR})
         target_compile_definitions(network_benchmarks PRIVATE WITH_THREAD_SYSTEM)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -96,6 +96,11 @@ if(CONTAINER_SYSTEM_INCLUDE_DIR)
     target_include_directories(connection_lifecycle_test PRIVATE ${CONTAINER_SYSTEM_INCLUDE_DIR})
 endif()
 
+# See issue #1095: required for transitive <kcenon/container/...> includes via network_system headers.
+if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+    target_include_directories(connection_lifecycle_test PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
+endif()
+
 if(THREAD_SYSTEM_INCLUDE_DIR)
     target_include_directories(connection_lifecycle_test PRIVATE ${THREAD_SYSTEM_INCLUDE_DIR})
 endif()
@@ -155,6 +160,10 @@ setup_asio_integration(protocol_integration_test)
 # Add system integration paths
 if(CONTAINER_SYSTEM_INCLUDE_DIR)
     target_include_directories(protocol_integration_test PRIVATE ${CONTAINER_SYSTEM_INCLUDE_DIR})
+endif()
+
+if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+    target_include_directories(protocol_integration_test PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
 endif()
 
 if(THREAD_SYSTEM_INCLUDE_DIR)
@@ -217,6 +226,10 @@ if(CONTAINER_SYSTEM_INCLUDE_DIR)
     target_include_directories(network_performance_test PRIVATE ${CONTAINER_SYSTEM_INCLUDE_DIR})
 endif()
 
+if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+    target_include_directories(network_performance_test PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
+endif()
+
 if(THREAD_SYSTEM_INCLUDE_DIR)
     target_include_directories(network_performance_test PRIVATE ${THREAD_SYSTEM_INCLUDE_DIR})
 endif()
@@ -275,6 +288,10 @@ setup_asio_integration(error_handling_test)
 # Add system integration paths
 if(CONTAINER_SYSTEM_INCLUDE_DIR)
     target_include_directories(error_handling_test PRIVATE ${CONTAINER_SYSTEM_INCLUDE_DIR})
+endif()
+
+if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+    target_include_directories(error_handling_test PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
 endif()
 
 if(THREAD_SYSTEM_INCLUDE_DIR)
@@ -377,6 +394,10 @@ if(CONTAINER_SYSTEM_INCLUDE_DIR)
     target_include_directories(tcp_load_test PRIVATE ${CONTAINER_SYSTEM_INCLUDE_DIR})
 endif()
 
+if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+    target_include_directories(tcp_load_test PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
+endif()
+
 if(THREAD_SYSTEM_INCLUDE_DIR)
     target_include_directories(tcp_load_test PRIVATE ${THREAD_SYSTEM_INCLUDE_DIR})
 endif()
@@ -432,6 +453,10 @@ if(CONTAINER_SYSTEM_INCLUDE_DIR)
     target_include_directories(udp_load_test PRIVATE ${CONTAINER_SYSTEM_INCLUDE_DIR})
 endif()
 
+if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+    target_include_directories(udp_load_test PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
+endif()
+
 if(THREAD_SYSTEM_INCLUDE_DIR)
     target_include_directories(udp_load_test PRIVATE ${THREAD_SYSTEM_INCLUDE_DIR})
 endif()
@@ -484,6 +509,10 @@ setup_asio_integration(websocket_load_test)
 
 if(CONTAINER_SYSTEM_INCLUDE_DIR)
     target_include_directories(websocket_load_test PRIVATE ${CONTAINER_SYSTEM_INCLUDE_DIR})
+endif()
+
+if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+    target_include_directories(websocket_load_test PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
 endif()
 
 if(THREAD_SYSTEM_INCLUDE_DIR)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,6 +81,14 @@ if(GTest_FOUND OR GTEST_FOUND)
             target_compile_definitions(${target} PRIVATE WITH_CONTAINER_SYSTEM)
         endif()
 
+        # network_system public headers transitively #include <kcenon/container/...>
+        # which lives under <root>/include. setup_container_system_integration() adds
+        # this PRIVATE on the library target, so it does not propagate to consumers.
+        # See issue #1095.
+        if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+            target_include_directories(${target} PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
+        endif()
+
         if(THREAD_SYSTEM_INCLUDE_DIR)
             target_include_directories(${target} PRIVATE ${THREAD_SYSTEM_INCLUDE_DIR})
             target_compile_definitions(${target} PRIVATE WITH_THREAD_SYSTEM)
@@ -144,6 +152,10 @@ if(GTest_FOUND OR GTEST_FOUND)
     if(CONTAINER_SYSTEM_INCLUDE_DIR)
         target_include_directories(network_thread_safety_test PRIVATE ${CONTAINER_SYSTEM_INCLUDE_DIR})
         target_compile_definitions(network_thread_safety_test PRIVATE WITH_CONTAINER_SYSTEM)
+    endif()
+
+    if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+        target_include_directories(network_thread_safety_test PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
     endif()
 
     if(THREAD_SYSTEM_INCLUDE_DIR)
@@ -459,6 +471,10 @@ if(GTest_FOUND OR GTEST_FOUND)
     if(CONTAINER_SYSTEM_INCLUDE_DIR)
         target_include_directories(network_messaging_bridge_interface_test PRIVATE ${CONTAINER_SYSTEM_INCLUDE_DIR})
         target_compile_definitions(network_messaging_bridge_interface_test PRIVATE WITH_CONTAINER_SYSTEM)
+    endif()
+
+    if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+        target_include_directories(network_messaging_bridge_interface_test PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
     endif()
 
     set_target_properties(network_messaging_bridge_interface_test PROPERTIES
@@ -2644,6 +2660,10 @@ if(FALSE AND benchmark_FOUND)
         target_compile_definitions(network_benchmark_tests PRIVATE WITH_CONTAINER_SYSTEM)
     endif()
 
+    if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+        target_include_directories(network_benchmark_tests PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
+    endif()
+
     if(THREAD_SYSTEM_INCLUDE_DIR)
         target_include_directories(network_benchmark_tests PRIVATE ${THREAD_SYSTEM_INCLUDE_DIR})
         target_compile_definitions(network_benchmark_tests PRIVATE WITH_THREAD_SYSTEM)
@@ -4352,6 +4372,10 @@ endif()
 if(CONTAINER_SYSTEM_INCLUDE_DIR)
     target_include_directories(network_system_lifecycle_test PRIVATE ${CONTAINER_SYSTEM_INCLUDE_DIR})
     target_compile_definitions(network_system_lifecycle_test PRIVATE WITH_CONTAINER_SYSTEM)
+endif()
+
+if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+    target_include_directories(network_system_lifecycle_test PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
 endif()
 
 set_target_properties(network_system_lifecycle_test PROPERTIES

--- a/tests/failure/CMakeLists.txt
+++ b/tests/failure/CMakeLists.txt
@@ -22,6 +22,11 @@ if(GTest_FOUND OR GTEST_FOUND)
         target_compile_definitions(network_failure_test PRIVATE WITH_CONTAINER_SYSTEM)
     endif()
 
+    # See issue #1095: required for transitive <kcenon/container/...> includes via network_system headers.
+    if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+        target_include_directories(network_failure_test PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
+    endif()
+
     if(THREAD_SYSTEM_INCLUDE_DIR)
         target_include_directories(network_failure_test PRIVATE ${THREAD_SYSTEM_INCLUDE_DIR})
         target_compile_definitions(network_failure_test PRIVATE WITH_THREAD_SYSTEM)
@@ -64,6 +69,10 @@ if(GTest_FOUND OR GTEST_FOUND)
     if(CONTAINER_SYSTEM_INCLUDE_DIR)
         target_include_directories(network_boundary_test PRIVATE ${CONTAINER_SYSTEM_INCLUDE_DIR})
         target_compile_definitions(network_boundary_test PRIVATE WITH_CONTAINER_SYSTEM)
+    endif()
+
+    if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+        target_include_directories(network_boundary_test PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
     endif()
 
     if(THREAD_SYSTEM_INCLUDE_DIR)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -36,6 +36,14 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test_e2e.cpp)
         target_compile_definitions(test_e2e PRIVATE WITH_CONTAINER_SYSTEM)
     endif()
 
+    # network_system public headers transitively #include <kcenon/container/...>
+    # which lives under <root>/include. setup_container_system_integration() adds
+    # this PRIVATE on the library target, so it does not propagate to consumers.
+    # See issue #1095.
+    if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+        target_include_directories(test_e2e PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
+    endif()
+
     if(THREAD_SYSTEM_INCLUDE_DIR)
         target_include_directories(test_e2e PRIVATE ${THREAD_SYSTEM_INCLUDE_DIR})
         target_compile_definitions(test_e2e PRIVATE WITH_THREAD_SYSTEM)
@@ -79,6 +87,10 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test_integration.cpp)
     if(CONTAINER_SYSTEM_INCLUDE_DIR)
         target_include_directories(stress_test PRIVATE ${CONTAINER_SYSTEM_INCLUDE_DIR})
         target_compile_definitions(stress_test PRIVATE WITH_CONTAINER_SYSTEM)
+    endif()
+
+    if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+        target_include_directories(stress_test PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
     endif()
 
     if(THREAD_SYSTEM_INCLUDE_DIR)
@@ -127,6 +139,10 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test_websocket_e2e.cpp)
     if(CONTAINER_SYSTEM_INCLUDE_DIR)
         target_include_directories(test_websocket_e2e PRIVATE ${CONTAINER_SYSTEM_INCLUDE_DIR})
         target_compile_definitions(test_websocket_e2e PRIVATE WITH_CONTAINER_SYSTEM)
+    endif()
+
+    if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+        target_include_directories(test_websocket_e2e PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
     endif()
 
     if(THREAD_SYSTEM_INCLUDE_DIR)
@@ -181,6 +197,10 @@ if(BUILD_QUIC_SUPPORT AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test_quic_e2e.cpp)
     if(CONTAINER_SYSTEM_INCLUDE_DIR)
         target_include_directories(test_quic_e2e PRIVATE ${CONTAINER_SYSTEM_INCLUDE_DIR})
         target_compile_definitions(test_quic_e2e PRIVATE WITH_CONTAINER_SYSTEM)
+    endif()
+
+    if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+        target_include_directories(test_quic_e2e PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
     endif()
 
     if(THREAD_SYSTEM_INCLUDE_DIR)
@@ -242,6 +262,10 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test_metrics_integration.cpp)
         target_compile_definitions(test_metrics_integration PRIVATE WITH_CONTAINER_SYSTEM)
     endif()
 
+    if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+        target_include_directories(test_metrics_integration PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
+    endif()
+
     if(THREAD_SYSTEM_INCLUDE_DIR)
         target_include_directories(test_metrics_integration PRIVATE ${THREAD_SYSTEM_INCLUDE_DIR})
         target_compile_definitions(test_metrics_integration PRIVATE WITH_THREAD_SYSTEM)
@@ -287,6 +311,10 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test_tracing_integration.cpp)
     if(CONTAINER_SYSTEM_INCLUDE_DIR)
         target_include_directories(test_tracing_integration PRIVATE ${CONTAINER_SYSTEM_INCLUDE_DIR})
         target_compile_definitions(test_tracing_integration PRIVATE WITH_CONTAINER_SYSTEM)
+    endif()
+
+    if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
+        target_include_directories(test_tracing_integration PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
     endif()
 
     if(THREAD_SYSTEM_INCLUDE_DIR)


### PR DESCRIPTION
## What

Pin `kcenon/container_system` fetch to `ref: develop` in three workflows
(`ci.yml`, `coverage.yml`, `integration-tests.yml`) and wire
`CONTAINER_SYSTEM_NEW_INCLUDE_DIR` into every test, integration test,
failure test, integration_tests, and benchmark target that already adds
`CONTAINER_SYSTEM_INCLUDE_DIR`.

### Change Type
- [x] Chore (CI / build glue)
- [ ] Bugfix
- [ ] Feature

### Affected Components
- `.github/workflows/{ci,coverage,integration-tests}.yml`
- `tests/CMakeLists.txt`, `tests/integration/CMakeLists.txt`,
  `tests/failure/CMakeLists.txt`
- `integration_tests/CMakeLists.txt`
- `benchmarks/CMakeLists.txt`

## Why

EPIC `kcenon/container_system#531` (header consolidation, CMake
decomposition, install rule cleanup, deprecated forwarding header
sweep) merged into container_system `develop` at `fa56dc5e` (PR #541)
on 2026-05-02. The EPIC's last acceptance criterion requires
"All tests plus downstream consumers (pacs, network) pass" — this PR
is the network-side verification.

Without the `ref: develop` pin, every CI job that enables
`BUILD_WITH_CONTAINER_SYSTEM=ON` checks out container_system `main`
(stale, pre-EPIC), so any layout mismatch would only surface at the
next release sync, after both repos merge to `main`.

Without the `CONTAINER_SYSTEM_NEW_INCLUDE_DIR` propagation, every
test/benchmark target transitively reaching
`<kcenon/network/internal/integration/container_integration.h>` →
`#include "container.h"` → `#include <kcenon/container/container.h>`
fails to resolve the canonical header, since
`setup_container_system_integration()` adds the new include dir
PRIVATE on the network_system library and `target_include_directories`
PRIVATE does not propagate to consumers.

## Where

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | sanitizers job: `ref: develop` for container_system checkout |
| `.github/workflows/coverage.yml` | coverage job: `ref: develop` for container_system checkout |
| `.github/workflows/integration-tests.yml` | integration-tests + performance-validation jobs: `ref: develop` |
| `tests/CMakeLists.txt` | 5 sites (1 helper function + 4 explicit targets) |
| `tests/integration/CMakeLists.txt` | 6 targets |
| `tests/failure/CMakeLists.txt` | 2 targets |
| `integration_tests/CMakeLists.txt` | 7 targets |
| `benchmarks/CMakeLists.txt` | 1 target |

Total: 99 insertions, 0 deletions.

## How

### Implementation
- Add `ref: develop` (with a one-line `# see #1095` comment) to every
  `actions/checkout@v6` step that fetches `kcenon/container_system`.
- After every `if(CONTAINER_SYSTEM_INCLUDE_DIR)` block on a
  test/benchmark target, append:
  ```cmake
  if(CONTAINER_SYSTEM_NEW_INCLUDE_DIR)
      target_include_directories(<target> PRIVATE ${CONTAINER_SYSTEM_NEW_INCLUDE_DIR})
  endif()
  ```
  matching the pattern already used by
  `setup_container_system_integration()` in
  `cmake/network_system_integration.cmake`.
- Library-side dependency detection
  (`cmake/network_system_dependencies.cmake`) already exports
  `CONTAINER_SYSTEM_NEW_INCLUDE_DIR`; this PR only wires the
  downstream test/benchmark consumers.

### Testing
- Local toolchain (`cmake`, `ninja`, `g++`, `clang++`) is unavailable
  in the verification sandbox, so build/test verification relies on CI.
- Affected CI jobs (run with `BUILD_WITH_CONTAINER_SYSTEM=ON` against
  container_system `develop` post-pin):
  - `ci.yml` sanitizers (TSan/ASan/UBSan, ubuntu-24.04)
  - `coverage.yml` ubuntu-24.04 coverage analysis
  - `integration-tests.yml` ubuntu-latest + macos-latest, Debug + Release
  - `integration-tests.yml` performance-validation
- Out of scope: other ecosystem checkouts (`common_system`,
  `thread_system`, `logger_system`) still fetch `main`. Pinning those
  is appropriate when each system reaches a similar EPIC milestone
  and is not bundled here per surgical-precision principle.

### Breaking Changes
None — additive only (no existing target loses an include dir).

### Rollback
`git revert` of this commit; container_system fetch falls back to
`main` and tests/benchmarks lose the new include path.

---

Refs: kcenon/container_system#531
Closes #1095
