### PR TITLE
infra(test): add mock_grpc_server_peer for gRPC unary loopback (Phase 2B of #1074)

### DIFF
--- a/tests/support/CMakeLists.txt
+++ b/tests/support/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(network_test_support STATIC
     mock_udp_peer.cpp
     mock_ws_handshake.cpp
     mock_h2_server_peer.cpp
+    mock_grpc_server_peer.cpp
 )
 
 target_include_directories(network_test_support

--- a/tests/support/README.md
+++ b/tests/support/README.md
@@ -30,6 +30,7 @@ follow-up tests drive those methods.
 | `mock_udp_peer.h/.cpp` | UDP peer wrapper for QUIC tests plus a stub QUIC long-header Initial-packet builder. |
 | `mock_ws_handshake.h/.cpp` | RFC 6455 client upgrade request and frame builders for WebSocket server tests. |
 | `mock_h2_server_peer.h/.cpp` | Server-side HTTP/2 framing peer (Phase 2A + 2A.2 of #1074): connection preface read, server SETTINGS send, client SETTINGS read, SETTINGS-ACK send. With `reply_mode::echo_one`, also reads one client request stream and replies with `:status: 200` HEADERS + a small END_STREAM DATA frame. Composes `tls_loopback_listener` and runs the exchange on a dedicated worker thread. |
+| `mock_grpc_server_peer.h/.cpp` | Server-side gRPC framing peer (Phase 2B of #1074): same SETTINGS exchange as `mock_h2_server_peer`. With `grpc_reply_mode::echo_unary`, additionally reads one client request stream and replies with `:status: 200` + `content-type: application/grpc` HEADERS, one length-prefixed DATA frame (gRPC 5-byte header + payload), and a trailing HEADERS frame carrying `grpc-status: 0` (END_STREAM). Drives `grpc_client::call_raw` past the trailer-scan and `grpc_message::parse` branches. |
 
 ## Composition pattern
 
@@ -130,6 +131,53 @@ TEST_F(MyHttp2ClientTest, GetReturnsResponseFromMockPeer)
     EXPECT_TRUE(peer.response_sent());
 
     (void)client->disconnect();
+    connector.join();
+}
+```
+
+For gRPC client tests that need a successful unary RPC reply (Phase 2B),
+use `mock_grpc_server_peer` which layers gRPC framing on top of the
+HTTP/2 SETTINGS exchange. With `grpc_reply_mode::echo_unary`, the peer
+reads one client request stream after SETTINGS and replies on the same
+stream with response HEADERS (`:status: 200`,
+`content-type: application/grpc`), one length-prefixed gRPC DATA frame,
+and trailing HEADERS (`grpc-status: 0`, END_STREAM):
+
+```cpp
+#include "hermetic_transport_fixture.h"
+#include "mock_grpc_server_peer.h"
+
+class MyGrpcClientTest
+    : public kcenon::network::tests::support::hermetic_transport_fixture
+{
+};
+
+TEST_F(MyGrpcClientTest, CallRawReturnsResponseFromMockGrpcPeer)
+{
+    using namespace kcenon::network::tests::support;
+
+    mock_grpc_server_peer peer(io(), grpc_reply_mode::echo_unary);
+
+    grpc::grpc_channel_config cfg;
+    cfg.use_tls = true;
+    cfg.default_timeout = std::chrono::milliseconds(2000);
+
+    const std::string target =
+        "127.0.0.1:" + std::to_string(static_cast<unsigned>(peer.port()));
+    auto client = std::make_shared<grpc::grpc_client>(target, cfg);
+
+    std::thread connector([&]() { (void)client->connect(); });
+    wait_for([&]() { return peer.settings_exchanged(); },
+             std::chrono::seconds(3));
+
+    auto response = client->call_raw(
+        "/svc/Echo", std::vector<uint8_t>{0x01, 0x02});
+    ASSERT_TRUE(response.is_ok());
+    EXPECT_EQ(response.value().data, (std::vector<uint8_t>{'o', 'k'}));
+    EXPECT_TRUE(peer.request_received());
+    EXPECT_TRUE(peer.response_sent());
+
+    client->disconnect();
     connector.join();
 }
 ```

--- a/tests/support/mock_grpc_server_peer.cpp
+++ b/tests/support/mock_grpc_server_peer.cpp
@@ -1,0 +1,401 @@
+// BSD 3-Clause License
+// Copyright (c) 2026, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file mock_grpc_server_peer.cpp
+ * @brief Implementation of server-side gRPC framing peer
+ *        (Phase 2B of Issue #1074)
+ */
+
+#include "mock_grpc_server_peer.h"
+
+#include "internal/protocols/http2/frame.h"
+
+#include <asio/buffer.hpp>
+#include <asio/read.hpp>
+#include <asio/write.hpp>
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <span>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace kcenon::network::tests::support
+{
+
+namespace
+{
+
+namespace http2 = kcenon::network::protocols::http2;
+
+constexpr std::size_t kPrefaceSize = 24;
+constexpr std::size_t kFrameHeaderSize = 9;
+
+// HTTP/2 connection preface bytes (RFC 7540 Section 3.5):
+// "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+constexpr std::uint8_t kPrefaceBytes[kPrefaceSize] = {
+    'P',  'R',  'I',  ' ',  '*',  ' ',  'H',  'T',
+    'T',  'P',  '/',  '2',  '.',  '0',  '\r', '\n',
+    '\r', '\n', 'S',  'M',  '\r', '\n', '\r', '\n'
+};
+
+// HPACK-encoded response headers for the unary echo path. Each entry uses
+// the literal-with-incremental-indexing form (0x40 prefix) followed by a
+// length-prefixed name and length-prefixed value. Static-table indexed
+// fields are used where they exist:
+//
+//   0x88            -> :status: 200            (static index 8)
+//
+// content-type and grpc-status are sent as literal headers because the
+// h2 client (http2_client) does not maintain a populated dynamic table
+// strict enough to require indexed encoding here, and the static table
+// has no exact match for "application/grpc" or numeric grpc-status.
+//
+// Encoding helpers below build the payload at runtime to keep the byte
+// layout legible without committing to a hand-rolled blob.
+
+// Build a literal-without-indexing HPACK header field (0x00 prefix per
+// RFC 7541 Section 6.2.2). Both name and value are sent as plain (non-
+// Huffman) length-prefixed strings. Length is encoded with the simple
+// 7-bit form because all values used here fit in <=127 bytes.
+auto encode_literal_header(std::string_view name, std::string_view value)
+    -> std::vector<std::uint8_t>
+{
+    std::vector<std::uint8_t> out;
+    out.reserve(2 + name.size() + value.size());
+    out.push_back(0x00); // literal header field without indexing, new name
+    out.push_back(static_cast<std::uint8_t>(name.size()));
+    out.insert(out.end(), name.begin(), name.end());
+    out.push_back(static_cast<std::uint8_t>(value.size()));
+    out.insert(out.end(), value.begin(), value.end());
+    return out;
+}
+
+// Build the HPACK block for the response HEADERS frame:
+//   :status: 200             (indexed, static table 8)
+//   content-type: application/grpc
+auto build_response_header_block() -> std::vector<std::uint8_t>
+{
+    std::vector<std::uint8_t> block;
+    block.push_back(0x88); // indexed header field, static index 8 = :status: 200
+    auto ct = encode_literal_header("content-type", "application/grpc");
+    block.insert(block.end(), ct.begin(), ct.end());
+    return block;
+}
+
+// Build the HPACK block for the trailing HEADERS frame:
+//   grpc-status: 0
+auto build_trailer_header_block() -> std::vector<std::uint8_t>
+{
+    return encode_literal_header("grpc-status", "0");
+}
+
+// Build a length-prefixed gRPC message body
+// (1 byte compressed flag = 0, 4 bytes big-endian length, payload).
+auto build_grpc_framed_body(std::span<const std::uint8_t> payload)
+    -> std::vector<std::uint8_t>
+{
+    std::vector<std::uint8_t> framed;
+    framed.reserve(5 + payload.size());
+    framed.push_back(0x00); // not compressed
+    const auto len = static_cast<std::uint32_t>(payload.size());
+    framed.push_back(static_cast<std::uint8_t>((len >> 24) & 0xFF));
+    framed.push_back(static_cast<std::uint8_t>((len >> 16) & 0xFF));
+    framed.push_back(static_cast<std::uint8_t>((len >> 8) & 0xFF));
+    framed.push_back(static_cast<std::uint8_t>(len & 0xFF));
+    framed.insert(framed.end(), payload.begin(), payload.end());
+    return framed;
+}
+
+} // namespace
+
+mock_grpc_server_peer::mock_grpc_server_peer(asio::io_context& io,
+                                             grpc_reply_mode mode)
+    : listener_(io), mode_(mode)
+{
+    worker_ = std::thread([this]() { this->run(); });
+}
+
+mock_grpc_server_peer::~mock_grpc_server_peer()
+{
+    stop_.store(true);
+    // The expected lifecycle is that the client issues disconnect() before
+    // this destructor runs. disconnect() emits a GOAWAY frame and closes
+    // the socket, which causes the worker's blocking read to return EOF
+    // and the worker to exit promptly.
+    if (worker_.joinable())
+    {
+        worker_.join();
+    }
+}
+
+auto mock_grpc_server_peer::request_body() const -> std::vector<std::uint8_t>
+{
+    std::lock_guard<std::mutex> lock(request_body_mutex_);
+    return request_body_;
+}
+
+void mock_grpc_server_peer::run()
+{
+    auto stream = listener_.accepted_socket(std::chrono::seconds(5));
+    if (!stream)
+    {
+        io_failed_.store(true);
+        return;
+    }
+
+    std::error_code ec;
+
+    // Step 1: Read the 24-byte client connection preface.
+    std::array<std::uint8_t, kPrefaceSize> preface_buf{};
+    asio::read(*stream, asio::buffer(preface_buf), ec);
+    if (ec ||
+        std::memcmp(preface_buf.data(), kPrefaceBytes, kPrefaceSize) != 0)
+    {
+        io_failed_.store(true);
+        return;
+    }
+
+    // Step 2: Send an empty server SETTINGS frame
+    // (length=0, type=0x4, flags=0, stream_id=0).
+    {
+        http2::settings_frame initial({}, /*ack=*/false);
+        const auto bytes = initial.serialize();
+        asio::write(*stream, asio::buffer(bytes), ec);
+        if (ec)
+        {
+            io_failed_.store(true);
+            return;
+        }
+    }
+
+    // Step 3: Read the client's SETTINGS frame header (9 bytes).
+    std::array<std::uint8_t, kFrameHeaderSize> hdr_buf{};
+    asio::read(*stream, asio::buffer(hdr_buf), ec);
+    if (ec)
+    {
+        io_failed_.store(true);
+        return;
+    }
+    auto parsed = http2::frame_header::parse(
+        std::span<const std::uint8_t>(hdr_buf.data(), hdr_buf.size()));
+    if (parsed.is_err())
+    {
+        io_failed_.store(true);
+        return;
+    }
+    const auto hdr = parsed.value();
+    if (hdr.type != http2::frame_type::settings ||
+        (hdr.flags & http2::frame_flags::ack) != 0)
+    {
+        io_failed_.store(true);
+        return;
+    }
+
+    // Drain the client SETTINGS payload. Any negotiated values are
+    // accepted as-is — gRPC unary success path coverage does not depend
+    // on enforcing them.
+    if (hdr.length > 0)
+    {
+        std::vector<std::uint8_t> payload(hdr.length);
+        asio::read(*stream, asio::buffer(payload), ec);
+        if (ec)
+        {
+            io_failed_.store(true);
+            return;
+        }
+    }
+
+    // Step 4: Send SETTINGS-ACK
+    // (length=0, type=0x4, flags=0x1, stream_id=0).
+    {
+        http2::settings_frame ack_frame({}, /*ack=*/true);
+        const auto bytes = ack_frame.serialize();
+        asio::write(*stream, asio::buffer(bytes), ec);
+        if (ec)
+        {
+            io_failed_.store(true);
+            return;
+        }
+    }
+
+    settings_exchanged_.store(true);
+
+    // grpc_reply_mode::echo_unary: read one client request stream and
+    // reply with HEADERS (status 200) + DATA (length-prefixed body) +
+    // trailing HEADERS (grpc-status: 0, END_STREAM). The drain loop
+    // afterwards absorbs PING/GOAWAY frames emitted during disconnect().
+    if (mode_ == grpc_reply_mode::echo_unary)
+    {
+        std::uint32_t request_stream_id = 0;
+        bool headers_received = false;
+        bool stream_complete = false;
+        std::vector<std::uint8_t> accumulated_body;
+
+        while (!stop_.load() && !stream_complete)
+        {
+            std::array<std::uint8_t, kFrameHeaderSize> req_hdr_buf{};
+            asio::read(*stream, asio::buffer(req_hdr_buf), ec);
+            if (ec)
+            {
+                io_failed_.store(true);
+                return;
+            }
+            auto req_parsed = http2::frame_header::parse(
+                std::span<const std::uint8_t>(
+                    req_hdr_buf.data(), req_hdr_buf.size()));
+            if (req_parsed.is_err())
+            {
+                io_failed_.store(true);
+                return;
+            }
+            const auto req_h = req_parsed.value();
+
+            std::vector<std::uint8_t> req_payload;
+            if (req_h.length > 0)
+            {
+                req_payload.resize(req_h.length);
+                asio::read(*stream, asio::buffer(req_payload), ec);
+                if (ec)
+                {
+                    io_failed_.store(true);
+                    return;
+                }
+            }
+
+            const bool end_stream =
+                (req_h.flags & http2::frame_flags::end_stream) != 0;
+
+            if (req_h.type == http2::frame_type::headers && !headers_received)
+            {
+                request_stream_id = req_h.stream_id;
+                headers_received = true;
+                last_request_stream_id_.store(request_stream_id);
+                if (end_stream)
+                {
+                    stream_complete = true;
+                }
+            }
+            else if (req_h.type == http2::frame_type::data &&
+                     headers_received &&
+                     req_h.stream_id == request_stream_id)
+            {
+                accumulated_body.insert(accumulated_body.end(),
+                                        req_payload.begin(),
+                                        req_payload.end());
+                if (end_stream)
+                {
+                    stream_complete = true;
+                }
+            }
+            // Other frames (PING, additional SETTINGS, frames on other
+            // streams) are deliberately drained without affecting state.
+        }
+
+        if (!stream_complete)
+        {
+            // Worker was asked to stop or the socket closed before we saw
+            // END_STREAM; nothing else to do.
+            return;
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(request_body_mutex_);
+            request_body_ = std::move(accumulated_body);
+        }
+        request_received_.store(true);
+
+        // Send response HEADERS frame: ":status: 200" + content-type.
+        // END_HEADERS set, END_STREAM unset (DATA + trailers follow).
+        {
+            const auto header_block = build_response_header_block();
+            http2::headers_frame response_headers(
+                request_stream_id, header_block,
+                /*end_stream=*/false, /*end_headers=*/true);
+            const auto bytes = response_headers.serialize();
+            asio::write(*stream, asio::buffer(bytes), ec);
+            if (ec)
+            {
+                io_failed_.store(true);
+                return;
+            }
+        }
+
+        // Send response DATA frame with a length-prefixed gRPC message.
+        // The body content is intentionally short ("ok") so tests can
+        // match it exactly.
+        {
+            constexpr std::array<std::uint8_t, 2> payload{'o', 'k'};
+            const auto framed = build_grpc_framed_body(
+                std::span<const std::uint8_t>(payload.data(), payload.size()));
+            http2::data_frame response_data(
+                request_stream_id, framed,
+                /*end_stream=*/false, /*padded=*/false);
+            const auto bytes = response_data.serialize();
+            asio::write(*stream, asio::buffer(bytes), ec);
+            if (ec)
+            {
+                io_failed_.store(true);
+                return;
+            }
+        }
+
+        // Send trailing HEADERS frame: "grpc-status: 0", END_STREAM set.
+        // gRPC carries terminal status as HTTP/2 trailers in the success
+        // path; the client extracts this from response.headers (the
+        // http2_client merges trailers into the headers vector before
+        // delivering the response).
+        {
+            const auto trailer_block = build_trailer_header_block();
+            http2::headers_frame trailers(
+                request_stream_id, trailer_block,
+                /*end_stream=*/true, /*end_headers=*/true);
+            const auto bytes = trailers.serialize();
+            asio::write(*stream, asio::buffer(bytes), ec);
+            if (ec)
+            {
+                io_failed_.store(true);
+                return;
+            }
+        }
+
+        response_sent_.store(true);
+    }
+
+    // Drain any subsequent frames (e.g. the GOAWAY emitted by client
+    // disconnect(), or further PING frames) until EOF or stop_ is set.
+    while (!stop_.load())
+    {
+        std::array<std::uint8_t, kFrameHeaderSize> drain_hdr{};
+        asio::read(*stream, asio::buffer(drain_hdr), ec);
+        if (ec)
+        {
+            break;
+        }
+        auto drain_parsed = http2::frame_header::parse(
+            std::span<const std::uint8_t>(drain_hdr.data(), drain_hdr.size()));
+        if (drain_parsed.is_err())
+        {
+            break;
+        }
+        const auto drain_h = drain_parsed.value();
+        if (drain_h.length > 0)
+        {
+            std::vector<std::uint8_t> payload(drain_h.length);
+            asio::read(*stream, asio::buffer(payload), ec);
+            if (ec)
+            {
+                break;
+            }
+        }
+    }
+}
+
+} // namespace kcenon::network::tests::support

--- a/tests/support/mock_grpc_server_peer.h
+++ b/tests/support/mock_grpc_server_peer.h
@@ -1,0 +1,278 @@
+// BSD 3-Clause License
+// Copyright (c) 2026, kcenon
+// See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+/**
+ * @file mock_grpc_server_peer.h
+ * @brief Server-side gRPC framing peer for grpc_client unit tests
+ *        (Phase 2B of Issue #1074, on top of Issue #1060)
+ *
+ * Builds on top of @ref tls_loopback_listener and adds the minimal
+ * server-side HTTP/2 + gRPC framing required to push @c grpc_client past
+ * the TCP/TLS connect gate, the HTTP/2 SETTINGS-exchange gate, and
+ * (optionally) all the way through a unary RPC. Once the SETTINGS
+ * exchange completes, @c grpc_client::is_connected() reports true *and*
+ * the post-connect public methods (e.g. @c call_raw, @c disconnect,
+ * @c wait_for_connected) reach code paths that previously timed out
+ * behind a silent peer.
+ *
+ * Two operating modes are supported via @ref grpc_reply_mode:
+ *
+ * - @ref grpc_reply_mode::drain_only (default): after the SETTINGS
+ *   handshake, the worker loops reading any further client frames
+ *   (HEADERS for the unary call, DATA for the gRPC-framed request,
+ *   GOAWAY emitted by @c disconnect()) and discards their payloads.
+ *   This drives the request-timeout / connection-error path on
+ *   @c grpc_client because the client's response future never resolves.
+ *
+ * - @ref grpc_reply_mode::echo_unary: after the SETTINGS handshake,
+ *   the worker reads exactly one client request stream (HEADERS, plus
+ *   any DATA frames until END_STREAM is set), then replies on the same
+ *   stream with:
+ *     1. A server HEADERS frame carrying @c :status: 200 and
+ *        @c content-type: application/grpc (END_HEADERS, no END_STREAM).
+ *     2. A DATA frame carrying one length-prefixed gRPC message with a
+ *        small body (END_STREAM unset because trailers follow).
+ *     3. A trailing HEADERS frame carrying @c grpc-status: 0
+ *        (END_HEADERS + END_STREAM).
+ *   This drives @c grpc_client::call_raw's full success path, including
+ *   the @c grpc_message::parse step and the trailer-based status
+ *   extraction.
+ *
+ * Sequence performed on a dedicated worker thread (both modes):
+ *  1. Wait for the @ref tls_loopback_listener to deliver the post-handshake
+ *     SSL stream (TLS 1.2+/1.3 negotiated with ALPN "h2" by the listener).
+ *  2. Read the fixed 24-byte client connection preface
+ *     (@c "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n").
+ *  3. Send an empty server SETTINGS frame.
+ *  4. Read the client's SETTINGS frame.
+ *  5. Send a SETTINGS-ACK frame.
+ *
+ * After step 5, behavior diverges per @ref grpc_reply_mode (see above).
+ *
+ * Hermetic: bound to @c 127.0.0.1:0 via the underlying listener; cert is
+ * regenerated per construction; no DNS, no external network, no on-disk
+ * secrets. Concurrent test executions never collide because every port
+ * is ephemeral.
+ */
+
+#include "mock_tls_socket.h"
+
+#include <asio/io_context.hpp>
+#include <asio/ip/tcp.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace kcenon::network::tests::support
+{
+
+/**
+ * @brief Selects the post-handshake behavior of @ref mock_grpc_server_peer.
+ */
+enum class grpc_reply_mode
+{
+    /// Drain client frames after the SETTINGS exchange, never reply with
+    /// HEADERS+DATA+trailers. Drives the request-timeout / unavailable
+    /// path on @c grpc_client.
+    drain_only,
+
+    /// Read exactly one client request stream after the SETTINGS exchange,
+    /// then reply on the same stream with response HEADERS
+    /// (`:status: 200`, `content-type: application/grpc`), one
+    /// length-prefixed DATA frame, and trailers
+    /// (`grpc-status: 0`, END_STREAM). Drives the response-success path on
+    /// @c grpc_client::call_raw.
+    echo_unary
+};
+
+/**
+ * @brief Server-side gRPC framing peer composed on top of
+ *        @ref tls_loopback_listener.
+ *
+ * Typical usage from a test fixture derived from
+ * @ref hermetic_transport_fixture:
+ * @code
+ * mock_grpc_server_peer peer(io());
+ *
+ * grpc::grpc_channel_config cfg;
+ * cfg.use_tls = false;  // mock peer presents TLS via the listener
+ * grpc::grpc_client client("127.0.0.1:" + std::to_string(peer.port()), cfg);
+ *
+ * std::thread connector([&]() {
+ *     (void)client.connect();
+ * });
+ *
+ * EXPECT_TRUE(wait_for([&]() { return peer.settings_exchanged(); },
+ *                      std::chrono::seconds(3)));
+ * EXPECT_TRUE(client.is_connected());
+ *
+ * client.disconnect();
+ * connector.join();
+ * @endcode
+ *
+ * For tests that need a successful unary response:
+ * @code
+ * mock_grpc_server_peer peer(io(), grpc_reply_mode::echo_unary);
+ *
+ * grpc::grpc_client client(...);
+ * std::thread connector([&]() { (void)client.connect(); });
+ * wait_for([&]() { return peer.settings_exchanged(); },
+ *          std::chrono::seconds(3));
+ *
+ * auto response = client.call_raw("/svc/Method", {0x01, 0x02},
+ *                                 grpc::call_options{});
+ * EXPECT_TRUE(response.is_ok());
+ * EXPECT_TRUE(peer.request_received());
+ * EXPECT_TRUE(peer.response_sent());
+ *
+ * client.disconnect();
+ * connector.join();
+ * @endcode
+ */
+class mock_grpc_server_peer
+{
+public:
+    /**
+     * @brief Construct the peer, opening the TLS listener and spawning
+     *        the worker thread.
+     * @param io io_context used by the underlying listener for accept
+     *        and TLS handshake.
+     * @param mode Post-handshake behavior. Defaults to
+     *        @ref grpc_reply_mode::drain_only for backward compatibility
+     *        with timeout-path tests.
+     */
+    explicit mock_grpc_server_peer(asio::io_context& io,
+                                   grpc_reply_mode mode
+                                       = grpc_reply_mode::drain_only);
+
+    /**
+     * @brief Destructor. Signals the worker to stop, closes the listener,
+     *        and joins the worker thread.
+     */
+    ~mock_grpc_server_peer();
+
+    mock_grpc_server_peer(const mock_grpc_server_peer&) = delete;
+    mock_grpc_server_peer& operator=(const mock_grpc_server_peer&) = delete;
+    mock_grpc_server_peer(mock_grpc_server_peer&&) = delete;
+    mock_grpc_server_peer& operator=(mock_grpc_server_peer&&) = delete;
+
+    /**
+     * @brief Port the underlying TLS listener is bound to.
+     */
+    [[nodiscard]] auto port() const -> unsigned short
+    {
+        return listener_.port();
+    }
+
+    /**
+     * @brief Endpoint the underlying TLS listener is bound to.
+     */
+    [[nodiscard]] auto endpoint() const -> asio::ip::tcp::endpoint
+    {
+        return listener_.endpoint();
+    }
+
+    /**
+     * @brief True after the worker has read the client preface, sent the
+     *        server SETTINGS, read the client SETTINGS, and sent the
+     *        SETTINGS-ACK.
+     *
+     * Tests should poll this via
+     * @ref hermetic_transport_fixture::wait_for to synchronize with the
+     * mock peer before asserting on the client.
+     */
+    [[nodiscard]] auto settings_exchanged() const -> bool
+    {
+        return settings_exchanged_.load();
+    }
+
+    /**
+     * @brief True if the worker thread exited via an I/O failure
+     *        (handshake timeout, preface mismatch, peer closed before
+     *        SETTINGS, etc.).
+     *
+     * Informational; tests that want to fail fast on a setup error can
+     * assert that this stays false.
+     */
+    [[nodiscard]] auto io_failed() const -> bool
+    {
+        return io_failed_.load();
+    }
+
+    /**
+     * @brief True after the worker has read a complete client request
+     *        (HEADERS + any DATA frames up to END_STREAM) on the
+     *        @ref grpc_reply_mode::echo_unary path.
+     *
+     * Always false in @ref grpc_reply_mode::drain_only because the worker
+     * never makes the half-closed-remote transition.
+     */
+    [[nodiscard]] auto request_received() const -> bool
+    {
+        return request_received_.load();
+    }
+
+    /**
+     * @brief True after the worker has written the response HEADERS frame
+     *        (status 200), a single DATA frame with a length-prefixed
+     *        gRPC message, and a trailing HEADERS frame
+     *        (`grpc-status: 0`) on the @ref grpc_reply_mode::echo_unary
+     *        path.
+     *
+     * Always false in @ref grpc_reply_mode::drain_only.
+     */
+    [[nodiscard]] auto response_sent() const -> bool
+    {
+        return response_sent_.load();
+    }
+
+    /**
+     * @brief Stream id observed in the first client HEADERS frame after
+     *        SETTINGS exchange (typically 1 for a fresh client).
+     *
+     * Zero until @ref request_received() returns true.
+     */
+    [[nodiscard]] auto last_request_stream_id() const -> std::uint32_t
+    {
+        return last_request_stream_id_.load();
+    }
+
+    /**
+     * @brief Bytes accumulated from all DATA frames the client sent on
+     *        the request stream, in receive order.
+     *
+     * Empty until at least one client DATA frame has been read. For a
+     * unary RPC this contains the gRPC-framed request body
+     * (1-byte compression flag + 4-byte big-endian length + payload).
+     * Tests can use this to assert that the client serialized its
+     * payload through the gRPC frame layer correctly.
+     */
+    [[nodiscard]] auto request_body() const -> std::vector<std::uint8_t>;
+
+private:
+    /**
+     * @brief Worker-thread entry point. Performs the SETTINGS exchange
+     *        and dispatches to the per-mode tail (drain or echo).
+     */
+    void run();
+
+    tls_loopback_listener listener_;
+    grpc_reply_mode mode_;
+    std::atomic<bool> settings_exchanged_{false};
+    std::atomic<bool> io_failed_{false};
+    std::atomic<bool> stop_{false};
+    std::atomic<bool> request_received_{false};
+    std::atomic<bool> response_sent_{false};
+    std::atomic<std::uint32_t> last_request_stream_id_{0};
+    mutable std::mutex request_body_mutex_;
+    std::vector<std::uint8_t> request_body_;
+    std::thread worker_;
+};
+
+} // namespace kcenon::network::tests::support

--- a/tests/unit/grpc_client_branch_test.cpp
+++ b/tests/unit/grpc_client_branch_test.cpp
@@ -1193,3 +1193,71 @@ TEST_F(GrpcClientHermeticTransportTest, DisconnectIsIdempotentAfterFullHandshake
 
     setup.connector.join();
 }
+
+// ============================================================================
+// Phase 2B demo: drive grpc_client::call_raw post-connect success path via
+// mock_grpc_server_peer (Phase 2B of #1074, on top of Phase 2A/2A.2).
+//
+// mock_grpc_server_peer extends mock_h2_server_peer's framing model with the
+// gRPC-specific server-side reply trio:
+//   1. response HEADERS (`:status: 200`, `content-type: application/grpc`)
+//   2. DATA frame carrying one length-prefixed gRPC message
+//   3. trailing HEADERS (`grpc-status: 0`, END_STREAM)
+//
+// This pushes call_raw past the http2_client::post wait, the response.headers
+// trailer scan (grpc_status extraction), and the grpc_message::parse on the
+// response body — branches that the Phase 2A `mock_h2_server_peer` peer
+// could not exercise because it never replied with HEADERS+DATA.
+// ============================================================================
+
+#include "mock_grpc_server_peer.h"
+
+TEST_F(GrpcClientHermeticTransportTest, CallRawSucceedsWithMockGrpcPeerEchoUnary)
+{
+    using namespace kcenon::network::tests::support;
+
+    mock_grpc_server_peer peer(io(), grpc_reply_mode::echo_unary);
+
+    grpc_channel_config cfg;
+    cfg.use_tls = true;
+    cfg.default_timeout = std::chrono::milliseconds(2000);
+
+    const std::string target =
+        "127.0.0.1:" + std::to_string(static_cast<unsigned>(peer.port()));
+    auto client = std::make_shared<grpc_client>(target, cfg);
+
+    std::thread connector([client]() { (void)client->connect(); });
+
+    EXPECT_TRUE(wait_for([&]() { return peer.settings_exchanged(); },
+                         std::chrono::seconds(3)));
+    ASSERT_TRUE(client->is_connected());
+
+    // call_raw drives: is_connected() check, method validation, header
+    // build, grpc_message::serialize, http2_client::post wait,
+    // response.headers trailer scan (grpc_status extraction), and
+    // grpc_message::parse on the response body.
+    auto result = client->call_raw(
+        "/svc/Echo", std::vector<uint8_t>{0x01, 0x02, 0x03});
+
+    EXPECT_TRUE(result.is_ok());
+    if (result.is_ok())
+    {
+        // The mock peer always replies with the body "ok".
+        const auto& msg = result.value();
+        ASSERT_EQ(msg.data.size(), 2u);
+        EXPECT_EQ(msg.data[0], 'o');
+        EXPECT_EQ(msg.data[1], 'k');
+    }
+
+    // The peer accumulated the client's request body (including the
+    // gRPC 5-byte length prefix). Verifying the prefix sanity-checks
+    // that the client serialized through the gRPC frame layer.
+    EXPECT_TRUE(peer.request_received());
+    EXPECT_TRUE(peer.response_sent());
+    const auto body = peer.request_body();
+    ASSERT_GE(body.size(), 5u);
+    EXPECT_EQ(body[0], 0x00);  // not compressed
+
+    client->disconnect();
+    connector.join();
+}


### PR DESCRIPTION
## What

### Summary
Phase 2B of issue #1074: ships `mock_grpc_server_peer` — a server-side gRPC framing peer composed on top of the existing `mock_h2_server_peer`'s HTTP/2 SETTINGS exchange. With `grpc_reply_mode::echo_unary`, the peer reads one client request stream and replies with response HEADERS (`:status: 200`, `content-type: application/grpc`), one length-prefixed gRPC DATA frame, and trailing HEADERS (`grpc-status: 0`, END_STREAM).

### Change Type
- [x] Feature (new test infrastructure)
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Test

### Affected Components
- `tests/support/mock_grpc_server_peer.{h,cpp}` — new server-side gRPC peer
- `tests/support/CMakeLists.txt` — add new TU to `network_test_support`
- `tests/support/README.md` — document the new peer + composition example
- `tests/unit/grpc_client_branch_test.cpp` — one demo `TEST_F` covering the unary success path

## Why

### Problem Solved
`grpc_client::call_raw` post-connect success branches (http2_client::post wait, trailer-scan extracting `grpc-status`, `grpc_message::parse` on the response body) cannot be exercised by the Phase 2A `mock_h2_server_peer` because it never replies with HEADERS+DATA+trailers. This blocks branch-coverage expansion on `protocols/grpc/client.cpp` (#1063 follow-ups) and was explicitly called out in #1074's scope as Phase 2B.

### Related Issues
- Part of #1074 (Phase 2 of #1060 — protocol-aware loopback peers)
- Part of #953 (epic: 40% to 80% coverage)

### Alternative Approaches Considered
- Reusing `mock_h2_server_peer::echo_one`: rejected because gRPC needs the trailer frame (`grpc-status: 0`) and `content-type: application/grpc`, neither of which are part of the bare h2 echo path.
- Pulling in a real gRPC server (grpc++): rejected as a hermeticity violation. Phase 2 specifically requires an in-process loopback peer with no external dependencies beyond the existing ASIO + OpenSSL stack.

## Where

| Directory | Files | Type |
|-----------|-------|------|
| `tests/support/` | `mock_grpc_server_peer.h`, `mock_grpc_server_peer.cpp` | New |
| `tests/support/` | `CMakeLists.txt` | Modified |
| `tests/support/` | `README.md` | Modified |
| `tests/unit/` | `grpc_client_branch_test.cpp` | Modified |

### API Changes
None. New test-only infrastructure under `tests/support/`. No changes to `src/` or public headers.

## How

### Implementation Highlights
1. **Same SETTINGS handshake as `mock_h2_server_peer`**: the new peer reuses the wire sequence (preface read -> server SETTINGS -> client SETTINGS read -> SETTINGS-ACK) so behavior diverges only after step 5.
2. **HPACK encoding is dependency-free**: `:status: 200` uses static index 8 (one byte: `0x88`); `content-type: application/grpc` and `grpc-status: 0` use literal-without-indexing (`0x00` prefix) with plain non-Huffman length-prefixed strings. All values fit in <=127 bytes so the simple 7-bit length form applies.
3. **Trailer frame ordering**: response HEADERS (END_HEADERS, no END_STREAM) -> DATA (no END_STREAM) -> trailing HEADERS (END_HEADERS + END_STREAM). The h2 client appends both header blocks into `response_headers`, so `grpc_client` sees `:status` and `grpc-status` in the same vector.
4. **Hermetic discipline preserved**: bound to `127.0.0.1:0` via the underlying `tls_loopback_listener`; RSA-2048 cert regenerated per construction; no DNS, no external network, no on-disk secrets.

### Testing Done
Local C++ toolchain unavailable in the working environment — relying on CI for build / test verification. Code reviewed for HPACK correctness against `src/protocols/http2/hpack.cpp` (verified `0x88` indexed and `0x00` literal-without-indexing decode paths) and frame constructors against `src/internal/protocols/http2/frame.h`.

### Test Plan for Reviewers
1. Build with the standard preset: `cmake --preset release && cmake --build build`
2. Run the new demo test: `cd build && ctest -R CallRawSucceedsWithMockGrpcPeerEchoUnary --output-on-failure`
3. Verify the test exercises:
   - `grpc_client::call_raw` returns a successful `Result<grpc_message>`
   - The response payload is the expected `{'o', 'k'}` body
   - `peer.request_received()` and `peer.response_sent()` both flip true
   - The captured `peer.request_body()` contains the gRPC 5-byte length prefix the client serialized

### Breaking Changes
None.

### Rollback Plan
Single commit — revert in one step. No migrations, no data, no public-API surface change.

## Issue scope acknowledgement
This PR ships Phase 2B only. Phases 2C (`mock_quic_peer_loop`), 2D (`network_test_friends.h` friend-test injection), and 2E (`frame_injector`) remain. Per the #1074 acceptance criteria the issue stays open until all five phases land plus per-protocol demo tests and the README entries. This PR uses `Part of`, not `Closes`.

Part of #1074
Part of #953
