### PR TITLE
test(http2): add frame_injector-driven error coverage round 2 (#1106)

### DIFF
--- a/tests/unit/http2_client_branch_test.cpp
+++ b/tests/unit/http2_client_branch_test.cpp
@@ -1102,3 +1102,216 @@ TEST_F(Http2ClientHermeticTransportTest,
     (void)setup.client->disconnect();
     setup.connector.join();
 }
+
+// ============================================================================
+// Phase 2E.R2: frame_injector-driven error coverage (Issue #1106, Part of #953)
+//
+// All TEST_F below compose mock_h2_server_peer with frame_injector to drive
+// previously-unreachable error branches in http2_client.cpp. The Phase 2E
+// substrate (#1074, PR #1105) routes every server-originated frame write
+// through injector_.write(), so a single injection_spec applies uniformly
+// to every write the peer emits during the handshake (server SETTINGS, then
+// SETTINGS-ACK; for reply_mode::echo_one, additionally response HEADERS and
+// DATA). Tests therefore choose injection parameters such that the targeted
+// fault either (a) lands on the very first server-originated frame so that
+// is_connected() never flips true, or (b) is constructed to be a no-op for
+// the 9-byte empty-payload SETTINGS frames and only takes effect on the
+// longer response frames in echo_one mode.
+//
+// Round 1 of #953 (#991, #1062) raised happy-path coverage but left
+// http2_client.cpp at 18.8% line / 9.9% branch (run 25430202846,
+// 2026-05-06) because the error branches required exactly this kind of
+// fault injection that did not exist until Phase 2E (#1074) shipped.
+// ============================================================================
+
+TEST_F(Http2ClientHermeticTransportTest,
+       DropFirstServerSettingsLeavesClientUnconnected)
+{
+    using namespace kcenon::network::tests::support;
+    injection_spec spec;
+    spec.mode = injection_mode::drop;
+
+    mock_h2_server_peer peer(io(), reply_mode::drain_only, spec);
+
+    auto client = std::make_shared<http2::http2_client>("phase-2e-r2-drop");
+    client->set_timeout(std::chrono::milliseconds(500));
+
+    std::thread connector(
+        [&]() { (void)client->connect("127.0.0.1", peer.port()); });
+
+    // The peer's injector swallows the first server SETTINGS write. Without
+    // server SETTINGS the client cannot complete the handshake; is_connected()
+    // never flips true and the peer's worker is blocked at the
+    // read-client-SETTINGS step (which is never sent). This drives the
+    // connect-timeout branch in http2_client::connect() that previously
+    // required an unreachable network condition.
+    EXPECT_FALSE(wait_for([&]() { return client->is_connected(); },
+                          std::chrono::milliseconds(300)));
+    EXPECT_FALSE(peer.settings_exchanged());
+
+    (void)client->disconnect();
+    connector.join();
+}
+
+TEST_F(Http2ClientHermeticTransportTest,
+       TruncatedServerSettingsHeaderTimesOutConnect)
+{
+    using namespace kcenon::network::tests::support;
+    injection_spec spec;
+    spec.mode = injection_mode::truncate;
+    spec.truncate_at = 4;  // partial 9-byte frame header → unparseable
+
+    mock_h2_server_peer peer(io(), reply_mode::drain_only, spec);
+
+    auto client = std::make_shared<http2::http2_client>("phase-2e-r2-truncate");
+    client->set_timeout(std::chrono::milliseconds(500));
+
+    std::thread connector(
+        [&]() { (void)client->connect("127.0.0.1", peer.port()); });
+
+    // The client receives 4 bytes (less than a complete 9-byte frame header)
+    // and waits indefinitely for the remaining 5 bytes. This drives the
+    // partial-header / read-loop short-read branch in http2_client.cpp that
+    // a well-formed peer never exercises. is_connected() stays false; the
+    // peer's worker is also stuck at the read-client-SETTINGS step.
+    EXPECT_FALSE(wait_for([&]() { return client->is_connected(); },
+                          std::chrono::milliseconds(300)));
+
+    (void)client->disconnect();
+    connector.join();
+}
+
+TEST_F(Http2ClientHermeticTransportTest,
+       MalformedServerSettingsTypeByteTriggersConnectTimeout)
+{
+    using namespace kcenon::network::tests::support;
+    injection_spec spec;
+    spec.mode = injection_mode::malform;
+    spec.malform_offset = 3;     // type byte of an HTTP/2 frame header
+    spec.malform_xor = 0x0F;     // 0x04 (SETTINGS) -> 0x0B (unknown)
+
+    mock_h2_server_peer peer(io(), reply_mode::drain_only, spec);
+
+    auto client = std::make_shared<http2::http2_client>(
+        "phase-2e-r2-malform-type");
+    client->set_timeout(std::chrono::milliseconds(500));
+
+    std::thread connector(
+        [&]() { (void)client->connect("127.0.0.1", peer.port()); });
+
+    // The first server-originated frame arrives with type byte = 0x0B,
+    // which the client cannot dispatch as SETTINGS. Per RFC 7540 §5.5 the
+    // client must ignore unknown frame types, so it discards the frame
+    // and waits for actual SETTINGS that never arrive. is_connected()
+    // stays false; this exercises the unknown-type dispatch branch in
+    // http2_client::process_frame() distinct from the partial-header path
+    // covered by TruncatedServerSettingsHeaderTimesOutConnect above.
+    EXPECT_FALSE(wait_for([&]() { return client->is_connected(); },
+                          std::chrono::milliseconds(300)));
+
+    (void)client->disconnect();
+    connector.join();
+}
+
+TEST_F(Http2ClientHermeticTransportTest,
+       MalformedServerSettingsStreamIdNonZeroIsProtocolError)
+{
+    using namespace kcenon::network::tests::support;
+    injection_spec spec;
+    spec.mode = injection_mode::malform;
+    spec.malform_offset = 8;     // last byte of stream_id (header offsets 5-8)
+    spec.malform_xor = 0x01;     // flips low bit: stream_id 0 -> 1
+
+    mock_h2_server_peer peer(io(), reply_mode::drain_only, spec);
+
+    auto client = std::make_shared<http2::http2_client>(
+        "phase-2e-r2-malform-sid");
+    client->set_timeout(std::chrono::milliseconds(500));
+
+    std::thread connector(
+        [&]() { (void)client->connect("127.0.0.1", peer.port()); });
+
+    // RFC 7540 §6.5: a SETTINGS frame whose stream identifier is non-zero
+    // MUST be treated as a connection error of type PROTOCOL_ERROR. Even
+    // a lenient implementation will not flip is_connected() to true on a
+    // SETTINGS frame received on stream 1 because the SETTINGS exchange
+    // has not been validated. This drives the stream-id validation branch
+    // in handle_settings_frame that handle_data_frame / handle_headers_frame
+    // do not exercise.
+    EXPECT_FALSE(wait_for([&]() { return client->is_connected(); },
+                          std::chrono::milliseconds(300)));
+
+    (void)client->disconnect();
+    connector.join();
+}
+
+TEST_F(Http2ClientHermeticTransportTest,
+       SlowWriteServerSettingsStillCompletesHandshake)
+{
+    using namespace kcenon::network::tests::support;
+    injection_spec spec;
+    spec.mode = injection_mode::slow_write;
+    spec.slow_step = std::chrono::microseconds(500);
+
+    mock_h2_server_peer peer(io(), reply_mode::drain_only, spec);
+
+    auto client = std::make_shared<http2::http2_client>("phase-2e-r2-slow");
+    client->set_timeout(std::chrono::seconds(2));
+
+    std::thread connector(
+        [&]() { (void)client->connect("127.0.0.1", peer.port()); });
+
+    // Each of the 9 bytes of server SETTINGS arrives 500 microseconds apart,
+    // so the full frame transmission takes ~4.5 ms. The handshake completes
+    // because slow_write does not corrupt the bytes — it only paces them.
+    // This drives the partial-read / accumulating-buffer branch in
+    // http2_client's frame-reader that a single-shot write does not exercise:
+    // the read callback is invoked multiple times before a complete header
+    // is in the buffer. Use a generous wait budget because SETTINGS-ACK
+    // is also paced byte-by-byte.
+    EXPECT_TRUE(wait_for([&]() { return peer.settings_exchanged(); },
+                         std::chrono::seconds(3)));
+    EXPECT_FALSE(peer.io_failed());
+    EXPECT_TRUE(client->is_connected());
+
+    (void)client->disconnect();
+    connector.join();
+}
+
+TEST_F(Http2ClientHermeticTransportTest,
+       EchoOneTruncateAtNineDropsResponsePayloadFailingGet)
+{
+    using namespace kcenon::network::tests::support;
+    injection_spec spec;
+    spec.mode = injection_mode::truncate;
+    spec.truncate_at = 9;  // empty SETTINGS frames are exactly 9 bytes (no-op)
+                           // longer response HEADERS + DATA frames lose their
+                           // payloads, leaving headers-only on the wire.
+
+    mock_h2_server_peer peer(io(), reply_mode::echo_one, spec);
+    auto setup = make_connected_client(peer, "phase-2e-r2-trunc-resp",
+                                       std::chrono::milliseconds(500));
+
+    // SETTINGS exchange completes because empty SETTINGS frames are exactly
+    // 9 bytes total and truncate_at = 9 keeps the entire buffer. The client
+    // therefore reaches the connected state.
+    EXPECT_TRUE(wait_for([&]() { return peer.settings_exchanged(); },
+                         std::chrono::seconds(3)));
+    EXPECT_TRUE(setup.client->is_connected());
+
+    // The peer's response HEADERS frame is 10 bytes (9-byte header +
+    // 1-byte HPACK payload 0x88 = ":status: 200"); after truncate_at = 9
+    // only the header reaches the client. The DATA frame is similarly
+    // truncated to its 9-byte header. The client therefore reads a frame
+    // header that promises a 1-byte HPACK payload but receives the next
+    // frame's header bytes in its place, corrupting either the HPACK
+    // decoder state or the request-completion machinery. Either way the
+    // GET resolves as an error rather than a successful response,
+    // exercising the request-error / timeout branch on the connected
+    // path that the happy-path echo_one tests do not reach.
+    auto response = setup.client->get("/echo", {});
+    EXPECT_TRUE(response.is_err());
+
+    (void)setup.client->disconnect();
+    setup.connector.join();
+}


### PR DESCRIPTION
## What

Round 2 of `http2_client.cpp` test-coverage expansion. Adds 6 new TEST_F
cases to `tests/unit/http2_client_branch_test.cpp` that compose
`mock_h2_server_peer` with the Phase 2E `frame_injector` (PR #1105) to
drive previously-unreachable error branches in
`src/protocols/http2/http2_client.cpp`.

### Change Type

- [x] Test only (no `src/` changes)
- [ ] Feature
- [ ] Bugfix

### Affected Components

| Path | Lines | Kind |
|---|---|---|
| `tests/unit/http2_client_branch_test.cpp` | +213 | 6 new TEST_F |

## Why

`http2_client.cpp` was at **18.8% line / 9.9% branch** on the 2026-05-06
develop measurement (run [25430202846](https://github.com/kcenon/network_system/actions/runs/25430202846)),
the single largest contributor to the gap between develop's 69.1% line
coverage and the 80% target tracked by epic #953. The Round 1 sub-issues
(#991, #1062) raised happy-path coverage but closed before the Phase 2E
substrate existed — so error-path branches that require deterministic
server-side frame faults remained unreachable.

PR #1105 (Phase 2E of #1074) shipped `frame_injector` and routed every
`mock_h2_server_peer` server-originated write through it. This PR is the
first consumer of that substrate against `http2_client.cpp`. The default
`injection_spec{}` produces `injection_mode::none`, so the 30+ existing
TEST_F call sites that do not supply a spec are unchanged.

## Who

- Reviewer: @kcenon
- Stakeholders: future Round 2 follow-ups for `grpc/client.cpp` (#1107)
  follow the same pattern this PR establishes.

## When

- Target release: rolling, no specific release.
- Dependencies: builds on Phase 2E (`frame_injector` + `mock_h2_server_peer`,
  PRs #1075, #1102, #1105 — all merged).
- Blocks: nothing else in flight. Unblocks future Round 2 sub-issues
  (#1107 for gRPC).

## Where

- Test-only scope. `src/` is not touched. No public-API change. No
  build-config change.
- The new TEST_F group sits inside the existing
  `Http2ClientHermeticTransportTest` fixture under a dedicated section
  header marked `Phase 2E.R2: frame_injector-driven error coverage`.

## How

### Per-test design

| TEST_F | injection_mode | Expected branch driven |
|---|---|---|
| `DropFirstServerSettingsLeavesClientUnconnected` | `drop` | connect-timeout branch in `connect()` |
| `TruncatedServerSettingsHeaderTimesOutConnect` | `truncate` (4 bytes) | short-read / partial-header in read loop |
| `MalformedServerSettingsTypeByteTriggersConnectTimeout` | `malform` (offset 3, XOR 0x0F) | `process_frame` unknown-type dispatch |
| `MalformedServerSettingsStreamIdNonZeroIsProtocolError` | `malform` (offset 8, XOR 0x01) | `handle_settings_frame` connection-level PROTOCOL_ERROR |
| `SlowWriteServerSettingsStillCompletesHandshake` | `slow_write` (500 us step) | accumulating-buffer / partial-read positive path |
| `EchoOneTruncateAtNineDropsResponsePayloadFailingGet` | `truncate` (9 bytes) + `reply_mode::echo_one` | request-error / timeout on connected path |

### Why these specific specs

The `frame_injector` applies one global spec to every server-originated
write a peer emits. There is no per-write granularity. Tests therefore
choose specs such that:

- **Faults that must land on the first frame** (drop / truncate / malform
  variants targeting the empty 9-byte SETTINGS frame) cause `is_connected()`
  to never flip true within the wait budget. The peer's worker is also
  blocked at the read-client-SETTINGS step because the client does not
  send its SETTINGS until it has parsed valid server SETTINGS.

- **`truncate_at = 9`** is a no-op for empty-payload SETTINGS frames
  (which are exactly 9 bytes total) but truncates response HEADERS and
  DATA frames in `reply_mode::echo_one` (which are 10 + 11 bytes
  respectively, header + payload). This is how the test reaches a
  *connected* state and still observes a request-level error.

- **`slow_write` is a positive test** verifying that pacing bytes
  500 us apart still completes the handshake; this drives the
  accumulating-buffer branch that single-shot writes do not exercise.

### Local verification

| Build | Result |
|---|---|
| `network_test_support` library | Clean |
| `network_http2_client_branch_test` target | Clean |

Test execution on macOS Apple Silicon (this machine): 4/6 new tests pass.
The 2 tests with positive `is_connected()` assertions
(`SlowWriteServerSettingsStillCompletesHandshake`,
`EchoOneTruncateAtNineDropsResponsePayloadFailingGet`) fail with the same
symptom as the unmodified `ConnectCompletesSettingsExchangeWithMockPeer`
test from develop tip — `peer.settings_exchanged()` does not flip true
within the wait budget. This is the same pre-existing local-environment
hermetic instability documented during the PR #1105 review and is not
introduced by this PR (verified via A/B run of the unmodified baseline
test, which also fails on this machine).

CI on Linux + GitHub macOS runners is the authoritative verification
surface for these positive-path assertions.

### Test plan for reviewers

```bash
cmake --build build --target network_http2_client_branch_test -j 4
./build/bin/network_http2_client_branch_test \
  --gtest_filter="Http2ClientHermeticTransportTest.DropFirstServerSettings*:Http2ClientHermeticTransportTest.TruncatedServerSettings*:Http2ClientHermeticTransportTest.MalformedServerSettings*:Http2ClientHermeticTransportTest.SlowWriteServerSettings*:Http2ClientHermeticTransportTest.EchoOneTruncateAtNine*"
# CI expectation: all 6 PASS
```

### Acceptance follow-up (#1106)

The acceptance criteria of #1106 include a coverage-uplift target
(line >= 60%, branch >= 40% on `http2_client.cpp`). Coverage is measured
post-merge by the Code Coverage workflow on develop. This PR's CI will
verify the test correctness; the coverage delta will appear on the
next develop coverage run after merge.

### Breaking changes

None.

### Rollback plan

Revert this PR. Only `tests/unit/http2_client_branch_test.cpp` is
affected; existing tests are unchanged.

## Related

- Closes #1106
- Part of #953 (Round 2 of test-coverage epic)
- Substrate provided by: PR #1105 (Phase 2E of #1074, merged 2026-05-06)

## Checklist

- [x] Code follows existing `tests/unit/http2_client_branch_test.cpp` style
- [x] Self-review completed
- [x] New tests added (6 TEST_F)
- [x] No `src/` changes
- [x] No sensitive data exposed
- [x] Commits are atomic and well-described
- [x] Related issue linked (Closes #1106, Part of #953)
