### PR TITLE
infra(test): add probe-based friend injection for server-private methods (Phase 2D of #1074)

### DIFF
--- a/cmake/network_system_targets.cmake
+++ b/cmake/network_system_targets.cmake
@@ -155,6 +155,15 @@ add_library(network_system
 # Alias for build-tree consumers (FetchContent / add_subdirectory)
 add_library(network_system::network_system ALIAS network_system)
 
+# Test-only friend access gate (Issue #1074 Phase 2D).
+# When BUILD_TESTS=ON, expose NETWORK_ENABLE_TEST_INJECTION so that production
+# headers can compile in friend declarations for tests/support/*_probe types
+# that drive otherwise-private server-side methods. PUBLIC propagation lets the
+# probe translation units pick up the same definition transitively.
+if(BUILD_TESTS)
+    target_compile_definitions(network_system PUBLIC NETWORK_ENABLE_TEST_INJECTION)
+endif()
+
 # Suppress warnings inherited from parent project (especially from ASIO)
 # WARNING: Suppressions removed for strict code quality check.
 # Fix the code instead of suppressing warnings!

--- a/src/internal/experimental/quic_server.h
+++ b/src/internal/experimental/quic_server.h
@@ -52,6 +52,13 @@ namespace kcenon::network::session
 	class quic_session;
 } // namespace kcenon::network::session
 
+#if defined(NETWORK_ENABLE_TEST_INJECTION)
+namespace kcenon::network::tests::support
+{
+	class quic_server_probe;
+} // namespace kcenon::network::tests::support
+#endif
+
 namespace kcenon::network::core
 {
 
@@ -410,6 +417,12 @@ namespace kcenon::network::core
 #endif // KCENON_WITH_COMMON_SYSTEM
 
 	private:
+#if defined(NETWORK_ENABLE_TEST_INJECTION)
+		// Test-only: grants tests/support/quic_server_probe access to private
+		// surfaces without leaking them through the public API.
+		friend class kcenon::network::tests::support::quic_server_probe;
+#endif
+
 		// =====================================================================
 		// Internal Implementation Methods
 		// =====================================================================

--- a/src/internal/http/websocket_server.h
+++ b/src/internal/http/websocket_server.h
@@ -30,6 +30,13 @@ namespace kcenon::network::internal
 	class websocket_socket;
 }
 
+#if defined(NETWORK_ENABLE_TEST_INJECTION)
+namespace kcenon::network::tests::support
+{
+	class ws_server_probe;
+} // namespace kcenon::network::tests::support
+#endif
+
 namespace kcenon::network::core
 {
 	class ws_session_manager;
@@ -386,6 +393,12 @@ namespace kcenon::network::core
 		auto set_error_callback(interfaces::i_websocket_server::error_callback_t callback) -> void override;
 
 	private:
+#if defined(NETWORK_ENABLE_TEST_INJECTION)
+		// Test-only: grants tests/support/ws_server_probe access to private
+		// surfaces without leaking them through the public API.
+		friend class kcenon::network::tests::support::ws_server_probe;
+#endif
+
 		// =====================================================================
 		// Internal Implementation Methods
 		// =====================================================================

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5074,6 +5074,20 @@ target_link_libraries(network_websocket_server_branch_test PRIVATE network::test
 add_network_test(network_websocket_server_loopback_test
                  unit/websocket_server_loopback_test.cpp)
 
+# Friend-test injection demo (Issue #1074 Phase 2D): invokes the previously
+# private messaging_quic_server::handle_packet entry point through the
+# tests/support/quic_server_probe forwarder, gated by NETWORK_ENABLE_TEST_INJECTION.
+add_network_test(network_quic_server_probe_test
+                 unit/quic_server_probe_test.cpp)
+target_link_libraries(network_quic_server_probe_test PRIVATE network::test_support)
+
+# Friend-test injection demo (Issue #1074 Phase 2D): invokes the previously
+# private messaging_ws_server::handle_new_connection entry point through the
+# tests/support/ws_server_probe forwarder, gated by NETWORK_ENABLE_TEST_INJECTION.
+add_network_test(network_ws_server_probe_test
+                 unit/ws_server_probe_test.cpp)
+target_link_libraries(network_ws_server_probe_test PRIVATE network::test_support)
+
 # HTTP parser extended coverage: url_encode/decode edge cases (percent
 # truncation, high-bit bytes, hex case), query string delimiter handling
 # (leading/trailing '&', duplicate keys, URL-encoded delimiters), cookie

--- a/tests/support/CMakeLists.txt
+++ b/tests/support/CMakeLists.txt
@@ -14,6 +14,8 @@ add_library(network_test_support STATIC
     mock_h2_server_peer.cpp
     mock_grpc_server_peer.cpp
     mock_quic_peer_loop.cpp
+    quic_server_probe.cpp
+    ws_server_probe.cpp
 )
 
 target_include_directories(network_test_support

--- a/tests/support/network_test_friends.h
+++ b/tests/support/network_test_friends.h
@@ -1,0 +1,21 @@
+// BSD 3-Clause License
+// Copyright (c) 2026, kcenon
+// See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+/**
+ * @file network_test_friends.h
+ * @brief Forward declarations for friend-test probes (Issue #1074 Phase 2D).
+ *
+ * Production headers that grant friend access to these probe types include
+ * a forward declaration of the probe under the same NETWORK_ENABLE_TEST_INJECTION
+ * gate. This header keeps test-side friend declarations in one place so the
+ * production headers do not need to pull in concrete probe definitions.
+ */
+
+namespace kcenon::network::tests::support
+{
+class quic_server_probe;
+class ws_server_probe;
+} // namespace kcenon::network::tests::support

--- a/tests/support/quic_server_probe.cpp
+++ b/tests/support/quic_server_probe.cpp
@@ -1,0 +1,18 @@
+// BSD 3-Clause License
+// Copyright (c) 2026, kcenon
+// See the LICENSE file in the project root for full license information.
+
+#include "quic_server_probe.h"
+
+namespace kcenon::network::tests::support
+{
+
+auto quic_server_probe::invoke_handle_packet(
+    kcenon::network::core::messaging_quic_server& srv,
+    std::span<const std::uint8_t> bytes,
+    const asio::ip::udp::endpoint& from) -> void
+{
+    srv.handle_packet(bytes, from);
+}
+
+} // namespace kcenon::network::tests::support

--- a/tests/support/quic_server_probe.h
+++ b/tests/support/quic_server_probe.h
@@ -1,0 +1,41 @@
+// BSD 3-Clause License
+// Copyright (c) 2026, kcenon
+// See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+/**
+ * @file quic_server_probe.h
+ * @brief Friend-access probe for messaging_quic_server::handle_packet
+ *        (Issue #1074 Phase 2D).
+ *
+ * The probe is a static-method forwarder: production code declares
+ * @c quic_server_probe a friend of @c messaging_quic_server under the
+ * @c NETWORK_ENABLE_TEST_INJECTION gate so tests can drive the previously
+ * private @c handle_packet entry point without standing up a live UDP peer.
+ */
+
+#define NETWORK_USE_EXPERIMENTAL
+#include "internal/experimental/quic_server.h"
+
+#include <asio/ip/udp.hpp>
+
+#include <cstdint>
+#include <span>
+
+namespace kcenon::network::tests::support
+{
+
+class quic_server_probe
+{
+public:
+    /**
+     * @brief Forward to @c messaging_quic_server::handle_packet.
+     */
+    static auto invoke_handle_packet(
+        kcenon::network::core::messaging_quic_server& srv,
+        std::span<const std::uint8_t> bytes,
+        const asio::ip::udp::endpoint& from) -> void;
+};
+
+} // namespace kcenon::network::tests::support

--- a/tests/support/ws_server_probe.cpp
+++ b/tests/support/ws_server_probe.cpp
@@ -1,0 +1,19 @@
+// BSD 3-Clause License
+// Copyright (c) 2026, kcenon
+// See the LICENSE file in the project root for full license information.
+
+#include "ws_server_probe.h"
+
+#include <utility>
+
+namespace kcenon::network::tests::support
+{
+
+auto ws_server_probe::invoke_handle_new_connection(
+    kcenon::network::core::messaging_ws_server& srv,
+    std::shared_ptr<asio::ip::tcp::socket> socket) -> void
+{
+    srv.handle_new_connection(std::move(socket));
+}
+
+} // namespace kcenon::network::tests::support

--- a/tests/support/ws_server_probe.h
+++ b/tests/support/ws_server_probe.h
@@ -1,0 +1,39 @@
+// BSD 3-Clause License
+// Copyright (c) 2026, kcenon
+// See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+/**
+ * @file ws_server_probe.h
+ * @brief Friend-access probe for messaging_ws_server::handle_new_connection
+ *        (Issue #1074 Phase 2D).
+ *
+ * The probe is a static-method forwarder: production code declares
+ * @c ws_server_probe a friend of @c messaging_ws_server under the
+ * @c NETWORK_ENABLE_TEST_INJECTION gate so tests can drive the previously
+ * private @c handle_new_connection entry point without standing up a live
+ * TCP client and WebSocket upgrade handshake.
+ */
+
+#include "internal/http/websocket_server.h"
+
+#include <asio/ip/tcp.hpp>
+
+#include <memory>
+
+namespace kcenon::network::tests::support
+{
+
+class ws_server_probe
+{
+public:
+    /**
+     * @brief Forward to @c messaging_ws_server::handle_new_connection.
+     */
+    static auto invoke_handle_new_connection(
+        kcenon::network::core::messaging_ws_server& srv,
+        std::shared_ptr<asio::ip::tcp::socket> socket) -> void;
+};
+
+} // namespace kcenon::network::tests::support

--- a/tests/unit/quic_server_probe_test.cpp
+++ b/tests/unit/quic_server_probe_test.cpp
@@ -1,0 +1,58 @@
+// BSD 3-Clause License
+// Copyright (c) 2026, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file quic_server_probe_test.cpp
+ * @brief Demo test for friend-test injection on messaging_quic_server
+ *        (Issue #1074 Phase 2D).
+ *
+ * Verifies the previously-private @c handle_packet entry point is reachable
+ * from tests via @c quic_server_probe under the NETWORK_ENABLE_TEST_INJECTION
+ * gate. The empty-data branch returns early without touching async state, so
+ * no live io_context or UDP peer is required.
+ */
+
+#define NETWORK_USE_EXPERIMENTAL
+#include "internal/experimental/quic_server.h"
+
+#include "quic_server_probe.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <span>
+
+using kcenon::network::core::messaging_quic_server;
+using kcenon::network::tests::support::quic_server_probe;
+
+TEST(QuicServerProbeTest, HandlePacketEmptyBufferDoesNotCrash)
+{
+    messaging_quic_server server("quic-probe-empty");
+
+    std::array<std::uint8_t, 0> empty{};
+    asio::ip::udp::endpoint from{};
+
+    // Empty data path: handle_packet must early-return without touching
+    // async state on a never-started server.
+    EXPECT_NO_FATAL_FAILURE(quic_server_probe::invoke_handle_packet(
+        server, std::span<const std::uint8_t>(empty.data(), empty.size()), from));
+
+    EXPECT_FALSE(server.is_running());
+}
+
+TEST(QuicServerProbeTest, HandlePacketGarbageBufferDoesNotCrash)
+{
+    messaging_quic_server server("quic-probe-garbage");
+
+    // Zero-filled buffer is rejected by the QUIC packet parser (parse_header
+    // returns is_err()); handle_packet logs and returns without dispatching.
+    std::array<std::uint8_t, 32> garbage{};
+    asio::ip::udp::endpoint from{};
+
+    EXPECT_NO_FATAL_FAILURE(quic_server_probe::invoke_handle_packet(
+        server, std::span<const std::uint8_t>(garbage.data(), garbage.size()), from));
+
+    EXPECT_FALSE(server.is_running());
+}

--- a/tests/unit/ws_server_probe_test.cpp
+++ b/tests/unit/ws_server_probe_test.cpp
@@ -1,0 +1,72 @@
+// BSD 3-Clause License
+// Copyright (c) 2026, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file ws_server_probe_test.cpp
+ * @brief Demo test for friend-test injection on messaging_ws_server
+ *        (Issue #1074 Phase 2D).
+ *
+ * Verifies the previously-private @c handle_new_connection entry point is
+ * reachable from tests via @c ws_server_probe under the
+ * NETWORK_ENABLE_TEST_INJECTION gate. On a never-started server the
+ * @c session_mgr_ is nullptr, so the handler hits the early-return guard
+ * without touching the inbound socket — safe to drive without an
+ * io_context loop or a real WebSocket upgrade handshake.
+ */
+
+#include "internal/http/websocket_server.h"
+
+#include "hermetic_transport_fixture.h"
+#include "ws_server_probe.h"
+
+#include <asio/io_context.hpp>
+#include <asio/ip/tcp.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <utility>
+
+using kcenon::network::core::messaging_ws_server;
+using kcenon::network::tests::support::hermetic_transport_fixture;
+using kcenon::network::tests::support::make_loopback_tcp_pair;
+using kcenon::network::tests::support::ws_server_probe;
+
+class WsServerProbeTest : public hermetic_transport_fixture
+{
+};
+
+TEST_F(WsServerProbeTest, HandleNewConnectionEarlyReturnNoSessionManager)
+{
+    messaging_ws_server server("ws-probe-no-session");
+
+    // A never-started server has session_mgr_ == nullptr, so handle_new_connection
+    // hits the early-return guard before touching the socket. We still pass a real
+    // connected loopback socket to keep the call shape realistic; the fixture
+    // owns the io_context worker thread that drives async_accept inside
+    // make_loopback_tcp_pair.
+    auto [client, accepted] = make_loopback_tcp_pair(io());
+
+    auto sock = std::make_shared<asio::ip::tcp::socket>(std::move(accepted));
+
+    EXPECT_NO_FATAL_FAILURE(
+        ws_server_probe::invoke_handle_new_connection(server, sock));
+
+    EXPECT_FALSE(server.is_running());
+}
+
+TEST_F(WsServerProbeTest, HandleNewConnectionEmptySocketEarlyReturn)
+{
+    messaging_ws_server server("ws-probe-empty-socket");
+
+    auto sock = std::make_shared<asio::ip::tcp::socket>(io());
+
+    // session_mgr_ is nullptr on a never-started server: the early-return
+    // guard fires before the socket is touched, so an unconnected socket is
+    // also safe here.
+    EXPECT_NO_FATAL_FAILURE(
+        ws_server_probe::invoke_handle_new_connection(server, sock));
+
+    EXPECT_FALSE(server.is_running());
+}


### PR DESCRIPTION
## What

Add friend-test injection so unit tests can drive two server-side private methods previously unreachable from public APIs. Plus probe classes and demo tests. No behavioral changes to `src/`.

### Targets opened to friend access

| Class (namespace) | Method | Header | Line |
|-------------------|--------|--------|------|
| `messaging_quic_server` (`kcenon::network::core`) | `handle_packet(span, endpoint)` | `src/internal/experimental/quic_server.h` | 432 |
| `messaging_ws_server` (`kcenon::network::core`) | `handle_new_connection(shared_ptr<tcp::socket>)` | `src/internal/http/websocket_server.h` | 415 |

### Change Type
- [x] Test infrastructure (one-line `friend` declaration + namespace forward-decl per header, both gated)
- [x] CMake gate symbol (test build only)
- [x] No public-API additions, no behavioral changes

## Why

Part of #1074 (Phase 2D). Continues #1075 (2A), #1082 (2A.2), #1102 (2B), #1103 (2C).

Issue #1074 §"Out of scope" explicitly limits this work to friend declarations. Two private methods were called out as the remaining barriers to unit-test coverage of server-side QUIC and WebSocket reception logic. Without friend access, post-private-state branches in `quic_server.cpp` and `websocket_server.cpp` remain dead code from the test runner's perspective.

### Related Issues

- Part of #1074 (Phase 2 of #1060)
- Builds on #1075 (Phase 2A), #1082 (Phase 2A.2), #1102 (Phase 2B), #1103 (Phase 2C)
- Unblocks coverage expansion for `messaging_quic_server` (#1066) and `messaging_ws_server` paths

## Where

| File | Change |
|------|--------|
| `cmake/network_system_targets.cmake` | +9 (gate symbol wiring inside `if(BUILD_TESTS)`) |
| `src/internal/experimental/quic_server.h` | +13 (forward-decl + `friend`, both gated) |
| `src/internal/http/websocket_server.h` | +13 (same shape) |
| `tests/support/network_test_friends.h` | new (+21) |
| `tests/support/quic_server_probe.{h,cpp}` | new (+59) |
| `tests/support/ws_server_probe.{h,cpp}` | new (+58) |
| `tests/support/CMakeLists.txt` | +2 (probe sources) |
| `tests/CMakeLists.txt` | +14 (2 test registrations) |
| `tests/unit/quic_server_probe_test.cpp` | new (+58) |
| `tests/unit/ws_server_probe_test.cpp` | new (+72) |

Total: 12 files, 319 insertions, 0 deletions. PR size: M.

## How

### Implementation Highlights

**Gate symbol — `NETWORK_ENABLE_TEST_INJECTION`.** Defined as `target_compile_definitions(network_system PUBLIC NETWORK_ENABLE_TEST_INJECTION)` inside an `if(BUILD_TESTS)` block. PUBLIC propagation so probe TUs and test executables inherit the same define. When `BUILD_TESTS=OFF`, the production binary is byte-identical to the previous develop tip — `friend` blocks compile out entirely.

**Production header pattern (mirrored in both):**
```cpp
#if defined(NETWORK_ENABLE_TEST_INJECTION)
namespace kcenon::network::tests::support
{
    class quic_server_probe;  // forward declaration only
} // namespace kcenon::network::tests::support
#endif

namespace kcenon::network::core
{
class messaging_quic_server : public ... {
    // ...
private:
#if defined(NETWORK_ENABLE_TEST_INJECTION)
    friend class kcenon::network::tests::support::quic_server_probe;
#endif
    // ...
};
}
```

The forward-decl block lives outside the production namespace, so the production header pulls in zero test types. Probe definitions live entirely in `tests/support/`.

**Probe shape (pure forwarder):**
```cpp
class quic_server_probe {
public:
    static auto invoke_handle_packet(
        kcenon::network::core::messaging_quic_server& srv,
        std::span<const std::uint8_t> bytes,
        const asio::ip::udp::endpoint& from) -> void;
};
```
Static-method forwarders, no instance state, no fixture dependency. The probe exists solely to grant the friend bridge.

### Testing Done

- `QuicServerProbeTest.HandlePacketEmptyBufferDoesNotCrash` — passes
- `QuicServerProbeTest.HandlePacketGarbageBufferDoesNotCrash` — passes
- `WsServerProbeTest.HandleNewConnectionEarlyReturnNoSessionManager` — passes
- `WsServerProbeTest.HandleNewConnectionEmptySocketEarlyReturn` — passes

The WebSocket tests exercise the `session_mgr_ == nullptr` early-return branch (server is never started). Reaching the started-server path requires a `ws_session_manager` and a connected loopback peer driving the WebSocket upgrade — that is the domain of `network_websocket_server_loopback_test`, not the probe wiring test. Phase 2D's job is proving the friend bridge works end-to-end and that the previously-private entry points are now reachable from tests.

### Test Plan for Reviewers

```bash
cmake -S . -B build -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
cmake --build build --target network_quic_server_probe_test network_ws_server_probe_test -j
ctest --test-dir build -R 'QuicServerProbe|WsServerProbe' --output-on-failure
```

Note: GTest test-case names are PascalCase (`QuicServerProbeTest`), CTest target names are snake_case (`network_quic_server_probe_test`) — the `-R` filter matches GTest names.

### Off-by-default Verification

To confirm `BUILD_TESTS=OFF` produces a byte-identical production library:
```bash
cmake -B build-rel -DBUILD_TESTS=OFF
cmake --build build-rel --target network_system
nm build-rel/libnetwork_system.a | grep -i probe
# Should be empty.
```

### Breaking Changes

None.

### Rollback

Revert this PR. No data, no public-API impact. Production binary semantics unchanged.

Part of #1074
