### PR TITLE
chore(release): verify SHA512 against actual archive (#1100)

### DIFF
--- a/.github/workflows/on-release-sync-registry.yml
+++ b/.github/workflows/on-release-sync-registry.yml
@@ -5,7 +5,57 @@ on:
     types: [published]
 
 jobs:
+  verify-archive:
+    name: Verify release archive SHA512
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify SHA512 against actual GitHub archive
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Independent SHA512 verification against the released archive.
+          # The reusable sync workflow at kcenon/common_system already performs
+          # this check internally (see kcenon/common_system#675, PR #676), but
+          # repeating it here on the caller side guards against drift if the
+          # reusable workflow changes or is repointed in the future.
+          # Reference: kcenon/network_system#1100, EPIC kcenon/common_system#674.
+          set -euo pipefail
+          ARCHIVE_URL="https://github.com/${REPO}/archive/refs/tags/${TAG}.tar.gz"
+          VERIFY_FILE="$(mktemp)"
+
+          echo "Fetching ${ARCHIVE_URL} for SHA512 verification..."
+          # Download to a file (not piped into sha512sum) so a fetch failure
+          # cannot silently produce the empty-input hash cf83e1357eefb8bdf...
+          if ! curl -fsSL --retry 3 --retry-delay 2 -o "${VERIFY_FILE}" "${ARCHIVE_URL}"; then
+            echo "::error::Failed to download release archive: ${ARCHIVE_URL}"
+            rm -f "${VERIFY_FILE}"
+            exit 1
+          fi
+
+          ARCHIVE_SIZE=$(stat -c %s "${VERIFY_FILE}" 2>/dev/null || stat -f %z "${VERIFY_FILE}")
+          if [ "${ARCHIVE_SIZE}" -lt 1024 ]; then
+            echo "::error::Downloaded archive is suspiciously small (${ARCHIVE_SIZE} bytes)"
+            rm -f "${VERIFY_FILE}"
+            exit 1
+          fi
+
+          ACTUAL_SHA=$(sha512sum "${VERIFY_FILE}" | awk '{print $1}')
+          rm -f "${VERIFY_FILE}"
+
+          # Empty-input SHA-512 sentinel guard.
+          EMPTY_SHA="cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+          if [ "${ACTUAL_SHA}" = "${EMPTY_SHA}" ]; then
+            echo "::error::Computed SHA512 matches the empty-input constant; download likely failed."
+            exit 1
+          fi
+
+          echo "SHA512 of ${ARCHIVE_URL}:"
+          echo "  ${ACTUAL_SHA}"
+          echo "Archive size: ${ARCHIVE_SIZE} bytes"
+
   sync:
+    needs: verify-archive
     uses: kcenon/common_system/.github/workflows/sync-vcpkg-registry.yml@main
     with:
       port-name: kcenon-network-system


### PR DESCRIPTION
## What

Add a `verify-archive` job to `.github/workflows/on-release-sync-registry.yml` that independently downloads the published release archive from GitHub, verifies a sane size, and computes its SHA512 before the reusable `sync-vcpkg-registry.yml` workflow at `kcenon/common_system` runs. The existing `sync` job now declares `needs: verify-archive`, so the registry publish never proceeds when the archive hash check fails.

## Why

`kcenon/network_system`'s release automation delegates to a reusable workflow that already performs SHA verification internally (see `kcenon/common_system#675`, merged via PR #676). This PR adds a second, caller-side check that:

- Guards against drift if the reusable workflow ever changes, is repointed to a different ref, or is silently broken.
- Provides early failure on the caller side, where the failure is visible alongside the release event.
- Brings `network_system` in line with the 5 sibling sub-issues from EPIC `kcenon/common_system#674` that have already shipped this hardening (`thread_system` PR #692, `container_system` PR #543, `logger_system` PR #635, `monitoring_system` PR #688, `database_system` PR #589).

Without verification, cold-cache consumers (new CI runners, new users) hit 100% install failure when the SHA in `vcpkg-registry/ports/kcenon-network-system/portfile.cmake` does not match the actual archive. See first finding `kcenon/common_system#653` and cross-port audit `kcenon/vcpkg-registry#87`.

## Where

| Item | Value |
|------|-------|
| Repository | `kcenon/network_system` |
| File changed | `.github/workflows/on-release-sync-registry.yml` |
| Job added | `verify-archive` (runs before the existing `sync` job) |
| Existing `sync` job | unchanged except for `needs: verify-archive` |

Audit confirmed `on-release-sync-registry.yml` is the only workflow that participates in the registry sync; no other workflow computes or writes a SHA for the vcpkg portfile.

## How

### Implementation details

- **File-based hashing.** The script downloads the archive to a temp file via `curl -fsSL --retry 3 --retry-delay 2 -o "$VERIFY_FILE"`, then runs `sha512sum "$VERIFY_FILE"`. Piping `curl ... | sha512sum` is explicitly avoided because pipe failures are masked: `sha512sum` of empty input is the fixed constant `cf83e1357eefb8bdf...`, and a 404 from `curl` (even with `-fsSL`) still drives the pipe to that constant.
- **Empty-input sentinel guard.** Even with file-based hashing, the script explicitly rejects the empty SHA-512 constant as a belt-and-suspenders defense against any future regression that produces a zero-byte download.
- **Minimum-size check.** Archives smaller than 1024 bytes are rejected with a clear error.
- **Job ordering.** `sync` declares `needs: verify-archive`, so an archive-fetch failure prevents the registry update.

### Acceptance criteria

- [x] Audit identified `on-release-sync-registry.yml` as the only relevant release/sync workflow in this repo.
- [x] The verification step runs AFTER the release publish event and BEFORE the reusable `sync` workflow that updates the portfile.
- [x] No composite-action extraction needed (single workflow, single thin caller).
- [x] Pattern matches the 6 successful sibling PRs (`#675`/`#676`, `#692`, `#543`, `#635`, `#688`, `#589`).

### References

- Parent EPIC: `kcenon/common_system#674`
- Reference sub-issue + reusable workflow: `kcenon/common_system#675` (merged via PR #676)
- First finding: `kcenon/common_system#653` (`microsoft/vcpkg#51511`)
- Cross-port audit: `kcenon/vcpkg-registry#87`
- Sibling PRs: `kcenon/thread_system#692`, `kcenon/container_system#543`, `kcenon/logger_system#635`, `kcenon/monitoring_system#688`, `kcenon/database_system#589`

Closes #1100
