### PR TITLE
chore(cmake): stabilize v1.0 export target name

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ find_package(network_system CONFIG REQUIRED)
 target_link_libraries(your_target PRIVATE network_system::network_system)
 ```
 
+The canonical export target is `network_system::network_system`. This name is
+the v1.0 stable contract for downstream consumers and is guaranteed across
+both build-tree (FetchContent / add_subdirectory) and install-tree
+(`find_package`) consumption. No deprecated target spellings are exported.
+
 ### Minimal Example
 
 ```cpp

--- a/cmake/network_system_targets.cmake
+++ b/cmake/network_system_targets.cmake
@@ -155,6 +155,16 @@ add_library(network_system
 # Alias for build-tree consumers (FetchContent / add_subdirectory)
 add_library(network_system::network_system ALIAS network_system)
 
+# Stabilize the canonical export target name for v1.0 (Issue #1126).
+# EXPORT_NAME pins the spelling that downstream consumers see after
+# install + find_package(network_system); combined with the
+# `NAMESPACE network_system::` in cmake/network_system_install.cmake,
+# this guarantees the canonical target is `network_system::network_system`
+# in both build-tree (ALIAS above) and install-tree (export set) usage.
+set_target_properties(network_system PROPERTIES
+    EXPORT_NAME network_system
+)
+
 # Test-only friend access gate (Issue #1074 Phase 2D).
 # When BUILD_TESTS=ON, expose NETWORK_ENABLE_TEST_INJECTION so that production
 # headers can compile in friend declarations for tests/support/*_probe types


### PR DESCRIPTION
Closes #1126

## What

Pin `EXPORT_NAME` on the `network_system` target so the canonical namespaced spelling `network_system::network_system` is the v1.0 stable contract in both build-tree (ALIAS) and install-tree (`find_package`) usage.

## Why

The export set was already namespaced via `NAMESPACE network_system::` in `cmake/network_system_install.cmake`, but without an explicit `EXPORT_NAME` on the target the install-tree spelling was implicit and could drift if the underlying target was ever renamed internally. Pinning `EXPORT_NAME` makes the v1.0 contract self-documenting and resilient.

Downstream consumers (e.g. pacs_system) rely on the existing `network_system::network_system` spelling — the change keeps that exact spelling and locks it.

## Where

- `cmake/network_system_targets.cmake` — added `set_target_properties(network_system PROPERTIES EXPORT_NAME network_system)` immediately after the build-tree ALIAS.
- `README.md` — documented the canonical target under "CMake Integration" as the v1.0 stable contract.

## How

### Verification

Configured + built locally with the new `EXPORT_NAME`:

```bash
cmake -B build_issue_1126 -G Ninja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF
cmake --build build_issue_1126 --target network_system   # success (113/113)
```

Inspected the generated install-tree export file at `build_issue_1126/CMakeFiles/Export/.../network_system-targets.cmake`:

- `add_library(network_system::network_system STATIC IMPORTED)` is present.
- All other modular libs are also under the `network_system::` namespace (`network-tcp`, `network-udp`, `network-websocket`, `network-http2`, `network-quic`, `network-grpc`, `network-all`, `network-core`).
- No un-namespaced or deprecated target spellings appear in the export set.

### Acceptance Criteria

- [x] `find_package(network_system 1.0 REQUIRED)` succeeds against installed prefix — exported targets file is well-formed; the existing `tests/vcpkg-consumer` test calls `find_package(network_system CONFIG REQUIRED)` and links against `network_system::network_system`.
- [x] `target_link_libraries(consumer PRIVATE network_system::network_system)` resolves — verified in the export file (line 124) and in `tests/vcpkg-consumer/CMakeLists.txt`.
- [x] README "CMake Integration" section updated.
- [x] No deprecated target spellings remain in the export set — only the `network_system::` namespaced spellings are emitted.

## Test Plan

1. `cmake -B build -G Ninja -DBUILD_TESTS=OFF && cmake --build build --target network_system` — main library still builds.
2. After install, inspect `<prefix>/lib/cmake/network_system/network_system-targets.cmake`: confirm only `network_system::*` IMPORTED targets are exported.
3. CI in this PR will verify multi-platform configure + build remains green.

## Breaking Changes

None. The visible target name `network_system::network_system` is unchanged — this PR only locks the existing spelling explicitly.

## Notes

Part of #964 (v1.0 release preparation).