### PR TITLE
test(quic): expand quic_socket.cpp dispatcher coverage (Round 1)

### DIFF
--- a/src/internal/quic_socket.h
+++ b/src/internal/quic_socket.h
@@ -21,6 +21,13 @@
 #include "internal/protocols/quic/packet.h"
 #include "kcenon/network/detail/utils/result_types.h"
 
+#if defined(NETWORK_ENABLE_TEST_INJECTION)
+namespace kcenon::network::tests::support
+{
+    class quic_socket_test_access;
+} // namespace kcenon::network::tests::support
+#endif
+
 namespace kcenon::network::internal
 {
 	/*!
@@ -478,6 +485,17 @@ namespace kcenon::network::internal
 
 		//! Mutex for state protection
 		mutable std::mutex state_mutex_;
+
+#if defined(NETWORK_ENABLE_TEST_INJECTION)
+		// Test-only: grants tests/support/quic_socket_test_access access to
+		// the private dispatcher entry points (process_frame, process_*_frame,
+		// determine_encryption_level, queue_crypto_data, transition_state,
+		// send_pending_packets, on_retransmit_timeout) and selected state
+		// members so tests/unit/quic_socket_dispatcher_branch_test.cpp can
+		// drive frame-dispatch branches without a live UDP peer + TLS-1.3
+		// handshake (Issue #1122).
+		friend class kcenon::network::tests::support::quic_socket_test_access;
+#endif
 	};
 
 } // namespace kcenon::network::internal

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5078,6 +5078,36 @@ add_network_test(network_quic_socket_branch_test
                  unit/quic_socket_branch_test.cpp)
 target_link_libraries(network_quic_socket_branch_test PRIVATE network::test_support)
 
+# QUIC socket dispatcher branch coverage (Issue #1122, Round 1 of #953):
+# Direct-dispatch tests for process_frame variant arms (padding, ping, ack,
+# stream, connection_close, handshake_done, plus the implicit fall-through
+# arm covering the 13 unhandled variants), process_stream_frame callback-
+# set + callback-empty branches, process_connection_close_frame callback-
+# set + callback-empty branches and the resulting draining-state
+# transition, process_handshake_done_frame client-when-incomplete +
+# client-when-already-complete short-circuit + server-role ignore branch,
+# process_ack_frame placeholder no-op invocation, queue_crypto_data
+# single-payload + multiple-payload + larger-payload append paths,
+# send_pending_packets early-return on idle / closed states + populated-
+# queue dispatch, determine_encryption_level for every long-header
+# packet_type (initial / zero_rtt / handshake / retry-default-fallthrough)
+# and short-header (application), transition_state walking every reachable
+# state, on_retransmit_timeout drives send_pending_packets, and
+# process_crypto_frame TLS-uninitialized error-path early-return. Mirrors
+# the strategy of Issue #1115 (http2_client) / #1119 (http2_client
+# dispatcher) / #1121 (http2_server dispatcher) by invoking
+# quic_socket::process_frame() and its private peers directly through the
+# tests::support::quic_socket_test_access friend class. The friend gate
+# NETWORK_ENABLE_TEST_INJECTION is defined PUBLIC on the network_system
+# target when BUILD_TESTS=ON (see cmake/network_system_targets.cmake), so
+# the macro propagates here transitively — no per-target definition is
+# required. The production header src/internal/quic_socket.h befriends
+# tests::support::quic_socket_test_access under the same gate.
+add_network_test(network_quic_socket_dispatcher_branch_test
+                 unit/quic_socket_dispatcher_branch_test.cpp)
+target_link_libraries(network_quic_socket_dispatcher_branch_test
+                      PRIVATE network::test_support)
+
 # QUIC server branch coverage: quic_server_config full-field round-trip
 # (cert/key/ca paths, ALPN vector, all numeric settings at zero/max
 # boundaries, retry_key vector, full-config copy round-trip), construction

--- a/tests/support/network_test_friends.h
+++ b/tests/support/network_test_friends.h
@@ -20,4 +20,5 @@ class quic_server_probe;
 class ws_server_probe;
 class http2_client_test_access;
 class http2_server_test_access;
+class quic_socket_test_access;
 } // namespace kcenon::network::tests::support

--- a/tests/support/quic_socket_test_access.h
+++ b/tests/support/quic_socket_test_access.h
@@ -1,0 +1,283 @@
+// BSD 3-Clause License
+// Copyright (c) 2026, kcenon
+// See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+/**
+ * @file quic_socket_test_access.h
+ * @brief Friend-accessor for hermetic dispatcher coverage of
+ *        src/internal/quic_socket.cpp (Issue #1122).
+ *
+ * Reuses the existing Phase 2D friend gate @c NETWORK_ENABLE_TEST_INJECTION
+ * (defined PUBLIC on @c network_system when @c BUILD_TESTS=ON, see
+ * @c cmake/network_system_targets.cmake). Production builds with
+ * @c BUILD_TESTS=OFF compile byte-identical because the macro is undefined
+ * and the friend declaration / forward declaration in
+ * @c src/internal/quic_socket.h are gated by
+ * @c #if defined(NETWORK_ENABLE_TEST_INJECTION).
+ *
+ * Mirrors @c http2_server_test_access.h (Round 3 / Issue #1121). The
+ * @c quic_socket dispatcher (process_frame, process_crypto_frame,
+ * process_stream_frame, process_ack_frame, process_connection_close_frame,
+ * process_handshake_done_frame), the encryption-level resolver
+ * (determine_encryption_level), the state transitioner (transition_state),
+ * the crypto-data queuer (queue_crypto_data), the pending-packet flusher
+ * (send_pending_packets) and the retransmit-timeout handler
+ * (on_retransmit_timeout) cannot be reached hermetically from the public
+ * API: doing so requires a live UDP peer that speaks the QUIC wire format
+ * end-to-end through a real TLS 1.3 handshake. Direct invocation via this
+ * access class sidesteps the wire path entirely while still routing
+ * through the production dispatcher logic.
+ *
+ * Round 1 of #1122: covers
+ *  - process_frame: every alternative arm of the @c protocols::quic::frame
+ *    variant (crypto, stream, ack, connection_close, handshake_done, ping,
+ *    padding, plus the implicit fall-through for the 13 other unhandled
+ *    variants).
+ *  - process_stream_frame: callback-set + callback-empty branches.
+ *  - process_connection_close_frame: callback-set + callback-empty
+ *    branches, and the resulting state transition to draining.
+ *  - process_handshake_done_frame: client + server role branches and the
+ *    handshake-already-complete short-circuit.
+ *  - process_ack_frame: placeholder no-op invocation for coverage.
+ *  - send_pending_packets: closed/idle early-return branch and the
+ *    populated-state path that flushes queued data.
+ *  - queue_crypto_data: append path with single + multiple + max-size
+ *    payloads.
+ *  - determine_encryption_level: every long-header packet_type branch
+ *    (initial, zero_rtt, handshake, default fall-through) and the
+ *    short-header (application) branch.
+ *  - transition_state: drives the state machine through every reachable
+ *    transition without a peer, exercising the atomic store and ensuring
+ *    state() observes the new value.
+ */
+
+#include "internal/quic_socket.h"
+#include "internal/protocols/quic/frame.h"
+#include "internal/protocols/quic/frame_types.h"
+#include "internal/protocols/quic/keys.h"
+#include "internal/protocols/quic/packet.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <span>
+#include <utility>
+#include <vector>
+
+namespace kcenon::network::tests::support
+{
+
+/**
+ * @brief Test-only friend class exposing private dispatcher entry points
+ *        of @ref kcenon::network::internal::quic_socket.
+ *
+ * Forward-declared in @c tests/support/network_test_friends.h alongside
+ * @c http2_client_test_access and @c http2_server_test_access. The
+ * production header @c src/internal/quic_socket.h forward-declares this
+ * class under @c #if defined(NETWORK_ENABLE_TEST_INJECTION) and grants
+ * friendship.
+ *
+ * Each static thunk is a pure forwarding call to a private member of
+ * @c quic_socket. The class itself holds no state.
+ */
+class quic_socket_test_access
+{
+public:
+    using quic_socket = ::kcenon::network::internal::quic_socket;
+    using quic_connection_state =
+        ::kcenon::network::internal::quic_connection_state;
+    using frame = ::kcenon::network::protocols::quic::frame;
+    using crypto_frame = ::kcenon::network::protocols::quic::crypto_frame;
+    using stream_frame = ::kcenon::network::protocols::quic::stream_frame;
+    using ack_frame = ::kcenon::network::protocols::quic::ack_frame;
+    using connection_close_frame =
+        ::kcenon::network::protocols::quic::connection_close_frame;
+    using packet_header =
+        ::kcenon::network::protocols::quic::packet_header;
+    using long_header =
+        ::kcenon::network::protocols::quic::long_header;
+    using short_header =
+        ::kcenon::network::protocols::quic::short_header;
+    using encryption_level =
+        ::kcenon::network::protocols::quic::encryption_level;
+
+    // ------------------------------------------------------------------
+    // Dispatcher
+    // ------------------------------------------------------------------
+
+    /**
+     * @brief Direct invocation of @c quic_socket::process_frame.
+     *
+     * Bypasses the do_receive / handle_packet read path so frame-dispatch
+     * branches can be measured under coverage instrumentation without a
+     * live UDP peer. The dispatch arm and per-handler body coverage is
+     * collected regardless of socket connectivity state.
+     */
+    static auto process_frame(quic_socket& s, const frame& f) -> void
+    {
+        s.process_frame(f);
+    }
+
+    /**
+     * @brief Direct invocation of @c quic_socket::process_crypto_frame.
+     */
+    static auto process_crypto_frame(quic_socket& s, const crypto_frame& f)
+        -> void
+    {
+        s.process_crypto_frame(f);
+    }
+
+    /**
+     * @brief Direct invocation of @c quic_socket::process_stream_frame.
+     */
+    static auto process_stream_frame(quic_socket& s, const stream_frame& f)
+        -> void
+    {
+        s.process_stream_frame(f);
+    }
+
+    /**
+     * @brief Direct invocation of @c quic_socket::process_ack_frame.
+     */
+    static auto process_ack_frame(quic_socket& s, const ack_frame& f) -> void
+    {
+        s.process_ack_frame(f);
+    }
+
+    /**
+     * @brief Direct invocation of
+     *        @c quic_socket::process_connection_close_frame.
+     */
+    static auto process_connection_close_frame(
+        quic_socket& s, const connection_close_frame& f) -> void
+    {
+        s.process_connection_close_frame(f);
+    }
+
+    /**
+     * @brief Direct invocation of
+     *        @c quic_socket::process_handshake_done_frame.
+     */
+    static auto process_handshake_done_frame(quic_socket& s) -> void
+    {
+        s.process_handshake_done_frame();
+    }
+
+    /**
+     * @brief Direct invocation of @c quic_socket::send_pending_packets.
+     *
+     * Used to drive the early-return branch (state == closed/idle) and
+     * the populated-state happy-path branch where queued crypto/stream
+     * data triggers send_packet().
+     */
+    static auto send_pending_packets(quic_socket& s) -> void
+    {
+        s.send_pending_packets();
+    }
+
+    /**
+     * @brief Direct invocation of @c quic_socket::queue_crypto_data.
+     */
+    static auto queue_crypto_data(
+        quic_socket& s, std::vector<uint8_t> data) -> void
+    {
+        s.queue_crypto_data(std::move(data));
+    }
+
+    /**
+     * @brief Direct invocation of
+     *        @c quic_socket::determine_encryption_level.
+     */
+    static auto determine_encryption_level(
+        const quic_socket& s, const packet_header& header) noexcept
+        -> encryption_level
+    {
+        return s.determine_encryption_level(header);
+    }
+
+    /**
+     * @brief Direct invocation of @c quic_socket::transition_state.
+     */
+    static auto transition_state(
+        quic_socket& s, quic_connection_state new_state) -> void
+    {
+        s.transition_state(new_state);
+    }
+
+    /**
+     * @brief Direct invocation of @c quic_socket::on_retransmit_timeout.
+     */
+    static auto on_retransmit_timeout(quic_socket& s) -> void
+    {
+        s.on_retransmit_timeout();
+    }
+
+    // ------------------------------------------------------------------
+    // State observers (private member reads)
+    // ------------------------------------------------------------------
+
+    /**
+     * @brief Read the size of the pending CRYPTO data queue at @p level.
+     *
+     * Used by queue_crypto_data tests to assert append behavior, and by
+     * send_pending_packets tests to verify the queue is drained on the
+     * happy path.
+     */
+    static auto pending_crypto_data_size(
+        const quic_socket& s, encryption_level level) noexcept -> std::size_t
+    {
+        const auto idx = static_cast<std::size_t>(level);
+        return s.pending_crypto_data_[idx].size();
+    }
+
+    /**
+     * @brief Read the size of the pending STREAM data queue for
+     *        @p stream_id, returning 0 when the stream is unknown.
+     */
+    static auto pending_stream_data_size(
+        const quic_socket& s, std::uint64_t stream_id) -> std::size_t
+    {
+        std::lock_guard<std::mutex> lock(s.state_mutex_);
+        auto it = s.pending_stream_data_.find(stream_id);
+        if (it == s.pending_stream_data_.end()) {
+            return 0;
+        }
+        return it->second.size();
+    }
+
+    /**
+     * @brief Force the @c handshake_complete_ atomic flag.
+     *
+     * Used to exercise the @c process_handshake_done_frame
+     * "already-complete" short-circuit branch which would otherwise
+     * require a peer-driven handshake to reach.
+     */
+    static auto set_handshake_complete(
+        quic_socket& s, bool value) noexcept -> void
+    {
+        s.handshake_complete_.store(value);
+    }
+
+    /**
+     * @brief Read the @c handshake_complete_ flag without going through
+     *        @c is_handshake_complete() (kept as a separate accessor for
+     *        symmetry with @c http2_server_test_access::is_alive).
+     */
+    static auto handshake_complete(const quic_socket& s) noexcept -> bool
+    {
+        return s.handshake_complete_.load();
+    }
+
+    /**
+     * @brief Read the connection state without going through @c state().
+     */
+    static auto state(const quic_socket& s) noexcept
+        -> quic_connection_state
+    {
+        return s.state_.load();
+    }
+};
+
+} // namespace kcenon::network::tests::support

--- a/tests/unit/quic_socket_dispatcher_branch_test.cpp
+++ b/tests/unit/quic_socket_dispatcher_branch_test.cpp
@@ -1,0 +1,679 @@
+// BSD 3-Clause License
+// Copyright (c) 2026, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file quic_socket_dispatcher_branch_test.cpp
+ * @brief Direct-dispatch branch coverage for src/internal/quic_socket.cpp
+ *        (Issue #1122, Round 1 of #953).
+ *
+ * Mirrors the strategy of @ref http2_server_dispatcher_branch_test.cpp
+ * Round 3 / #1121: invokes the private @c quic_socket::process_frame and
+ * its per-handler private members directly via the
+ * @c quic_socket_test_access friend, sidestepping the wire path that
+ * would otherwise require a live UDP peer plus a complete TLS 1.3
+ * handshake to reach.
+ *
+ * Coverage targets per handler:
+ *  - process_frame: every alternative arm of the protocols::quic::frame
+ *    variant that the dispatcher inspects (crypto, stream, ack,
+ *    connection_close, handshake_done, ping, padding) plus the implicit
+ *    fall-through arm covering the 13 unhandled variants.
+ *  - process_stream_frame: callback-set + callback-empty branches.
+ *  - process_connection_close_frame: callback-set + callback-empty
+ *    branches; resulting state transition to draining.
+ *  - process_handshake_done_frame: client + server role branches and the
+ *    handshake-already-complete short-circuit.
+ *  - process_ack_frame: placeholder no-op invocation for coverage.
+ *  - send_pending_packets: closed/idle early-return branch (state guard)
+ *    and the populated-state path that flushes queued data even when no
+ *    write keys are available (graceful failure of send_packet).
+ *  - queue_crypto_data: append path with single + multiple + larger
+ *    payloads, current_level()-driven indexing.
+ *  - determine_encryption_level: every long-header packet_type branch
+ *    (initial, zero_rtt, handshake, default fall-through) and the
+ *    short-header (application) branch.
+ *  - transition_state: drives the state machine through every reachable
+ *    transition without a peer, exercising the atomic store and ensuring
+ *    state() observes the new value.
+ *
+ * State preconditions: the socket is constructed on a UDP socket bound to
+ * an ephemeral port with no peer. Most tests assert callback observations
+ * rather than network state — the wire path is intentionally unreachable
+ * here.
+ */
+
+#include "internal/quic_socket.h"
+#include "internal/protocols/quic/frame.h"
+#include "internal/protocols/quic/frame_types.h"
+#include "internal/protocols/quic/keys.h"
+#include "internal/protocols/quic/packet.h"
+
+#include "quic_socket_test_access.h"
+
+#include <gtest/gtest.h>
+
+#include <asio.hpp>
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace internal_ns = kcenon::network::internal;
+namespace quic_proto = kcenon::network::protocols::quic;
+namespace test_support = kcenon::network::tests::support;
+
+using test_access = test_support::quic_socket_test_access;
+
+namespace
+{
+
+// Helper to construct a fresh quic_socket bound to v4 ephemeral.
+std::shared_ptr<internal_ns::quic_socket> make_quic(
+    asio::io_context& io,
+    internal_ns::quic_role role)
+{
+    asio::ip::udp::socket sock(io, asio::ip::udp::v4());
+    return std::make_shared<internal_ns::quic_socket>(
+        std::move(sock), role);
+}
+
+} // namespace
+
+class QuicSocketDispatcherBranchTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        io_ = std::make_unique<asio::io_context>();
+    }
+
+    void TearDown() override
+    {
+        if (io_)
+        {
+            io_->stop();
+            io_.reset();
+        }
+    }
+
+    std::unique_ptr<asio::io_context> io_;
+};
+
+// ============================================================================
+// process_frame: variant arm coverage
+// ============================================================================
+
+TEST_F(QuicSocketDispatcherBranchTest, ProcessFrameDispatchesPaddingArm)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    quic_proto::frame f = quic_proto::padding_frame{};
+    test_access::process_frame(*q, f);
+
+    // No observable side effect for padding — coverage of the dispatch
+    // arm is the assertion.
+    EXPECT_EQ(test_access::state(*q),
+              internal_ns::quic_connection_state::idle);
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, ProcessFrameDispatchesPingArm)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    quic_proto::frame f = quic_proto::ping_frame{};
+    test_access::process_frame(*q, f);
+
+    // PING frames don't transition state by themselves — they will be
+    // ACKed with the next outgoing packet which is not driven here.
+    EXPECT_EQ(test_access::state(*q),
+              internal_ns::quic_connection_state::idle);
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, ProcessFrameDispatchesAckArm)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    quic_proto::ack_frame ack{};
+    ack.largest_acknowledged = 5;
+    ack.ack_delay = 100;
+
+    quic_proto::frame f = ack;
+    test_access::process_frame(*q, f);
+
+    // process_ack_frame is a placeholder no-op; coverage of the dispatch
+    // arm is the assertion.
+    SUCCEED();
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, ProcessFrameDispatchesStreamArm)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    std::atomic<bool> got_callback{false};
+    std::atomic<std::uint64_t> received_stream_id{0};
+    std::atomic<bool> received_fin{false};
+    q->set_stream_data_callback(
+        [&](std::uint64_t sid, std::span<const std::uint8_t>, bool fin) {
+            received_stream_id.store(sid);
+            received_fin.store(fin);
+            got_callback.store(true);
+        });
+
+    quic_proto::stream_frame sf{};
+    sf.stream_id = 4;
+    sf.data = {0xde, 0xad, 0xbe, 0xef};
+    sf.fin = true;
+
+    quic_proto::frame f = sf;
+    test_access::process_frame(*q, f);
+
+    EXPECT_TRUE(got_callback.load());
+    EXPECT_EQ(received_stream_id.load(), 4u);
+    EXPECT_TRUE(received_fin.load());
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, ProcessFrameDispatchesConnectionCloseArm)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    std::atomic<bool> got_close{false};
+    std::atomic<std::uint64_t> received_code{0};
+    q->set_close_callback(
+        [&](std::uint64_t code, const std::string&) {
+            received_code.store(code);
+            got_close.store(true);
+        });
+
+    quic_proto::connection_close_frame cc{};
+    cc.error_code = 0x7;
+    cc.reason_phrase = "test";
+    cc.is_application_error = false;
+
+    quic_proto::frame f = cc;
+    test_access::process_frame(*q, f);
+
+    EXPECT_TRUE(got_close.load());
+    EXPECT_EQ(received_code.load(), 0x7u);
+    EXPECT_EQ(test_access::state(*q),
+              internal_ns::quic_connection_state::draining);
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, ProcessFrameDispatchesHandshakeDoneArm)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    quic_proto::frame f = quic_proto::handshake_done_frame{};
+    test_access::process_frame(*q, f);
+
+    // Client-side HANDSHAKE_DONE flips handshake_complete_ true and
+    // transitions state to connected.
+    EXPECT_TRUE(test_access::handshake_complete(*q));
+    EXPECT_EQ(test_access::state(*q),
+              internal_ns::quic_connection_state::connected);
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, ProcessFrameDefaultFallthroughForUnhandledVariant)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    // max_streams_frame is one of the 13 variants the dispatcher does
+    // not inspect — falls through the if/else-if chain with no side
+    // effect. Drives the implicit fall-through arm.
+    quic_proto::max_streams_frame ms{};
+    ms.bidirectional = true;
+    ms.maximum_streams = 100;
+
+    quic_proto::frame f = ms;
+    test_access::process_frame(*q, f);
+
+    // No observable side effect — coverage of the fall-through is the
+    // assertion.
+    EXPECT_EQ(test_access::state(*q),
+              internal_ns::quic_connection_state::idle);
+}
+
+// ============================================================================
+// process_stream_frame: callback-set + callback-empty branches
+// ============================================================================
+
+TEST_F(QuicSocketDispatcherBranchTest, ProcessStreamFrameWithEmptyCallback)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    // No callback set — exercises the empty-function branch.
+    quic_proto::stream_frame sf{};
+    sf.stream_id = 1;
+    sf.data = {1, 2, 3};
+    sf.fin = false;
+
+    test_access::process_stream_frame(*q, sf);
+
+    SUCCEED();
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, ProcessStreamFrameWithCallbackSet)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    std::atomic<int> invocation_count{0};
+    std::atomic<std::uint64_t> last_stream_id{0};
+    q->set_stream_data_callback(
+        [&](std::uint64_t sid, std::span<const std::uint8_t>, bool) {
+            invocation_count.fetch_add(1);
+            last_stream_id.store(sid);
+        });
+
+    for (std::uint64_t sid : {std::uint64_t{1}, std::uint64_t{5},
+                               std::uint64_t{9}})
+    {
+        quic_proto::stream_frame sf{};
+        sf.stream_id = sid;
+        sf.data = {0xa, 0xb};
+        sf.fin = false;
+        test_access::process_stream_frame(*q, sf);
+    }
+
+    EXPECT_EQ(invocation_count.load(), 3);
+    EXPECT_EQ(last_stream_id.load(), 9u);
+}
+
+// ============================================================================
+// process_ack_frame: placeholder no-op invocation
+// ============================================================================
+
+TEST_F(QuicSocketDispatcherBranchTest, ProcessAckFramePlaceholderNoOp)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    quic_proto::ack_frame ack{};
+    ack.largest_acknowledged = 42;
+    ack.ack_delay = 250;
+    ack.ranges.push_back({0, 3});
+
+    test_access::process_ack_frame(*q, ack);
+
+    // Placeholder — no side effect.
+    EXPECT_EQ(test_access::state(*q),
+              internal_ns::quic_connection_state::idle);
+}
+
+// ============================================================================
+// process_connection_close_frame: callback-set + callback-empty branches
+// ============================================================================
+
+TEST_F(QuicSocketDispatcherBranchTest, ProcessConnectionCloseFrameWithEmptyCallback)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    // No callback — exercises the empty-function branch in the close
+    // handler. The state still transitions to draining and the idle
+    // timer is started.
+    quic_proto::connection_close_frame cc{};
+    cc.error_code = 0;
+    cc.reason_phrase = "";
+
+    test_access::process_connection_close_frame(*q, cc);
+
+    EXPECT_EQ(test_access::state(*q),
+              internal_ns::quic_connection_state::draining);
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, ProcessConnectionCloseFrameWithApplicationError)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    std::atomic<std::uint64_t> received_code{0};
+    std::atomic<bool> reason_seen{false};
+    q->set_close_callback(
+        [&](std::uint64_t code, const std::string& r) {
+            received_code.store(code);
+            reason_seen.store(!r.empty());
+        });
+
+    quic_proto::connection_close_frame cc{};
+    cc.error_code = 0x100;
+    cc.reason_phrase = "application error";
+    cc.is_application_error = true;
+
+    test_access::process_connection_close_frame(*q, cc);
+
+    EXPECT_EQ(received_code.load(), 0x100u);
+    EXPECT_TRUE(reason_seen.load());
+    EXPECT_EQ(test_access::state(*q),
+              internal_ns::quic_connection_state::draining);
+}
+
+// ============================================================================
+// process_handshake_done_frame: client + server role branches and the
+// handshake-already-complete short-circuit
+// ============================================================================
+
+TEST_F(QuicSocketDispatcherBranchTest, ProcessHandshakeDoneFrameOnClientWhenIncomplete)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    std::atomic<int> connected_calls{0};
+    q->set_connected_callback([&]() { connected_calls.fetch_add(1); });
+
+    EXPECT_FALSE(test_access::handshake_complete(*q));
+
+    test_access::process_handshake_done_frame(*q);
+
+    EXPECT_TRUE(test_access::handshake_complete(*q));
+    EXPECT_EQ(test_access::state(*q),
+              internal_ns::quic_connection_state::connected);
+    EXPECT_EQ(connected_calls.load(), 1);
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, ProcessHandshakeDoneFrameOnClientWhenAlreadyComplete)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    // Pre-set handshake_complete_ to true — drives the
+    // !handshake_complete_.load() short-circuit branch.
+    test_access::set_handshake_complete(*q, true);
+
+    std::atomic<int> connected_calls{0};
+    q->set_connected_callback([&]() { connected_calls.fetch_add(1); });
+
+    test_access::process_handshake_done_frame(*q);
+
+    // No transition / no callback when handshake already complete.
+    EXPECT_EQ(connected_calls.load(), 0);
+    // State should still be idle since we never transitioned earlier.
+    EXPECT_EQ(test_access::state(*q),
+              internal_ns::quic_connection_state::idle);
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, ProcessHandshakeDoneFrameOnServerIsIgnored)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::server);
+
+    std::atomic<int> connected_calls{0};
+    q->set_connected_callback([&]() { connected_calls.fetch_add(1); });
+
+    test_access::process_handshake_done_frame(*q);
+
+    // Server-side is the !=client branch — no transition / no callback.
+    EXPECT_FALSE(test_access::handshake_complete(*q));
+    EXPECT_EQ(connected_calls.load(), 0);
+    EXPECT_EQ(test_access::state(*q),
+              internal_ns::quic_connection_state::idle);
+}
+
+// ============================================================================
+// queue_crypto_data: append path
+// ============================================================================
+
+TEST_F(QuicSocketDispatcherBranchTest, QueueCryptoDataSinglePayload)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    // current_level() defaults to initial when crypto is uninitialized.
+    EXPECT_EQ(test_access::pending_crypto_data_size(
+                  *q, quic_proto::encryption_level::initial),
+              0u);
+
+    test_access::queue_crypto_data(*q, std::vector<std::uint8_t>{1, 2, 3});
+
+    EXPECT_EQ(test_access::pending_crypto_data_size(
+                  *q, quic_proto::encryption_level::initial),
+              1u);
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, QueueCryptoDataMultiplePayloads)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    for (int i = 0; i < 5; ++i)
+    {
+        test_access::queue_crypto_data(
+            *q, std::vector<std::uint8_t>(static_cast<std::size_t>(i + 1),
+                                           static_cast<std::uint8_t>(i)));
+    }
+
+    EXPECT_EQ(test_access::pending_crypto_data_size(
+                  *q, quic_proto::encryption_level::initial),
+              5u);
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, QueueCryptoDataLargePayload)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    constexpr std::size_t kSize = 4096;
+    test_access::queue_crypto_data(
+        *q, std::vector<std::uint8_t>(kSize, 0xAB));
+
+    EXPECT_EQ(test_access::pending_crypto_data_size(
+                  *q, quic_proto::encryption_level::initial),
+              1u);
+}
+
+// ============================================================================
+// send_pending_packets: state-guard branches
+// ============================================================================
+
+TEST_F(QuicSocketDispatcherBranchTest, SendPendingPacketsEarlyReturnOnIdleState)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    // Default state == idle — drives the early-return branch.
+    test_access::send_pending_packets(*q);
+
+    SUCCEED();
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, SendPendingPacketsEarlyReturnOnClosedState)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    // Force state to closed — drives the second early-return condition.
+    test_access::transition_state(
+        *q, internal_ns::quic_connection_state::closed);
+
+    test_access::send_pending_packets(*q);
+
+    SUCCEED();
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, SendPendingPacketsWithQueuedCryptoDataNonIdle)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    // Queue some crypto data so the populated-state path has work to do.
+    test_access::queue_crypto_data(
+        *q, std::vector<std::uint8_t>{0x10, 0x20});
+    EXPECT_EQ(test_access::pending_crypto_data_size(
+                  *q, quic_proto::encryption_level::initial),
+              1u);
+
+    // Move out of idle so the state-guard does not short-circuit.
+    test_access::transition_state(
+        *q, internal_ns::quic_connection_state::handshake);
+
+    // Without write keys, send_packet returns an error and the work is
+    // dropped from the queue — but the dispatch path through
+    // send_pending_packets is exercised regardless.
+    test_access::send_pending_packets(*q);
+
+    EXPECT_EQ(test_access::pending_crypto_data_size(
+                  *q, quic_proto::encryption_level::initial),
+              0u);
+}
+
+// ============================================================================
+// determine_encryption_level: every long-header packet_type branch and
+// the short-header (application) branch
+// ============================================================================
+
+TEST_F(QuicSocketDispatcherBranchTest, DetermineEncryptionLevelLongHeaderInitial)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    quic_proto::long_header lh{};
+    // first_byte: long-form (bit7=1) + fixed-bit (bit6=1) + type Initial (bits 4-5 = 00)
+    lh.first_byte = 0xC0;
+    quic_proto::packet_header header = lh;
+
+    EXPECT_EQ(test_access::determine_encryption_level(*q, header),
+              quic_proto::encryption_level::initial);
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, DetermineEncryptionLevelLongHeaderZeroRtt)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    quic_proto::long_header lh{};
+    // first_byte: long-form + fixed-bit + type 0-RTT (bits 4-5 = 01)
+    lh.first_byte = 0xD0;
+    quic_proto::packet_header header = lh;
+
+    EXPECT_EQ(test_access::determine_encryption_level(*q, header),
+              quic_proto::encryption_level::zero_rtt);
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, DetermineEncryptionLevelLongHeaderHandshake)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    quic_proto::long_header lh{};
+    // first_byte: long-form + fixed-bit + type Handshake (bits 4-5 = 10)
+    lh.first_byte = 0xE0;
+    quic_proto::packet_header header = lh;
+
+    EXPECT_EQ(test_access::determine_encryption_level(*q, header),
+              quic_proto::encryption_level::handshake);
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, DetermineEncryptionLevelLongHeaderRetryFallsThroughToInitial)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    quic_proto::long_header lh{};
+    // first_byte: long-form + fixed-bit + type Retry (bits 4-5 = 11)
+    lh.first_byte = 0xF0;
+    quic_proto::packet_header header = lh;
+
+    // Retry is not initial / 0-RTT / handshake — falls through the
+    // default arm to encryption_level::initial.
+    EXPECT_EQ(test_access::determine_encryption_level(*q, header),
+              quic_proto::encryption_level::initial);
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, DetermineEncryptionLevelShortHeaderIsApplication)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    quic_proto::short_header sh{};
+    sh.first_byte = 0x40;  // short-form (bit7=0), fixed-bit (bit6=1)
+    quic_proto::packet_header header = sh;
+
+    EXPECT_EQ(test_access::determine_encryption_level(*q, header),
+              quic_proto::encryption_level::application);
+}
+
+// ============================================================================
+// transition_state: drives the state machine through every reachable
+// transition without a peer
+// ============================================================================
+
+TEST_F(QuicSocketDispatcherBranchTest, TransitionStateWalksAllReachableStates)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    using state = internal_ns::quic_connection_state;
+    const std::array<state, 7> walk = {
+        state::idle,
+        state::handshake_start,
+        state::handshake,
+        state::connected,
+        state::closing,
+        state::draining,
+        state::closed,
+    };
+
+    for (auto s : walk)
+    {
+        test_access::transition_state(*q, s);
+        EXPECT_EQ(test_access::state(*q), s);
+    }
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, TransitionStateRoundTripIsIdempotent)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    using state = internal_ns::quic_connection_state;
+
+    // Apply the same state twice — the atomic store happens regardless
+    // and is observable via state().
+    test_access::transition_state(*q, state::handshake);
+    EXPECT_EQ(test_access::state(*q), state::handshake);
+
+    test_access::transition_state(*q, state::handshake);
+    EXPECT_EQ(test_access::state(*q), state::handshake);
+
+    // And go backwards (e.g., for testing).
+    test_access::transition_state(*q, state::idle);
+    EXPECT_EQ(test_access::state(*q), state::idle);
+}
+
+// ============================================================================
+// on_retransmit_timeout: drives the retransmit handler
+// ============================================================================
+
+TEST_F(QuicSocketDispatcherBranchTest, OnRetransmitTimeoutOnIdleSocketIsSafe)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    // on_retransmit_timeout calls send_pending_packets which short-
+    // circuits on idle — exercises the handler entry path.
+    test_access::on_retransmit_timeout(*q);
+
+    SUCCEED();
+}
+
+TEST_F(QuicSocketDispatcherBranchTest, OnRetransmitTimeoutOnHandshakeSocketDrivesSendPending)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    test_access::queue_crypto_data(
+        *q, std::vector<std::uint8_t>{0xAA, 0xBB});
+    test_access::transition_state(
+        *q, internal_ns::quic_connection_state::handshake);
+
+    test_access::on_retransmit_timeout(*q);
+
+    // send_pending_packets ran and (without keys) drained the queue.
+    EXPECT_EQ(test_access::pending_crypto_data_size(
+                  *q, quic_proto::encryption_level::initial),
+              0u);
+}
+
+// ============================================================================
+// process_crypto_frame: TLS-uninitialized error-path coverage
+// ============================================================================
+
+TEST_F(QuicSocketDispatcherBranchTest, ProcessCryptoFrameOnUninitializedTlsReturnsEarly)
+{
+    auto q = make_quic(*io_, internal_ns::quic_role::client);
+
+    // Without init_client(), crypto_.process_crypto_data() returns an
+    // error — drives the response_result.is_err() early-return branch.
+    quic_proto::crypto_frame cf{};
+    cf.offset = 0;
+    cf.data = {0x16, 0x03, 0x03};
+
+    test_access::process_crypto_frame(*q, cf);
+
+    EXPECT_FALSE(test_access::handshake_complete(*q));
+    EXPECT_EQ(test_access::state(*q),
+              internal_ns::quic_connection_state::idle);
+}


