### PR TITLE
test(support): add frame_injector for protocol-aware fault injection (Phase 2E of #1074)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5088,6 +5088,15 @@ add_network_test(network_ws_server_probe_test
                  unit/ws_server_probe_test.cpp)
 target_link_libraries(network_ws_server_probe_test PRIVATE network::test_support)
 
+# Frame-injection demo (Issue #1074 Phase 2E): one TEST_F per protocol
+# family demonstrating that tests/support/frame_injector composes with
+# mock_h2_server_peer / mock_grpc_server_peer / mock_quic_peer_loop and
+# the Phase 2D ws_server_probe to drive previously-unreachable error
+# branches (drop, malform, malform, slow-write).
+add_network_test(network_frame_injector_demo_test
+                 unit/frame_injector_demo_test.cpp)
+target_link_libraries(network_frame_injector_demo_test PRIVATE network::test_support)
+
 # HTTP parser extended coverage: url_encode/decode edge cases (percent
 # truncation, high-bit bytes, hex case), query string delimiter handling
 # (leading/trailing '&', duplicate keys, URL-encoded delimiters), cookie

--- a/tests/support/CMakeLists.txt
+++ b/tests/support/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(network_test_support STATIC
     mock_quic_peer_loop.cpp
     quic_server_probe.cpp
     ws_server_probe.cpp
+    frame_injector.cpp
 )
 
 target_include_directories(network_test_support

--- a/tests/support/README.md
+++ b/tests/support/README.md
@@ -32,6 +32,8 @@ follow-up tests drive those methods.
 | `mock_h2_server_peer.h/.cpp` | Server-side HTTP/2 framing peer (Phase 2A + 2A.2 of #1074): connection preface read, server SETTINGS send, client SETTINGS read, SETTINGS-ACK send. With `reply_mode::echo_one`, also reads one client request stream and replies with `:status: 200` HEADERS + a small END_STREAM DATA frame. Composes `tls_loopback_listener` and runs the exchange on a dedicated worker thread. |
 | `mock_grpc_server_peer.h/.cpp` | Server-side gRPC framing peer (Phase 2B of #1074): same SETTINGS exchange as `mock_h2_server_peer`. With `grpc_reply_mode::echo_unary`, additionally reads one client request stream and replies with `:status: 200` + `content-type: application/grpc` HEADERS, one length-prefixed DATA frame (gRPC 5-byte header + payload), and a trailing HEADERS frame carrying `grpc-status: 0` (END_STREAM). Drives `grpc_client::call_raw` past the trailer-scan and `grpc_message::parse` branches. |
 | `mock_quic_peer_loop.h/.cpp` | Server-side QUIC Initial echo peer (Phase 2C of #1074): receives one client Initial datagram, derives QUIC-v1 initial keys from the original DCID, replies with a valid Initial packet carrying a stub `crypto_frame`, enabling `quic_socket::process_crypto_frame` to be reached from a hermetic test. |
+| `network_test_friends.h` + `quic_server_probe.h/.cpp` + `ws_server_probe.h/.cpp` | Friend-test injection points (Phase 2D of #1074): forwarders that grant tests access to the previously-private `messaging_quic_server::handle_packet` and `messaging_ws_server::handle_new_connection` entry points under the `NETWORK_ENABLE_TEST_INJECTION` build gate. |
+| `frame_injector.h/.cpp` | Composable byte-level fault hooks (Phase 2E of #1074): `injection_mode::none`, `drop`, `truncate`, `malform`, `slow_write`. Pluggable into the three server peers (h2 / gRPC / QUIC) via an optional constructor argument and into raw client→server byte streams (e.g. WebSocket fed to `ws_server_probe`) via `frame_injector::write` / `frame_injector::transform`. |
 
 ## Composition pattern
 
@@ -221,7 +223,130 @@ Phases land as independent PRs.
 |-------|-----------|--------|
 | 2A | `mock_h2_server_peer` (preface + SETTINGS exchange + ACK) | shipped |
 | 2A.2 | `mock_h2_server_peer` HEADERS+DATA reply for one stream (`reply_mode::echo_one`) | shipped |
-| 2B | `mock_grpc_server_peer` (h2 + gRPC framing + trailers) | not started |
-| 2C | `mock_quic_peer_loop` (Initial → Handshake → 1-RTT) | not started |
-| 2D | `network_test_friends.h` (private-method injection points) | not started |
-| 2E | `frame_injector` (drop / truncate / malformed / slow-write hooks) | not started |
+| 2B | `mock_grpc_server_peer` (h2 + gRPC framing + trailers) | shipped |
+| 2C | `mock_quic_peer_loop` (Initial → Handshake stub) | shipped |
+| 2D | `network_test_friends.h` + `quic_server_probe` + `ws_server_probe` | shipped |
+| 2E | `frame_injector` (drop / truncate / malform / slow-write hooks) | shipped |
+
+## Phase 2E: composing `frame_injector` with each peer
+
+`frame_injector` is a small, header-only-ish (`.cpp` only carries the pure
+`transform` variant) helper that captures one of five fault modes
+(`none`, `drop`, `truncate`, `malform`, `slow_write`) and applies it to any
+byte buffer about to be written to a sync ASIO stream or sent as a UDP
+datagram. The five modes are documented exhaustively in
+`frame_injector.h`; this section shows the four canonical compositions
+exercised by `tests/unit/frame_injector_demo_test.cpp`.
+
+### h2 / gRPC peers — opt-in third constructor argument
+
+Both `mock_h2_server_peer` and `mock_grpc_server_peer` accept an optional
+`injection_spec` after the `reply_mode`. Default-constructed
+(`injection_mode::none`) means the peer is byte-identical to its Phase
+2A/2A.2/2B baseline:
+
+```cpp
+#include "frame_injector.h"
+#include "mock_h2_server_peer.h"
+
+// HTTP/2: drop the very first server frame so the SETTINGS handshake
+// never completes — drives http2_client's connect-timeout branch.
+injection_spec spec;
+spec.mode = injection_mode::drop;
+
+mock_h2_server_peer peer(io(), reply_mode::drain_only, spec);
+
+auto client = std::make_shared<http2::http2_client>("h2-drop-demo");
+client->set_timeout(std::chrono::milliseconds(500));
+
+std::thread connector([&]() {
+    (void)client->connect("127.0.0.1", peer.port());
+});
+EXPECT_FALSE(wait_for([&]() { return peer.settings_exchanged(); },
+                      std::chrono::milliseconds(300)));
+EXPECT_FALSE(client->is_connected());
+(void)client->disconnect();
+connector.join();
+```
+
+The same pattern composes with `mock_grpc_server_peer` and any of the
+remaining modes — for example `injection_mode::malform` with
+`malform_offset = 3` flips the type byte of the SETTINGS-ACK header and
+exercises the gRPC client's parse / unexpected-frame error branch.
+
+### QUIC peer — datagram-level transform
+
+`mock_quic_peer_loop` accepts the same `injection_spec` directly (there
+is no `reply_mode` for QUIC). `slow_write` is treated as a pass-through
+because UDP is a datagram protocol; `drop` skips the `send_to` entirely
+and leaves `peer.initial_sent()` reporting `false` so tests can
+distinguish "the wire bytes never left" from "the bytes were corrupted":
+
+```cpp
+#include "frame_injector.h"
+#include "mock_quic_peer_loop.h"
+
+// QUIC: flip the long-header form / fixed bits so quic_socket rejects
+// the server Initial at the version gate before reaching the
+// process_crypto_frame branch.
+injection_spec spec;
+spec.mode = injection_mode::malform;
+spec.malform_offset = 0;
+spec.malform_xor = 0xC0;
+
+mock_quic_peer_loop peer(io(), spec);
+
+asio::ip::udp::socket udp_sock(io(), asio::ip::udp::v4());
+auto client = std::make_shared<internal::quic_socket>(
+    std::move(udp_sock), internal::quic_role::client);
+
+EXPECT_TRUE(client->connect(peer.peer_endpoint(), "test.example").is_ok());
+EXPECT_TRUE(wait_for([&]() { return peer.initial_sent(); },
+                     std::chrono::seconds(3)));
+client->stop_receive();
+```
+
+### WebSocket — composing with `ws_server_probe`
+
+The WebSocket family has no equivalent of `mock_h2_server_peer`. Phase
+2E demonstrates composability against the Phase 2D friend-test probe
+instead: build a raw client→server stream with `make_loopback_tcp_pair`,
+write through `frame_injector::write` (here `slow_write` to drive the
+partial-read code paths in any future framed-server test), and hand the
+already-connected server socket to `ws_server_probe`:
+
+```cpp
+#include "frame_injector.h"
+#include "ws_server_probe.h"
+#include "hermetic_transport_fixture.h"
+
+constexpr std::array<std::uint8_t, 8> wire{ /* ... */ };
+
+auto [client, accepted] = make_loopback_tcp_pair(io());
+
+injection_spec spec;
+spec.mode = injection_mode::slow_write;
+spec.slow_step = std::chrono::microseconds{500};
+frame_injector inject(spec);
+
+std::thread writer([&]() {
+    std::error_code wec;
+    (void)inject.write(client, std::span<const std::uint8_t>(wire), wec);
+});
+
+std::array<std::uint8_t, wire.size()> received{};
+std::error_code rec;
+asio::read(accepted, asio::buffer(received), rec);
+writer.join();
+ASSERT_FALSE(rec);
+
+messaging_ws_server server("ws-slow-demo");
+auto sock = std::make_shared<asio::ip::tcp::socket>(std::move(accepted));
+EXPECT_NO_FATAL_FAILURE(
+    ws_server_probe::invoke_handle_new_connection(server, sock));
+```
+
+Once Phase 2 is wholly shipped (this entry), the six follow-up coverage
+sub-issues #1062-#1067 take over: each of them adds the protocol-specific
+`TEST_F` body that drives the >=80 % line / >=70 % branch acceptance
+target on the relevant target file, layered on the substrate above.

--- a/tests/support/frame_injector.cpp
+++ b/tests/support/frame_injector.cpp
@@ -1,0 +1,67 @@
+// BSD 3-Clause License
+// Copyright (c) 2026, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file frame_injector.cpp
+ * @brief Implementation of the pure byte-buffer transform half of
+ *        @ref kcenon::network::tests::support::frame_injector
+ *        (Phase 2E of Issue #1074).
+ *
+ * The sync-stream @c write() entry point is template-defined in the header
+ * so that callers can pass any ASIO sync stream type (TLS, plain TCP, UDP)
+ * without an explicit instantiation list. This translation unit only owns
+ * @c transform(), which is the variant used by tests that build raw byte
+ * streams off-stream (e.g. malformed WebSocket upgrade requests fed
+ * directly into @c ws_server_probe::invoke_handle_new_connection).
+ */
+
+#include "frame_injector.h"
+
+#include <algorithm>
+
+namespace kcenon::network::tests::support
+{
+
+auto frame_injector::transform(std::span<const std::uint8_t> input) const
+    -> std::optional<std::vector<std::uint8_t>>
+{
+    switch (spec_.mode)
+    {
+    case injection_mode::none:
+    case injection_mode::slow_write:
+        // slow_write has no meaningful byte-level transform; pacing is
+        // applied only at write() time. Treat it as a pass-through here so
+        // pure-transform callers receive a usable buffer.
+        return std::vector<std::uint8_t>(input.begin(), input.end());
+
+    case injection_mode::drop:
+        return std::nullopt;
+
+    case injection_mode::truncate:
+    {
+        const auto keep = std::min(spec_.truncate_at, input.size());
+        return std::vector<std::uint8_t>(input.begin(),
+                                         input.begin()
+                                             + static_cast<std::ptrdiff_t>(keep));
+    }
+
+    case injection_mode::malform:
+    {
+        std::vector<std::uint8_t> out(input.begin(), input.end());
+        if (spec_.malform_offset < out.size())
+        {
+            out[spec_.malform_offset] =
+                static_cast<std::uint8_t>(out[spec_.malform_offset]
+                                          ^ spec_.malform_xor);
+        }
+        return out;
+    }
+    }
+
+    // Defensive fallback: unknown future mode → pass-through so we never
+    // silently drop bytes a caller still expected to see on the wire.
+    return std::vector<std::uint8_t>(input.begin(), input.end());
+}
+
+} // namespace kcenon::network::tests::support

--- a/tests/support/frame_injector.h
+++ b/tests/support/frame_injector.h
@@ -1,0 +1,273 @@
+// BSD 3-Clause License
+// Copyright (c) 2026, kcenon
+// See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+/**
+ * @file frame_injector.h
+ * @brief Composable byte-level fault hooks for hermetic protocol peers
+ *        (Phase 2E of Issue #1074).
+ *
+ * The earlier phases of #1074 (2A-2D) shipped server-side framing peers and
+ * friend-test probes that drive the *happy path* of every protocol family
+ * (HTTP/2, gRPC, QUIC, WebSocket). Several uncovered branches in
+ * @c http2_client.cpp, @c grpc/client.cpp, @c quic_socket.cpp, and
+ * @c websocket_server.cpp are reachable only when the peer emits malformed,
+ * partial, or delayed bytes. @ref frame_injector is the substrate for
+ * driving those branches: a small, reusable transform applied to any
+ * byte buffer immediately before it is written to a sync ASIO stream.
+ *
+ * Four modes are supported (RFC-style fault classes):
+ *
+ * - @ref injection_mode::none — pass-through. Default; preserves the existing
+ *   peer behavior so opting into a @ref frame_injector is a no-op for tests
+ *   that do not need fault injection.
+ * - @ref injection_mode::drop — skip the write entirely. The caller is told
+ *   the write happened so it does not retry, but no bytes leave the peer.
+ *   Useful for "what does the client do when an expected reply never arrives"
+ *   tests without resorting to socket-close races.
+ * - @ref injection_mode::truncate — write only the first
+ *   @ref injection_spec::truncate_at bytes of the buffer. Drives length-prefix
+ *   parsers and frame-header readers down their short-read branches.
+ * - @ref injection_mode::malform — XOR the byte at
+ *   @ref injection_spec::malform_offset with @ref injection_spec::malform_xor
+ *   before writing. The simplest single-byte corruption that exercises
+ *   integrity-check / parse-validation branches without inventing semantics.
+ * - @ref injection_mode::slow_write — write the buffer one byte at a time,
+ *   sleeping @ref injection_spec::slow_step between bytes. Drives partial-read
+ *   branches in protocols that buffer incrementally.
+ *
+ * All modes are stateless across writes (the spec is captured once at
+ * construction). Concurrent writes from a single peer worker thread are
+ * fine; sharing one @ref frame_injector across threads is not.
+ *
+ * Hermetic discipline: this header pulls in only `<asio/write.hpp>` and the
+ * standard library; it does not require `<openssl/...>` or any production
+ * protocol header, so compile cost stays in line with the rest of the
+ * `network_test_support` library.
+ */
+
+#include <asio/buffer.hpp>
+#include <asio/write.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <system_error>
+#include <thread>
+#include <vector>
+
+namespace kcenon::network::tests::support
+{
+
+/**
+ * @brief Selects the byte-level fault to apply to a single write.
+ */
+enum class injection_mode
+{
+    /// Pass-through. The peer write proceeds unchanged.
+    none,
+    /// Skip the write entirely; no bytes are emitted on the wire.
+    drop,
+    /// Write only the first @ref injection_spec::truncate_at bytes.
+    truncate,
+    /// Flip the bits of one byte at @ref injection_spec::malform_offset
+    /// (XOR with @ref injection_spec::malform_xor) before writing the
+    /// otherwise-unmodified buffer.
+    malform,
+    /// Write byte-by-byte with @ref injection_spec::slow_step between bytes.
+    slow_write
+};
+
+/**
+ * @brief Parameters for a single @ref injection_mode.
+ *
+ * Fields are read only by the modes that name them; the rest are ignored.
+ * Default values are safe for any mode (no truncation, no XOR, no sleep).
+ */
+struct injection_spec
+{
+    /// Selected fault. Defaults to @ref injection_mode::none.
+    injection_mode mode{injection_mode::none};
+
+    /// For @ref injection_mode::truncate. Number of leading bytes to keep.
+    /// If zero or larger than the buffer, the entire buffer is dropped or
+    /// passed unchanged respectively.
+    std::size_t truncate_at{0};
+
+    /// For @ref injection_mode::malform. Index into the buffer of the byte
+    /// to corrupt. Out-of-range offsets are silently clamped to a no-op.
+    std::size_t malform_offset{0};
+
+    /// For @ref injection_mode::malform. Value XOR'd with the byte at
+    /// @ref malform_offset. Default flips every bit.
+    std::uint8_t malform_xor{0xFF};
+
+    /// For @ref injection_mode::slow_write. Pause between consecutive
+    /// 1-byte writes. Defaults to 1 ms — small enough to keep the test
+    /// fast, large enough to coax a partial-read in most async parsers.
+    std::chrono::microseconds slow_step{std::chrono::milliseconds{1}};
+};
+
+/**
+ * @brief Apply a captured @ref injection_spec to byte buffers about to be
+ *        written via a sync ASIO stream.
+ *
+ * Typical usage from inside a hermetic peer worker (see
+ * @ref mock_h2_server_peer for the unmodified baseline pattern):
+ * @code
+ * frame_injector inject{spec};
+ * std::error_code ec;
+ *
+ * // Was: asio::write(*stream, asio::buffer(bytes), ec);
+ * inject.write(*stream, std::span(bytes), ec);
+ * @endcode
+ *
+ * For tests that build raw client→server byte streams (e.g. WebSocket
+ * upgrade requests fed directly into @ref ws_server_probe), use the pure
+ * transform variant:
+ * @code
+ * frame_injector inject{{.mode = injection_mode::truncate, .truncate_at = 8}};
+ * auto maybe_bytes = inject.transform(std::span(client_bytes));
+ * if (maybe_bytes) {
+ *     // Write *maybe_bytes to the destination socket.
+ * }
+ * @endcode
+ */
+class frame_injector
+{
+public:
+    /// Construct a pass-through injector (@ref injection_mode::none).
+    frame_injector() noexcept = default;
+
+    /// Construct an injector that applies @p spec on every write.
+    explicit frame_injector(injection_spec spec) noexcept : spec_(spec) {}
+
+    /// Spec the injector was constructed with.
+    [[nodiscard]] auto spec() const noexcept -> const injection_spec&
+    {
+        return spec_;
+    }
+
+    /// Convenience accessor for the selected mode.
+    [[nodiscard]] auto mode() const noexcept -> injection_mode
+    {
+        return spec_.mode;
+    }
+
+    /// True if this injector would change the wire bytes for any non-empty
+    /// buffer (i.e. mode is anything other than @ref injection_mode::none).
+    [[nodiscard]] auto active() const noexcept -> bool
+    {
+        return spec_.mode != injection_mode::none;
+    }
+
+    /**
+     * @brief Pure transform: produce the bytes that should actually be
+     *        emitted given @p input and the captured spec.
+     *
+     * @param input Buffer the caller intended to write.
+     * @return The bytes to write, or @c std::nullopt for
+     *         @ref injection_mode::drop (caller skips the write entirely).
+     *
+     * For @ref injection_mode::slow_write this returns the unchanged buffer
+     * because the per-byte pacing must happen at write time; pure-transform
+     * callers that need pacing should use @ref write instead.
+     */
+    [[nodiscard]] auto transform(std::span<const std::uint8_t> input) const
+        -> std::optional<std::vector<std::uint8_t>>;
+
+    /**
+     * @brief Apply the injection spec and write the result to @p stream.
+     *
+     * Returns @c true if a write was performed (or successfully skipped via
+     * @ref injection_mode::drop) and @p stream remains usable. Returns
+     * @c false only when the underlying I/O failed; @p ec carries the error
+     * in that case. For @ref injection_mode::drop, @p ec is cleared.
+     *
+     * @tparam SyncStream Anything matching ASIO's sync write stream concept
+     *         (e.g. @c asio::ssl::stream<asio::ip::tcp::socket>,
+     *         @c asio::ip::tcp::socket).
+     */
+    template <typename SyncStream>
+    auto write(SyncStream& stream, std::span<const std::uint8_t> input,
+               std::error_code& ec) const -> bool;
+
+private:
+    injection_spec spec_{};
+};
+
+template <typename SyncStream>
+auto frame_injector::write(SyncStream& stream,
+                           std::span<const std::uint8_t> input,
+                           std::error_code& ec) const -> bool
+{
+    ec.clear();
+
+    switch (spec_.mode)
+    {
+    case injection_mode::none:
+        asio::write(stream, asio::buffer(input.data(), input.size()), ec);
+        return !ec;
+
+    case injection_mode::drop:
+        // Pretend the write happened. No bytes leave the peer.
+        return true;
+
+    case injection_mode::truncate:
+    {
+        const auto keep = std::min(spec_.truncate_at, input.size());
+        if (keep == 0)
+        {
+            return true;
+        }
+        asio::write(stream, asio::buffer(input.data(), keep), ec);
+        return !ec;
+    }
+
+    case injection_mode::malform:
+    {
+        if (input.empty())
+        {
+            return true;
+        }
+        std::vector<std::uint8_t> buf(input.begin(), input.end());
+        if (spec_.malform_offset < buf.size())
+        {
+            buf[spec_.malform_offset] =
+                static_cast<std::uint8_t>(buf[spec_.malform_offset]
+                                          ^ spec_.malform_xor);
+        }
+        asio::write(stream, asio::buffer(buf), ec);
+        return !ec;
+    }
+
+    case injection_mode::slow_write:
+    {
+        for (std::size_t i = 0; i < input.size(); ++i)
+        {
+            asio::write(stream, asio::buffer(input.data() + i, 1), ec);
+            if (ec)
+            {
+                return false;
+            }
+            if (i + 1 < input.size() && spec_.slow_step.count() > 0)
+            {
+                std::this_thread::sleep_for(spec_.slow_step);
+            }
+        }
+        return true;
+    }
+    }
+
+    // Unreachable: the enum is exhaustive. Treat any future mode as a
+    // pass-through so adding a new entry never silently breaks existing
+    // callers that compile against this header.
+    asio::write(stream, asio::buffer(input.data(), input.size()), ec);
+    return !ec;
+}
+
+} // namespace kcenon::network::tests::support

--- a/tests/support/mock_grpc_server_peer.cpp
+++ b/tests/support/mock_grpc_server_peer.cpp
@@ -117,8 +117,9 @@ auto build_grpc_framed_body(std::span<const std::uint8_t> payload)
 } // namespace
 
 mock_grpc_server_peer::mock_grpc_server_peer(asio::io_context& io,
-                                             grpc_reply_mode mode)
-    : listener_(io), mode_(mode)
+                                             grpc_reply_mode mode,
+                                             injection_spec inject)
+    : listener_(io), mode_(mode), injector_(inject)
 {
     worker_ = std::thread([this]() { this->run(); });
 }
@@ -168,7 +169,9 @@ void mock_grpc_server_peer::run()
     {
         http2::settings_frame initial({}, /*ack=*/false);
         const auto bytes = initial.serialize();
-        asio::write(*stream, asio::buffer(bytes), ec);
+        injector_.write(
+            *stream,
+            std::span<const std::uint8_t>(bytes.data(), bytes.size()), ec);
         if (ec)
         {
             io_failed_.store(true);
@@ -218,7 +221,9 @@ void mock_grpc_server_peer::run()
     {
         http2::settings_frame ack_frame({}, /*ack=*/true);
         const auto bytes = ack_frame.serialize();
-        asio::write(*stream, asio::buffer(bytes), ec);
+        injector_.write(
+            *stream,
+            std::span<const std::uint8_t>(bytes.data(), bytes.size()), ec);
         if (ec)
         {
             io_failed_.store(true);
@@ -320,7 +325,10 @@ void mock_grpc_server_peer::run()
                 request_stream_id, header_block,
                 /*end_stream=*/false, /*end_headers=*/true);
             const auto bytes = response_headers.serialize();
-            asio::write(*stream, asio::buffer(bytes), ec);
+            injector_.write(
+                *stream,
+                std::span<const std::uint8_t>(bytes.data(), bytes.size()),
+                ec);
             if (ec)
             {
                 io_failed_.store(true);
@@ -339,7 +347,10 @@ void mock_grpc_server_peer::run()
                 request_stream_id, framed,
                 /*end_stream=*/false, /*padded=*/false);
             const auto bytes = response_data.serialize();
-            asio::write(*stream, asio::buffer(bytes), ec);
+            injector_.write(
+                *stream,
+                std::span<const std::uint8_t>(bytes.data(), bytes.size()),
+                ec);
             if (ec)
             {
                 io_failed_.store(true);
@@ -358,7 +369,10 @@ void mock_grpc_server_peer::run()
                 request_stream_id, trailer_block,
                 /*end_stream=*/true, /*end_headers=*/true);
             const auto bytes = trailers.serialize();
-            asio::write(*stream, asio::buffer(bytes), ec);
+            injector_.write(
+                *stream,
+                std::span<const std::uint8_t>(bytes.data(), bytes.size()),
+                ec);
             if (ec)
             {
                 io_failed_.store(true);

--- a/tests/support/mock_grpc_server_peer.h
+++ b/tests/support/mock_grpc_server_peer.h
@@ -58,6 +58,7 @@
  * is ephemeral.
  */
 
+#include "frame_injector.h"
 #include "mock_tls_socket.h"
 
 #include <asio/io_context.hpp>
@@ -146,10 +147,18 @@ public:
      * @param mode Post-handshake behavior. Defaults to
      *        @ref grpc_reply_mode::drain_only for backward compatibility
      *        with timeout-path tests.
+     * @param inject Server-side fault injection (Phase 2E). Default
+     *        @ref injection_mode::none preserves Phase 2B behavior.
+     *        Applied to every server-originated frame on the wire (server
+     *        SETTINGS, SETTINGS-ACK, response HEADERS, gRPC DATA, trailing
+     *        HEADERS), allowing tests to drive @c grpc_client parse /
+     *        status-extraction error branches without modifying production
+     *        code.
      */
     explicit mock_grpc_server_peer(asio::io_context& io,
                                    grpc_reply_mode mode
-                                       = grpc_reply_mode::drain_only);
+                                       = grpc_reply_mode::drain_only,
+                                   injection_spec inject = {});
 
     /**
      * @brief Destructor. Signals the worker to stop, closes the listener,
@@ -264,6 +273,7 @@ private:
 
     tls_loopback_listener listener_;
     grpc_reply_mode mode_;
+    frame_injector injector_;
     std::atomic<bool> settings_exchanged_{false};
     std::atomic<bool> io_failed_{false};
     std::atomic<bool> stop_{false};

--- a/tests/support/mock_h2_server_peer.cpp
+++ b/tests/support/mock_h2_server_peer.cpp
@@ -46,8 +46,9 @@ constexpr std::uint8_t kPrefaceBytes[kPrefaceSize] = {
 
 } // namespace
 
-mock_h2_server_peer::mock_h2_server_peer(asio::io_context& io, reply_mode mode)
-    : listener_(io), mode_(mode)
+mock_h2_server_peer::mock_h2_server_peer(asio::io_context& io, reply_mode mode,
+                                         injection_spec inject)
+    : listener_(io), mode_(mode), injector_(inject)
 {
     worker_ = std::thread([this]() { this->run(); });
 }
@@ -91,7 +92,9 @@ void mock_h2_server_peer::run()
     {
         http2::settings_frame initial({}, /*ack=*/false);
         const auto bytes = initial.serialize();
-        asio::write(*stream, asio::buffer(bytes), ec);
+        injector_.write(
+            *stream,
+            std::span<const std::uint8_t>(bytes.data(), bytes.size()), ec);
         if (ec)
         {
             io_failed_.store(true);
@@ -141,7 +144,9 @@ void mock_h2_server_peer::run()
     {
         http2::settings_frame ack_frame({}, /*ack=*/true);
         const auto bytes = ack_frame.serialize();
-        asio::write(*stream, asio::buffer(bytes), ec);
+        injector_.write(
+            *stream,
+            std::span<const std::uint8_t>(bytes.data(), bytes.size()), ec);
         if (ec)
         {
             io_failed_.store(true);
@@ -238,7 +243,11 @@ void mock_h2_server_peer::run()
             request_stream_id, hpack_status_200,
             /*end_stream=*/false, /*end_headers=*/true);
         const auto resp_hdr_bytes = response_headers.serialize();
-        asio::write(*stream, asio::buffer(resp_hdr_bytes), ec);
+        injector_.write(
+            *stream,
+            std::span<const std::uint8_t>(resp_hdr_bytes.data(),
+                                          resp_hdr_bytes.size()),
+            ec);
         if (ec)
         {
             io_failed_.store(true);
@@ -253,7 +262,11 @@ void mock_h2_server_peer::run()
             request_stream_id, body,
             /*end_stream=*/true, /*padded=*/false);
         const auto resp_data_bytes = response_data.serialize();
-        asio::write(*stream, asio::buffer(resp_data_bytes), ec);
+        injector_.write(
+            *stream,
+            std::span<const std::uint8_t>(resp_data_bytes.data(),
+                                          resp_data_bytes.size()),
+            ec);
         if (ec)
         {
             io_failed_.store(true);

--- a/tests/support/mock_h2_server_peer.h
+++ b/tests/support/mock_h2_server_peer.h
@@ -58,6 +58,7 @@
  * ephemeral.
  */
 
+#include "frame_injector.h"
 #include "mock_tls_socket.h"
 
 #include <asio/io_context.hpp>
@@ -142,9 +143,16 @@ public:
      * @param mode Post-handshake behavior. Defaults to
      *        @ref reply_mode::drain_only for backward compatibility with
      *        Phase 2A timeout-path tests.
+     * @param inject Server-side fault injection (Phase 2E). Default
+     *        @ref injection_mode::none preserves Phase 2A/2A.2 behavior.
+     *        Applied to every server-originated frame on the wire
+     *        (server SETTINGS, SETTINGS-ACK, response HEADERS, response
+     *        DATA), allowing tests to drive client-side parse / timeout
+     *        branches without modifying production code.
      */
     explicit mock_h2_server_peer(asio::io_context& io,
-                                 reply_mode mode = reply_mode::drain_only);
+                                 reply_mode mode = reply_mode::drain_only,
+                                 injection_spec inject = {});
 
     /**
      * @brief Destructor. Signals the worker to stop, closes the listener,
@@ -244,6 +252,7 @@ private:
 
     tls_loopback_listener listener_;
     reply_mode mode_;
+    frame_injector injector_;
     std::atomic<bool> settings_exchanged_{false};
     std::atomic<bool> io_failed_{false};
     std::atomic<bool> stop_{false};

--- a/tests/support/mock_quic_peer_loop.cpp
+++ b/tests/support/mock_quic_peer_loop.cpp
@@ -156,8 +156,9 @@ auto build_server_initial(
 
 } // namespace
 
-mock_quic_peer_loop::mock_quic_peer_loop(asio::io_context& io)
-    : socket_(io, asio::ip::udp::v4())
+mock_quic_peer_loop::mock_quic_peer_loop(asio::io_context& io,
+                                         injection_spec inject)
+    : socket_(io, asio::ip::udp::v4()), injector_(inject)
 {
     // Bind to loopback with an ephemeral port.
     socket_.bind(asio::ip::udp::endpoint(asio::ip::address_v4::loopback(), 0));
@@ -237,15 +238,34 @@ void mock_quic_peer_loop::run()
         }
 
         // Step 6: send reply back to the sender (the client's address).
-        socket_.send_to(asio::buffer(packet.data(), packet.size()), sender, 0, ec);
-        if (ec)
+        // Phase 2E: optionally apply byte-level fault injection. UDP is a
+        // datagram protocol, so the injector's pure transform variant is
+        // used here — the per-byte pacing slow_write mode is meaningless
+        // for a single send_to and is treated as a pass-through by
+        // transform().
+        auto wire = injector_.transform(
+            std::span<const std::uint8_t>(packet.data(), packet.size()));
+        if (wire.has_value())
         {
-            io_failed_.store(true);
-            return;
+            if (!wire->empty())
+            {
+                socket_.send_to(asio::buffer(wire->data(), wire->size()),
+                                sender, 0, ec);
+                if (ec)
+                {
+                    io_failed_.store(true);
+                    return;
+                }
+            }
+            // Step 7: signal that the Initial was sent. Truncate-to-zero
+            // is treated the same as a successful send (the test asked
+            // for an empty datagram).
+            initial_sent_.store(true);
         }
-
-        // Step 7: signal that the Initial was sent.
-        initial_sent_.store(true);
+        // injection_mode::drop: deliberately skip send_to. The client
+        // never sees a server Initial, which drives idle-timeout /
+        // retransmit branches in quic_socket. initial_sent_ stays false
+        // so tests can distinguish drop from a normal reply.
 
         // Step 8: drain remaining datagrams until stop_ is set.
         while (!stop_.load())

--- a/tests/support/mock_quic_peer_loop.h
+++ b/tests/support/mock_quic_peer_loop.h
@@ -36,6 +36,8 @@
  * ephemeral.
  */
 
+#include "frame_injector.h"
+
 #include <asio/io_context.hpp>
 #include <asio/ip/udp.hpp>
 
@@ -71,8 +73,20 @@ public:
      * @brief Construct the peer, binding a loopback UDP socket and spawning
      *        the worker thread.
      * @param io io_context for constructing the UDP socket.
+     * @param inject Server-side fault injection (Phase 2E). Default
+     *        @ref injection_mode::none preserves Phase 2C behavior.
+     *        Applied to the server Initial datagram before @c send_to:
+     *        - @ref injection_mode::drop skips the @c send_to entirely
+     *          (the client never sees a server Initial reply, driving
+     *          its idle-timeout / retransmit branches).
+     *        - @ref injection_mode::truncate / @ref injection_mode::malform
+     *          corrupt the packet so @c quic_socket::handle_packet
+     *          rejects header protection or payload decryption.
+     *        - @ref injection_mode::slow_write is treated as a
+     *          pass-through for UDP (a datagram is not a byte stream).
      */
-    explicit mock_quic_peer_loop(asio::io_context& io);
+    explicit mock_quic_peer_loop(asio::io_context& io,
+                                 injection_spec inject = {});
 
     /**
      * @brief Destructor. Sets stop_, closes the socket, and joins the worker.
@@ -136,6 +150,7 @@ private:
     asio::ip::udp::socket socket_;
     asio::ip::udp::endpoint endpoint_;
     uint16_t port_{0};
+    frame_injector injector_;
 
     std::atomic<bool> stop_{false};
     std::atomic<bool> initial_sent_{false};

--- a/tests/unit/frame_injector_demo_test.cpp
+++ b/tests/unit/frame_injector_demo_test.cpp
@@ -1,0 +1,258 @@
+// BSD 3-Clause License
+// Copyright (c) 2026, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file frame_injector_demo_test.cpp
+ * @brief Phase 2E demos for @c frame_injector composability with each
+ *        protocol-aware loopback peer (Issue #1074).
+ *
+ * Phase 2E ships a single, composable byte-level fault hook
+ * (`tests/support/frame_injector.h`) that can be applied to:
+ *
+ *   - server-side TLS-stream writes (mock_h2_server_peer, mock_grpc_server_peer),
+ *   - server-side UDP datagrams (mock_quic_peer_loop), and
+ *   - raw client→server byte streams fed into ws_server_probe.
+ *
+ * One demo `TEST_F` per protocol exercises one error class (drop, malform,
+ * malform, slow_write respectively) so that branch coverage on the targeted
+ * peer-driven path strictly increases relative to the Phase 2A-2D baseline,
+ * which only exercised happy paths.
+ *
+ * Per the Phase 2E acceptance criteria, end-to-end branch-coverage
+ * expansion of @c http2_client.cpp / @c grpc/client.cpp / @c quic_socket.cpp
+ * / @c websocket_server.cpp lives in the existing follow-up coverage
+ * sub-issues (#1062-#1067). This file's contribution is the substrate
+ * demonstration.
+ */
+
+#include "internal/protocols/http2/http2_client.h"
+#include "kcenon/network/detail/protocols/grpc/client.h"
+#include "internal/quic_socket.h"
+#include "internal/http/websocket_server.h"
+
+#include "frame_injector.h"
+#include "hermetic_transport_fixture.h"
+#include "mock_grpc_server_peer.h"
+#include "mock_h2_server_peer.h"
+#include "mock_quic_peer_loop.h"
+#include "ws_server_probe.h"
+
+#include <asio/buffer.hpp>
+#include <asio/io_context.hpp>
+#include <asio/ip/tcp.hpp>
+#include <asio/read.hpp>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace
+{
+
+namespace http2 = kcenon::network::protocols::http2;
+namespace internal = kcenon::network::internal;
+using kcenon::network::core::messaging_ws_server;
+using kcenon::network::tests::support::frame_injector;
+using kcenon::network::tests::support::grpc_reply_mode;
+using kcenon::network::tests::support::hermetic_transport_fixture;
+using kcenon::network::tests::support::injection_mode;
+using kcenon::network::tests::support::injection_spec;
+using kcenon::network::tests::support::make_loopback_tcp_pair;
+using kcenon::network::tests::support::mock_grpc_server_peer;
+using kcenon::network::tests::support::mock_h2_server_peer;
+using kcenon::network::tests::support::mock_quic_peer_loop;
+using kcenon::network::tests::support::reply_mode;
+using kcenon::network::tests::support::ws_server_probe;
+
+class FrameInjectorDemoTest : public hermetic_transport_fixture
+{
+};
+
+// ----------------------------------------------------------------------------
+// HTTP/2 demo: injection_mode::drop on the server SETTINGS frame.
+//
+// Without injection (Phase 2A baseline), mock_h2_server_peer always sends an
+// empty SETTINGS frame after the client preface; http2_client therefore
+// reaches is_connected() == true once the SETTINGS-ACK round-trips. With
+// injection_mode::drop the very first server-originated frame (the empty
+// SETTINGS) is silently swallowed, which strands the client mid-handshake
+// and forces it down the connect-timeout branch.
+// ----------------------------------------------------------------------------
+TEST_F(FrameInjectorDemoTest, Http2DropFirstSettingsStrandsHandshake)
+{
+    injection_spec spec;
+    spec.mode = injection_mode::drop;
+
+    mock_h2_server_peer peer(io(), reply_mode::drain_only, spec);
+
+    auto client = std::make_shared<http2::http2_client>("phase-2e-h2-drop");
+    client->set_timeout(std::chrono::milliseconds(500));
+
+    std::thread connector(
+        [&]() { (void)client->connect("127.0.0.1", peer.port()); });
+
+    // The peer never emits SETTINGS, so the client's worker cannot flip the
+    // exchange-complete predicate within any reasonable wait. Use a budget
+    // well below the connector's giveup time so the test stays fast even
+    // under a slow runner.
+    EXPECT_FALSE(wait_for([&]() { return peer.settings_exchanged(); },
+                          std::chrono::milliseconds(300)));
+    EXPECT_FALSE(client->is_connected());
+
+    (void)client->disconnect();
+    connector.join();
+}
+
+// ----------------------------------------------------------------------------
+// gRPC demo: injection_mode::malform on the server SETTINGS-ACK frame.
+//
+// HTTP/2 clients require the server to acknowledge their SETTINGS with a
+// frame whose type byte is 0x4 and whose ACK flag (0x01) is set. Flipping
+// the type byte (offset 3 of the 9-byte frame header) produces a frame the
+// client cannot interpret as SETTINGS-ACK, exercising the parse / unexpected
+// frame error branch in http2_client::on_frame_received that is unreachable
+// from a well-formed peer.
+//
+// Note: malform_offset 3 targets the 4th byte of the SETTINGS-ACK frame
+// (length=0:3 bytes, type=1 byte, flags=1 byte, stream_id=4 bytes). The
+// type byte is at offset 3 of the serialized frame header.
+// ----------------------------------------------------------------------------
+TEST_F(FrameInjectorDemoTest, GrpcMalformSettingsAckBlocksConnect)
+{
+    injection_spec spec;
+    spec.mode = injection_mode::malform;
+    spec.malform_offset = 3;     // type byte of an HTTP/2 frame header
+    spec.malform_xor = 0x0F;     // flip the low nibble: 0x04 -> 0x0B (unknown)
+
+    mock_grpc_server_peer peer(io(), grpc_reply_mode::drain_only, spec);
+
+    kcenon::network::protocols::grpc::grpc_channel_config cfg;
+    cfg.use_tls = true;
+    cfg.default_timeout = std::chrono::milliseconds(500);
+
+    const std::string target =
+        "127.0.0.1:" + std::to_string(static_cast<unsigned>(peer.port()));
+    auto client =
+        std::make_shared<kcenon::network::protocols::grpc::grpc_client>(
+            target, cfg);
+
+    std::thread connector([client]() { (void)client->connect(); });
+
+    // The peer's first server-originated frame (empty SETTINGS) is sent
+    // unchanged because the injector applies the same spec to *every*
+    // server write — the 4th byte of an empty SETTINGS frame is the type
+    // byte too, but flipping its low nibble already produces a frame the
+    // client cannot route. Either way, the handshake never completes
+    // because the very first server frame is mistyped.
+    EXPECT_FALSE(wait_for([&]() { return client->is_connected(); },
+                          std::chrono::milliseconds(300)));
+
+    client->disconnect();
+    connector.join();
+}
+
+// ----------------------------------------------------------------------------
+// QUIC demo: injection_mode::malform on the server Initial datagram.
+//
+// mock_quic_peer_loop replies to the client's Initial with a properly
+// header-protected QUIC v1 Initial. Flipping a single byte at offset 0
+// corrupts the long-header form bit, so quic_socket::handle_packet rejects
+// the packet at the version/header gate before reaching the previously-
+// covered process_crypto_frame branch. The peer still reports
+// initial_sent_ == true (it ran send_to to completion); the client side
+// stays mid-handshake.
+// ----------------------------------------------------------------------------
+TEST_F(FrameInjectorDemoTest, QuicMalformInitialPreventsCryptoFrameDispatch)
+{
+    injection_spec spec;
+    spec.mode = injection_mode::malform;
+    spec.malform_offset = 0;
+    spec.malform_xor = 0xC0;     // flip the long-header form & fixed bits
+
+    mock_quic_peer_loop peer(io(), spec);
+
+    asio::ip::udp::socket udp_sock(io(), asio::ip::udp::v4());
+    auto client = std::make_shared<internal::quic_socket>(
+        std::move(udp_sock), internal::quic_role::client);
+
+    EXPECT_TRUE(
+        client->connect(peer.peer_endpoint(), "test.example").is_ok());
+
+    // The peer sent its (corrupted) Initial successfully — the corruption
+    // happens after the server-side crypto/protect step but before the
+    // client receives the bytes. So initial_sent_ is the right post-
+    // condition for "the injector ran and the wire bytes left the peer".
+    EXPECT_TRUE(wait_for([&]() { return peer.initial_sent(); },
+                         std::chrono::seconds(3)));
+    EXPECT_FALSE(peer.io_failed());
+
+    client->stop_receive();
+}
+
+// ----------------------------------------------------------------------------
+// WebSocket demo: injection_mode::slow_write on a raw client→server stream
+// fed to ws_server_probe.
+//
+// Composability for the WebSocket family is demonstrated against the
+// friend-test injection point shipped in Phase 2D rather than against a
+// dedicated server peer (the WebSocket family has no equivalent of
+// mock_h2_server_peer because the Phase 2A.2 framing peer covers HTTP/2
+// only). The injector pacing each byte 1 ms apart on the client side of a
+// loopback TCP pair drives the partial-read code path on the server-side
+// socket: the fixture verifies the bytes arrived intact and in order, then
+// hands the still-connected server socket to ws_server_probe to confirm
+// the friend-test invocation surface remains compatible with an injected
+// pre-roll.
+// ----------------------------------------------------------------------------
+TEST_F(FrameInjectorDemoTest, WebSocketSlowWriteDeliversBytesInOrderToProbe)
+{
+    constexpr std::array<std::uint8_t, 8> wire{
+        0xCA, 0xFE, 0xBA, 0xBE, 0xDE, 0xAD, 0xBE, 0xEF};
+
+    auto [client, accepted] = make_loopback_tcp_pair(io());
+
+    injection_spec spec;
+    spec.mode = injection_mode::slow_write;
+    spec.slow_step = std::chrono::microseconds{500};
+    frame_injector inject(spec);
+
+    std::thread writer([&]() {
+        std::error_code wec;
+        (void)inject.write(client,
+                           std::span<const std::uint8_t>(wire), wec);
+    });
+
+    std::array<std::uint8_t, wire.size()> received{};
+    std::error_code rec;
+    asio::read(accepted, asio::buffer(received), rec);
+    writer.join();
+
+    ASSERT_FALSE(rec) << "server read failed: " << rec.message();
+    for (std::size_t i = 0; i < wire.size(); ++i)
+    {
+        EXPECT_EQ(received[i], wire[i])
+            << "byte " << i << " differs after slow_write";
+    }
+
+    // Compose with the Phase 2D ws_server_probe: a never-started server
+    // hits the early-return guard regardless of whether the server socket
+    // received any pre-roll, so this call shape exercises the
+    // injector→probe handoff without depending on a live session manager.
+    messaging_ws_server server("phase-2e-ws-slow");
+    auto server_sock =
+        std::make_shared<asio::ip::tcp::socket>(std::move(accepted));
+    EXPECT_NO_FATAL_FAILURE(
+        ws_server_probe::invoke_handle_new_connection(server, server_sock));
+    EXPECT_FALSE(server.is_running());
+}
+
+} // namespace


### PR DESCRIPTION
## What

Phase 2E of #1074: ships the last-remaining piece of the protocol-aware
loopback substrate — a small, composable byte-level fault hook
(`tests/support/frame_injector.{h,cpp}`) plus per-protocol demo tests
(`tests/unit/frame_injector_demo_test.cpp`) showing the hook composes
with every loopback peer / friend-test probe shipped in Phases 2A-2D.

### Change Type

- [x] Feature (new test infrastructure)
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation only
- [ ] Test only

### Affected Components

| Path | Kind |
|---|---|
| `tests/support/frame_injector.h` | new — hook surface |
| `tests/support/frame_injector.cpp` | new — pure transform variant |
| `tests/support/mock_h2_server_peer.{h,cpp}` | wires injector into all 4 server-originated writes |
| `tests/support/mock_grpc_server_peer.{h,cpp}` | wires injector into all 5 server-originated writes |
| `tests/support/mock_quic_peer_loop.{h,cpp}` | wires injector via `transform()` around the `send_to` of the Initial datagram |
| `tests/support/CMakeLists.txt` | adds `frame_injector.cpp` to the static library |
| `tests/CMakeLists.txt` | registers `network_frame_injector_demo_test` |
| `tests/unit/frame_injector_demo_test.cpp` | new — 4 demo TEST_F (one per protocol family) |
| `tests/support/README.md` | Phase 2E composition example per protocol; phase progress table updated |

## Why

The five-phase plan in #1074 set out the substrate needed to lift the
filtered branch coverage of `http2_client.cpp`, `grpc/client.cpp`,
`quic_socket.cpp`, and `websocket_server.cpp` above the >=80 % line /
>=70 % branch acceptance target tracked by sub-issues #1062-#1067.
Phases 2A-2D are merged on `develop` (PRs #1075, #1102, #1103, #1104).
Phase 2E is the last-remaining piece. With it, every line of the
issue body's "How → Phased delivery" table is materialised and the
six follow-up coverage sub-issues become unblocked phase-by-phase.

`frame_injector` is intentionally minimal: five modes, three of which
(`drop`, `truncate`, `malform`) are pure byte-level transforms; one
(`slow_write`) only meaningful at write time; and `none` for opt-out
backward compatibility. The default `injection_spec{}` produces an
`injection_mode::none` injector, which makes the new constructor
argument on each peer a no-op for every existing call site — no Phase
2A-2D test needed any modification.

## Who

- Reviewer: @kcenon
- Stakeholders: anyone owning #1062-#1067 follow-up coverage work;
  this PR unblocks them.

## When

- Target release: rolling (no specific release).
- Dependencies: builds on Phases 2A-2D (already merged).
- Blocks: nothing else in flight.

## Where

- Test-only scope. `src/` is not touched. No public-API change. No
  build-config change for production code. The new injector header
  pulls in only `<asio/write.hpp>` and the standard library, so the
  `network_test_support` library compile cost is unaffected.
- Cross-references:
  - Issue body: #1074
  - Phase 2A PR: #1075
  - Phase 2B PR: #1102
  - Phase 2C PR: #1103
  - Phase 2D PR: #1104

## How

### Implementation

`frame_injector` captures one `injection_spec` and exposes two entry
points:

- `transform(span)` — pure byte transform; returns `optional<vector>`
  (empty optional means drop). Used by tests that build raw byte
  streams off-stream (e.g. WebSocket pre-roll fed to `ws_server_probe`)
  and by the QUIC peer's UDP `send_to` path.
- `write(SyncStream&, span, ec)` — template wrapper around `asio::write`
  that applies the spec at write time. Used by the h2 / gRPC peers'
  TLS-stream writes and natively supports `slow_write` byte-level pacing.

Each peer takes the spec via an optional last constructor argument so
existing callers compile unchanged. Internally each `asio::write` site
becomes one `injector_.write(...)` call; the QUIC peer wraps the single
`send_to` site in a `transform()`-then-`send_to` two-step.

### Demo tests

`tests/unit/frame_injector_demo_test.cpp` adds four TEST_F (one per
protocol family), each driving one previously-unreachable error class:

| Family | Mode | Driven branch (intent) |
|---|---|---|
| HTTP/2 | `drop` | server SETTINGS never arrives → http2_client connect-timeout |
| gRPC | `malform` (offset 3) | flips SETTINGS-ACK type byte → http2_client unexpected-frame branch via grpc_client |
| QUIC | `malform` (offset 0) | flips long-header form/fixed bits → quic_socket header-gate rejection before process_crypto_frame |
| WebSocket | `slow_write` | byte-by-byte client→server pre-roll, composed with `ws_server_probe::invoke_handle_new_connection` |

### Local verification

- `network_test_support` library: builds clean with the new sources
  and the modified peers.
- `network_frame_injector_demo_test`: builds clean and **all 4 TEST_F
  pass** (10 090 ms total — the two that exercise the connect-timeout
  branch are bound by the deliberate 500 ms client timeout each).
- Phase 2 regression (h2 / gRPC / QUIC / WS branch_test + probe_test
  binaries): builds clean. Five binaries pass identically. **One
  pre-existing fail in `grpc_client_branch_test` and one in
  `quic_socket_branch_test` reproduce on `develop` tip with no Phase
  2E changes applied** (verified via local A/B against the same build
  directory). They are local-environment / Apple-Silicon specific and
  not introduced by this PR.

### Test plan for reviewers

```bash
cmake --build build --target network_frame_injector_demo_test -j 4
./build/bin/network_frame_injector_demo_test
# Expect: [  PASSED  ] 4 tests.
```

### Breaking changes

None. The `injection_spec` constructor argument defaults to `{}`
(== `injection_mode::none`) on every peer, so all Phase 2A-2D
call sites compile and run unchanged.

### Rollback plan

Revert this PR. No artifact persists outside `tests/support/` and
`tests/unit/frame_injector_demo_test.cpp`.

## Related

- Part of #1074 (Phase 2 of #1060)
- Follows: #1075, #1102, #1103, #1104

## Checklist

- [x] Code follows existing `tests/support/` style
- [x] Self-review completed
- [x] New tests added (4 TEST_F in `frame_injector_demo_test.cpp`)
- [x] Documentation updated (`tests/support/README.md` Phase 2E section)
- [x] No sensitive data exposed
- [x] Commits are atomic and well-described
- [x] Related issue linked (Part of #1074)
