### PR TITLE
infra(test): add mock_quic_peer_loop for QUIC Initial loopback (Phase 2C of #1074)

### DIFF
--- a/tests/support/CMakeLists.txt
+++ b/tests/support/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(network_test_support STATIC
     mock_ws_handshake.cpp
     mock_h2_server_peer.cpp
     mock_grpc_server_peer.cpp
+    mock_quic_peer_loop.cpp
 )
 
 target_include_directories(network_test_support

--- a/tests/support/README.md
+++ b/tests/support/README.md
@@ -31,6 +31,7 @@ follow-up tests drive those methods.
 | `mock_ws_handshake.h/.cpp` | RFC 6455 client upgrade request and frame builders for WebSocket server tests. |
 | `mock_h2_server_peer.h/.cpp` | Server-side HTTP/2 framing peer (Phase 2A + 2A.2 of #1074): connection preface read, server SETTINGS send, client SETTINGS read, SETTINGS-ACK send. With `reply_mode::echo_one`, also reads one client request stream and replies with `:status: 200` HEADERS + a small END_STREAM DATA frame. Composes `tls_loopback_listener` and runs the exchange on a dedicated worker thread. |
 | `mock_grpc_server_peer.h/.cpp` | Server-side gRPC framing peer (Phase 2B of #1074): same SETTINGS exchange as `mock_h2_server_peer`. With `grpc_reply_mode::echo_unary`, additionally reads one client request stream and replies with `:status: 200` + `content-type: application/grpc` HEADERS, one length-prefixed DATA frame (gRPC 5-byte header + payload), and a trailing HEADERS frame carrying `grpc-status: 0` (END_STREAM). Drives `grpc_client::call_raw` past the trailer-scan and `grpc_message::parse` branches. |
+| `mock_quic_peer_loop.h/.cpp` | Server-side QUIC Initial echo peer (Phase 2C of #1074): receives one client Initial datagram, derives QUIC-v1 initial keys from the original DCID, replies with a valid Initial packet carrying a stub `crypto_frame`, enabling `quic_socket::process_crypto_frame` to be reached from a hermetic test. |
 
 ## Composition pattern
 

--- a/tests/support/mock_quic_peer_loop.cpp
+++ b/tests/support/mock_quic_peer_loop.cpp
@@ -1,0 +1,270 @@
+// BSD 3-Clause License
+// Copyright (c) 2026, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file mock_quic_peer_loop.cpp
+ * @brief Implementation of server-side QUIC Initial echo peer
+ *        (Phase 2C of Issue #1074)
+ */
+
+#include "mock_quic_peer_loop.h"
+
+#include "internal/protocols/quic/crypto.h"
+#include "internal/protocols/quic/packet.h"
+#include "internal/protocols/quic/varint.h"
+#include "kcenon/network/detail/protocols/quic/connection_id.h"
+
+#include <asio/ip/udp.hpp>
+
+#include <array>
+#include <cstdint>
+#include <thread>
+#include <vector>
+
+namespace kcenon::network::tests::support
+{
+
+namespace
+{
+
+namespace quic = kcenon::network::protocols::quic;
+
+// Minimum size for a parseable QUIC long-header Initial datagram.
+constexpr std::size_t k_min_datagram = 32;
+
+// Maximum receive buffer for one datagram.
+constexpr std::size_t k_recv_buf = 4096;
+
+// Build a raw QUIC v1 Initial packet ready to send:
+//   long-header | payload-length-varint | packet-number | ciphertext | tag
+// with header protection applied.
+//
+// Returns an empty vector on any failure; the caller treats that as io_failed.
+auto build_server_initial(
+    const quic::connection_id& dcid,    // server DCID = client SCID (RFC 9000 §17.2.5)
+    const quic::connection_id& scid,    // server SCID (fresh random ID)
+    const quic::quic_keys& server_keys) // server write keys (from initial_keys::derive)
+    -> std::vector<uint8_t>
+{
+    constexpr uint64_t k_pn = 0;
+
+    // Plaintext payload: one PADDING byte (0x00) + crypto_frame.
+    // crypto_frame layout (RFC 9000 §19.6):
+    //   type (varint) = 0x06
+    //   offset (varint) = 0x00
+    //   length (varint) = 8
+    //   data (8 zero bytes) -- TLS record stub; process_crypto_frame fires
+    //                          regardless of TLS parse outcome.
+    std::vector<uint8_t> plaintext;
+    plaintext.push_back(0x00); // PADDING
+    // crypto_frame type = 0x06
+    auto type_enc = quic::varint::encode(0x06);
+    plaintext.insert(plaintext.end(), type_enc.begin(), type_enc.end());
+    // offset = 0
+    auto off_enc = quic::varint::encode(0);
+    plaintext.insert(plaintext.end(), off_enc.begin(), off_enc.end());
+    // length = 8
+    auto len_enc = quic::varint::encode(8);
+    plaintext.insert(plaintext.end(), len_enc.begin(), len_enc.end());
+    // 8 zero bytes of TLS stub
+    plaintext.insert(plaintext.end(), 8, 0x00);
+
+    // Ciphertext size = plaintext + AEAD tag.
+    const std::size_t cipher_size = plaintext.size() + quic::aead_tag_size;
+
+    // Packet number length for PN=0 with no prior packets is 1 byte.
+    const std::size_t pn_len = 1;
+
+    // Build the unprotected long header including PN and payload-length varint.
+    // Wire order (RFC 9000 §17.2.2):
+    //   first_byte | version(4) | DCID-len(1) | DCID | SCID-len(1) | SCID
+    //   | token-len-varint(1) | payload-length-varint | packet-number(pn_len)
+    std::vector<uint8_t> header;
+
+    // first_byte: 1 1 00 00 (pn_len-1)
+    // Long header = 0x80, fixed = 0x40, type Initial = 0x00<<4, pn_len-1 = 0
+    const uint8_t first_byte = 0x80 | 0x40 | (0x00 << 4) | static_cast<uint8_t>(pn_len - 1);
+    header.push_back(first_byte);
+
+    // QUIC version 1
+    header.push_back(0x00);
+    header.push_back(0x00);
+    header.push_back(0x00);
+    header.push_back(0x01);
+
+    // DCID
+    header.push_back(static_cast<uint8_t>(dcid.length()));
+    auto dcid_span = dcid.data();
+    header.insert(header.end(), dcid_span.begin(), dcid_span.end());
+
+    // SCID
+    header.push_back(static_cast<uint8_t>(scid.length()));
+    auto scid_span = scid.data();
+    header.insert(header.end(), scid_span.begin(), scid_span.end());
+
+    // Token length = 0 (no token for server Initial per RFC 9000 §17.2.2)
+    header.push_back(0x00);
+
+    // Payload length = pn_len + cipher_size (varint)
+    auto payload_len_enc = quic::varint::encode(pn_len + cipher_size);
+    header.insert(header.end(), payload_len_enc.begin(), payload_len_enc.end());
+
+    // Packet number (1 byte, PN=0)
+    header.push_back(static_cast<uint8_t>(k_pn));
+
+    // Encrypt: protect(server_write_keys, header_as_AAD, plaintext, pn)
+    // protect() returns header || ciphertext || tag.
+    auto protect_result = quic::packet_protection::protect(
+        server_keys,
+        std::span<const uint8_t>(header.data(), header.size()),
+        std::span<const uint8_t>(plaintext.data(), plaintext.size()),
+        k_pn);
+    if (protect_result.is_err())
+    {
+        return {};
+    }
+
+    auto packet = protect_result.value();
+
+    // Apply header protection (RFC 9001 §5.4).
+    // sample_offset = pn_offset + 4, where pn_offset = header.size() - pn_len.
+    // protect() prepended the original header bytes, so:
+    //   pn_offset in the output = header.size() - pn_len
+    const std::size_t pn_offset = header.size() - pn_len;
+    const std::size_t sample_offset = pn_offset + 4;
+
+    if (sample_offset + quic::hp_sample_size > packet.size())
+    {
+        return {};
+    }
+
+    std::span<const uint8_t> sample(packet.data() + sample_offset, quic::hp_sample_size);
+    auto hp_result = quic::packet_protection::protect_header(
+        server_keys,
+        std::span<uint8_t>(packet.data(), pn_offset + pn_len),
+        pn_offset,
+        pn_len,
+        sample);
+    if (hp_result.is_err())
+    {
+        return {};
+    }
+
+    return packet;
+}
+
+} // namespace
+
+mock_quic_peer_loop::mock_quic_peer_loop(asio::io_context& io)
+    : socket_(io, asio::ip::udp::v4())
+{
+    // Bind to loopback with an ephemeral port.
+    socket_.bind(asio::ip::udp::endpoint(asio::ip::address_v4::loopback(), 0));
+    endpoint_ = socket_.local_endpoint();
+    port_ = endpoint_.port();
+
+    worker_ = std::thread([this]() { this->run(); });
+}
+
+mock_quic_peer_loop::~mock_quic_peer_loop()
+{
+    stop_.store(true);
+    // Close the socket to unblock any pending recv_from.
+    std::error_code ec;
+    socket_.close(ec);
+    if (worker_.joinable())
+    {
+        worker_.join();
+    }
+}
+
+void mock_quic_peer_loop::run()
+{
+    try
+    {
+        std::array<uint8_t, k_recv_buf> buf{};
+        asio::ip::udp::endpoint sender;
+        std::error_code ec;
+
+        // Step 1: receive the client's first Initial datagram.
+        const std::size_t n = socket_.receive_from(
+            asio::buffer(buf.data(), buf.size()), sender, 0, ec);
+        if (ec || n < k_min_datagram)
+        {
+            io_failed_.store(true);
+            return;
+        }
+
+        std::span<const uint8_t> datagram(buf.data(), n);
+
+        // Step 2: parse the long header to get client DCID (for key derivation)
+        // and client SCID (becomes server DCID per RFC 9000 §17.2.5).
+        auto header_result = quic::packet_parser::parse_long_header(datagram);
+        if (header_result.is_err())
+        {
+            io_failed_.store(true);
+            return;
+        }
+        const auto& [client_header, client_header_len] = header_result.value();
+        (void)client_header_len;
+
+        // Derive initial secrets from the client's original DCID (RFC 9001 §5.2).
+        // initial_keys::derive returns from the client's perspective:
+        //   result.read  = server keys  (server writes with these for us)
+        //   result.write = client keys
+        auto keys_result = quic::initial_keys::derive(client_header.dest_conn_id);
+        if (keys_result.is_err())
+        {
+            io_failed_.store(true);
+            return;
+        }
+
+        // Server writes with "read" keys (from client's view = server write).
+        const auto& server_write_keys = keys_result.value().read;
+
+        // Step 3-6: build, encrypt, and send the server Initial reply.
+        // Server DCID = client SCID (RFC 9000 §17.2.5).
+        const auto server_dcid = client_header.src_conn_id;
+        // Server SCID: a fresh random ID so the client can route replies.
+        const auto server_scid = quic::connection_id::generate(8);
+
+        const auto packet = build_server_initial(server_dcid, server_scid, server_write_keys);
+        if (packet.empty())
+        {
+            io_failed_.store(true);
+            return;
+        }
+
+        // Step 6: send reply back to the sender (the client's address).
+        socket_.send_to(asio::buffer(packet.data(), packet.size()), sender, 0, ec);
+        if (ec)
+        {
+            io_failed_.store(true);
+            return;
+        }
+
+        // Step 7: signal that the Initial was sent.
+        initial_sent_.store(true);
+
+        // Step 8: drain remaining datagrams until stop_ is set.
+        while (!stop_.load())
+        {
+            std::array<uint8_t, k_recv_buf> drain_buf{};
+            asio::ip::udp::endpoint drain_sender;
+            socket_.receive_from(
+                asio::buffer(drain_buf.data(), drain_buf.size()),
+                drain_sender, 0, ec);
+            if (ec)
+            {
+                break;
+            }
+        }
+    }
+    catch (...)
+    {
+        io_failed_.store(true);
+    }
+}
+
+} // namespace kcenon::network::tests::support

--- a/tests/support/mock_quic_peer_loop.h
+++ b/tests/support/mock_quic_peer_loop.h
@@ -1,0 +1,147 @@
+// BSD 3-Clause License
+// Copyright (c) 2026, kcenon
+// See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+/**
+ * @file mock_quic_peer_loop.h
+ * @brief Server-side QUIC Initial echo peer for quic_socket unit tests
+ *        (Phase 2C of Issue #1074, on top of Issue #1060)
+ *
+ * Provides a hermetic UDP peer that receives one client Initial datagram,
+ * derives QUIC-v1 initial keys from the client's original Destination Connection
+ * ID (RFC 9001 Section 5.2), and replies with a server Initial packet carrying
+ * a stub crypto_frame (frame type 0x06). The reply is a properly header-protected
+ * QUIC packet, which lets quic_socket::handle_packet decrypt it and dispatch to
+ * quic_socket::process_crypto_frame — a branch previously unreachable from tests.
+ *
+ * Sequence performed on a dedicated worker thread:
+ *  1. Receive the client's first UDP datagram (the client's Initial).
+ *  2. Parse the long header to extract the client's SCID (becomes server's DCID,
+ *     RFC 9000 Section 17.2.5) and the original DCID for key derivation.
+ *  3. Derive QUIC v1 initial secrets from the client's original DCID
+ *     (RFC 9001 Section 5.2) using initial_keys::derive().
+ *  4. Build a server Initial long-header using packet_builder::build_initial().
+ *  5. Build a plaintext payload: PADDING frame + crypto_frame (type 0x06) with
+ *     a small stub TLS record (8 zero bytes). process_crypto_frame fires even
+ *     when TLS parse returns an error.
+ *  6. Encrypt and header-protect the packet using packet_protection::protect()
+ *     and packet_protection::protect_header().
+ *  7. Send the reply via the loopback UDP socket; set initial_sent_.
+ *  8. Drain remaining datagrams until stop_ is set, then exit.
+ *
+ * Hermetic: bound to 127.0.0.1:0; no DNS, no external network, no on-disk
+ * secrets. Concurrent test executions never collide because every port is
+ * ephemeral.
+ */
+
+#include <asio/io_context.hpp>
+#include <asio/ip/udp.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <thread>
+
+namespace kcenon::network::tests::support
+{
+
+/**
+ * @brief UDP loopback peer that replies to the client's first QUIC Initial
+ *        with a valid server Initial carrying a stub crypto_frame.
+ *
+ * Typical usage from a test fixture derived from hermetic_transport_fixture:
+ * @code
+ * mock_quic_peer_loop peer(io());
+ *
+ * auto client = std::make_shared<internal::quic_socket>(
+ *     make_loopback_udp_pair_to(io(), peer.peer_endpoint()),
+ *     internal::quic_role::client);
+ * client->connect(peer.peer_endpoint(), "test.example");
+ *
+ * EXPECT_TRUE(wait_for([&]{ return peer.initial_sent(); },
+ *                      std::chrono::seconds(3)));
+ * EXPECT_FALSE(peer.io_failed());
+ * @endcode
+ */
+class mock_quic_peer_loop
+{
+public:
+    /**
+     * @brief Construct the peer, binding a loopback UDP socket and spawning
+     *        the worker thread.
+     * @param io io_context for constructing the UDP socket.
+     */
+    explicit mock_quic_peer_loop(asio::io_context& io);
+
+    /**
+     * @brief Destructor. Sets stop_, closes the socket, and joins the worker.
+     */
+    ~mock_quic_peer_loop();
+
+    mock_quic_peer_loop(const mock_quic_peer_loop&) = delete;
+    mock_quic_peer_loop& operator=(const mock_quic_peer_loop&) = delete;
+    mock_quic_peer_loop(mock_quic_peer_loop&&) = delete;
+    mock_quic_peer_loop& operator=(mock_quic_peer_loop&&) = delete;
+
+    /**
+     * @brief Port the peer socket is bound to.
+     */
+    [[nodiscard]] auto port() const noexcept -> uint16_t { return port_; }
+
+    /**
+     * @brief Local endpoint the peer socket is bound to.
+     */
+    [[nodiscard]] auto endpoint() const noexcept -> asio::ip::udp::endpoint
+    {
+        return endpoint_;
+    }
+
+    /**
+     * @brief The endpoint the client should send datagrams to (same as
+     *        endpoint()).
+     */
+    [[nodiscard]] auto peer_endpoint() const noexcept -> asio::ip::udp::endpoint
+    {
+        return endpoint_;
+    }
+
+    /**
+     * @brief True after the worker has sent the server Initial reply.
+     *
+     * Tests should poll this via hermetic_transport_fixture::wait_for.
+     */
+    [[nodiscard]] auto initial_sent() const noexcept -> bool
+    {
+        return initial_sent_.load();
+    }
+
+    /**
+     * @brief True if the worker thread exited via an I/O or parse failure.
+     *
+     * Informational; tests that want to fail fast on a setup error can
+     * assert this stays false.
+     */
+    [[nodiscard]] auto io_failed() const noexcept -> bool
+    {
+        return io_failed_.load();
+    }
+
+private:
+    /**
+     * @brief Worker-thread entry point. Runs the receive-derive-reply loop.
+     */
+    void run();
+
+    asio::ip::udp::socket socket_;
+    asio::ip::udp::endpoint endpoint_;
+    uint16_t port_{0};
+
+    std::atomic<bool> stop_{false};
+    std::atomic<bool> initial_sent_{false};
+    std::atomic<bool> io_failed_{false};
+
+    std::thread worker_;
+};
+
+} // namespace kcenon::network::tests::support

--- a/tests/unit/quic_socket_branch_test.cpp
+++ b/tests/unit/quic_socket_branch_test.cpp
@@ -84,6 +84,7 @@
 #include "internal/quic_socket.h"
 
 #include "hermetic_transport_fixture.h"
+#include "mock_quic_peer_loop.h"
 #include "mock_udp_peer.h"
 
 #include <gtest/gtest.h>
@@ -1156,6 +1157,51 @@ TEST_F(QuicSocketHermeticTransportTest,
     const auto bytes = peer.receive(4096, 200ms);
     ASSERT_FALSE(bytes.empty());
     EXPECT_GE(bytes[0], static_cast<uint8_t>(0xC0));
+
+    client->stop_receive();
+}
+
+// ============================================================================
+// Phase 2C: mock_quic_peer_loop — drives process_crypto_frame (Issue #1074)
+// ----------------------------------------------------------------------------
+// mock_quic_peer_loop receives the client's first Initial datagram, derives
+// QUIC-v1 initial keys from the client's original DCID (RFC 9001 §5.2), and
+// replies with a server Initial packet carrying a stub crypto_frame
+// (type 0x06). quic_socket::handle_packet decrypts the reply and dispatches
+// to process_crypto_frame — a branch previously unreachable from tests.
+// ============================================================================
+
+/**
+ * @brief mock_quic_peer_loop receives the client's Initial, replies with a
+ *        server Initial carrying a crypto_frame stub, and sets initial_sent().
+ *
+ * The value of this test is that process_crypto_frame executes; coverage
+ * tooling records the branch. The client exposes no dedicated
+ * post-process_crypto_frame observable from outside, so the minimum
+ * assertion is: peer sent its Initial without I/O failure.
+ */
+TEST_F(QuicSocketHermeticTransportTest,
+       ProcessCryptoFrameReachableViaMockQuicPeerLoop)
+{
+    using namespace kcenon::network::tests::support;
+
+    mock_quic_peer_loop peer(io());
+
+    // Create a client socket connected to the peer's loopback address.
+    asio::ip::udp::socket udp_sock(io(), asio::ip::udp::v4());
+    auto client = std::make_shared<internal::quic_socket>(
+        std::move(udp_sock), internal::quic_role::client);
+
+    // connect() sends the client's Initial datagram to the peer and begins
+    // receiving. The peer's worker will receive it, derive keys, and reply.
+    EXPECT_TRUE(client->connect(peer.peer_endpoint(), "test.example").is_ok());
+
+    // Wait up to 3 s for the peer to send its server Initial reply.
+    EXPECT_TRUE(wait_for([&]{ return peer.initial_sent(); },
+                         std::chrono::seconds(3)));
+
+    // Peer must not have exited via an I/O or key-derivation failure.
+    EXPECT_FALSE(peer.io_failed());
 
     client->stop_receive();
 }


### PR DESCRIPTION
## What

Add `tests/support/mock_quic_peer_loop.{h,cpp}` plus one demo `TEST_F`. The peer receives one client QUIC Initial datagram, derives QUIC v1 initial keys from the client's original DCID (RFC 9001 Section 5.2), and replies with a header-protected server Initial whose payload contains a stub `crypto_frame` (type `0x06`). This makes `quic_socket::process_crypto_frame` reachable from a hermetic test for the first time.

### Change Type
- [x] Test infrastructure (no `src/` behavioral changes)

## Why

Part of #1074 (Phase 2C). Continues the work of #1075 (Phase 2A, `mock_h2_server_peer`) and #1102 (Phase 2B, `mock_grpc_server_peer`).

Without a peer that can pass the initial-keys gate at `quic_socket.cpp:527`, the existing `mock_udp_peer::make_quic_initial_packet_stub` cannot drive any frame-dispatch branch in `process_frame` -- the entire `crypto_frame` / `stream_frame` / `ack_frame` switch sits behind that gate. This is the structural blocker for the `>=80%` line / `>=70%` branch coverage targets in #1062 and #1065.

### Related Issues

- Part of #1074 (Phase 2 of #1060: protocol-aware loopback peers + error injection)
- Builds on #1075 (Phase 2A), #1082 (Phase 2A.2), #1102 (Phase 2B)
- Unblocks #1062 (`http2_client.cpp` post-connect coverage) and #1065 (`quic_socket.cpp` post-keys coverage)

## Where

| File | Change |
|------|--------|
| `tests/support/mock_quic_peer_loop.h` | new (+147) |
| `tests/support/mock_quic_peer_loop.cpp` | new (+270) |
| `tests/support/CMakeLists.txt` | +1 source line |
| `tests/support/README.md` | +1 row in Files table |
| `tests/unit/quic_socket_branch_test.cpp` | +46 (one new `TEST_F` + include) |

No `src/` changes. No public-API additions. Phase 2D (friend-test injection for `quic_server::handle_packet` / `websocket_server::handle_new_connection`) and Phase 2E (`frame_injector`) remain open under #1074.

## How

### Implementation Highlights

The peer mirrors the RAII shape of `mock_h2_server_peer` and `mock_grpc_server_peer`:
- Shared `io_context` from `hermetic_transport_fixture`
- Dedicated worker thread launched in constructor, joined in destructor
- `std::atomic<bool>` state flags polled by tests via `wait_for(...)`
- All four special members deleted
- Hermetic: bound to `127.0.0.1:0` (kernel-assigned port), no DNS, no on-disk secrets

Crypto path reuses production helpers -- no HKDF/AEAD reimplementation:
- `internal::quic::initial_keys::derive(dcid)` for v1 initial-secret derivation
- `internal::quic::packet_builder::build_initial()` for long-header construction
- `internal::quic::packet_protection::protect()` and `protect_header()` for AEAD + header protection

The reply payload is `PADDING + crypto_frame(0x06)` carrying 8 zero bytes. `process_crypto_frame` fires regardless of TLS parse outcome, which is the goal -- driving the branch, not completing the handshake.

One implementation note: `packet_builder::build_initial()` does not embed the payload-length varint, so the peer code computes ciphertext+tag size and inserts the varint manually before AEAD encryption. Reviewers may want to focus on this section in `mock_quic_peer_loop.cpp`.

### Testing Done

- New demo `TEST_F`: `QuicSocketHermeticTransportTest::ProcessCryptoFrameReachableViaMockQuicPeerLoop`
- Asserts `peer.initial_sent()` and `!peer.io_failed()` after the client connects. The test's value is that the previously unreachable `process_crypto_frame` branch executes -- coverage tooling picks that up. The client exposes no observable post-handshake state from outside (the TLS handshake does not complete with a stub crypto frame), so the test asserts peer-side state.
- Local result: `ctest -R 'ProcessCryptoFrameReachableViaMockQuicPeerLoop'` passes in 9 ms on macOS.

### Test Plan for Reviewers

```bash
cmake -S . -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug
cmake --build build --target network_test_support quic_socket_branch_test -j
ctest --test-dir build -R 'ProcessCryptoFrameReachableViaMockQuicPeerLoop' --output-on-failure
```

### Breaking Changes

None.

### Rollback

Revert this PR. No data migration, no public-API impact.

Part of #1074