### PR DESCRIPTION
Closes #1122
Part of #953

## Summary

Mirrors the strategy of #1115 (http2_client / Round 6), #1119
(http2_client_dispatcher / Round 3) and #1121 (http2_server_dispatcher
/ Round 3) to raise `src/internal/quic_socket.cpp` line/branch
coverage from 43.7%/21.3% toward the 70%/50% target. Direct-dispatch
tests invoke the private `quic_socket` dispatcher entry points
(`process_frame`, `process_*_frame`, `send_pending_packets`,
`queue_crypto_data`, `determine_encryption_level`,
`transition_state`, `on_retransmit_timeout`) via a new
`tests::support::quic_socket_test_access` friend class, sidestepping
the live UDP peer + TLS 1.3 handshake that the wire path otherwise
requires.

## Why

- Branch `quic_socket_branch_test.cpp` (Issue #1051) already covers
  the public-API surface but explicitly notes (lines 56-82 of that
  file) that the impl-level dispatcher methods "remain reachable
  only with a UDP transport fixture and a TLS-1.3 peer" — a fixture
  that is not available in this repository's hermetic test environment.
- Friend injection is the proven strategy on this repo for dispatcher
  coverage in the absence of a live peer (see
  `http2_client_test_access` / Issue #1115 and
  `http2_server_test_access` / Issue #1121).

## What

Adds 31 hermetic `TEST_F` cases targeting:

- **process_frame**: every alternative arm of the
  `protocols::quic::frame` variant the dispatcher inspects (padding,
  ping, ack, stream, connection_close, handshake_done) plus the
  implicit fall-through arm covering the 13 unhandled variants
- **process_stream_frame**: callback-set + callback-empty branches
- **process_connection_close_frame**: callback-set + callback-empty
  branches and the resulting draining-state transition
- **process_handshake_done_frame**: client-when-incomplete +
  client-when-already-complete short-circuit + server-role ignore
  branch
- **process_ack_frame**: placeholder no-op invocation for coverage
- **queue_crypto_data**: single-payload + multiple-payload +
  larger-payload (4 KiB) append paths driven by `current_level()`
- **send_pending_packets**: state-guard early-return on idle / closed
  + populated-queue dispatch through `send_packet` (no-keys failure
  path)
- **determine_encryption_level**: every long-header `packet_type`
  branch (initial / zero_rtt / handshake / retry-default-fallthrough)
  and short-header (application)
- **transition_state**: walks every reachable state and round-trip
  idempotency
- **on_retransmit_timeout**: drives `send_pending_packets` entry
  path for both idle and handshake state
- **process_crypto_frame**: TLS-uninitialized error-path early-return

## Where

- New: `tests/support/quic_socket_test_access.h` — friend access
  class mirroring `http2_server_test_access.h`
- New: `tests/unit/quic_socket_dispatcher_branch_test.cpp` — 31
  TEST_F
- Modified: `src/internal/quic_socket.h` — adds
  `#if defined(NETWORK_ENABLE_TEST_INJECTION)` forward declaration
  and friend grant on `quic_socket` (existing gate from #1074
  Phase 2D)
- Modified: `tests/support/network_test_friends.h` — adds forward
  declaration
- Modified: `tests/CMakeLists.txt` — adds new test target

## How

The friend gate `NETWORK_ENABLE_TEST_INJECTION` is the same one
defined PUBLIC on `network_system` when `BUILD_TESTS=ON` (see
`cmake/network_system_targets.cmake`). Production builds with
`BUILD_TESTS=OFF` compile byte-identical — the macro is undefined
and the friend declaration / forward declaration are wholly elided.

Tests construct a `quic_socket` on a UDP socket bound to an
ephemeral port without any peer. Most assertions observe callback
invocations and state transitions rather than network state — the
wire path is intentionally unreachable by these tests.

## Test Plan

```bash
cmake --build build --target network_quic_socket_dispatcher_branch_test
./build/bin/network_quic_socket_dispatcher_branch_test
# Expect: [==========] 31 tests from 1 test suite ran.
# Expect: [  PASSED  ] 31 tests.
```

Verified locally:
- 31/31 new tests pass
- network_quic_socket_construction_test: 19/19 pass
- network_quic_socket_branch_test: 59/59 hermetic tests pass (4
  pre-existing UDP-loopback transport tests fail under macOS sandbox
  with no peer reachable; unaffected by this PR — they don't reference
  `quic_socket_test_access`)
- network_quic_server_branch_test, network_http2_server_branch_test
  build clean
- Coverage workflow re-measurement to be attached after CI completes.