### PR TITLE
docs(api): complete v1.0 API reference (Doxygen)

### DIFF
--- a/.github/workflows/doxygen-warnings-check.yml
+++ b/.github/workflows/doxygen-warnings-check.yml
@@ -1,0 +1,66 @@
+name: Doxygen Warnings Check
+
+# Verifies that running Doxygen against the public include/ surface produces
+# zero warnings for files under include/kcenon/network/ (excluding detail/).
+# Internal-only headers (detail/, src/internal/) are reported but do not gate
+# the workflow, in line with the v1.0 API contract scope.
+
+on:
+  push:
+    branches: [ main, develop, phase-* ]
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - 'include/**'
+      - 'Doxyfile'
+      - '.github/workflows/doxygen-warnings-check.yml'
+
+jobs:
+  doxygen-public-zero-warnings:
+    name: Zero warnings on public headers
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Doxygen
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen graphviz
+
+      - name: Show Doxygen version
+        run: doxygen --version
+
+      - name: Run Doxygen
+        run: |
+          doxygen Doxyfile 2>doxygen-warnings.log >doxygen-stdout.log || true
+
+      - name: Filter public-header warnings
+        id: filter
+        run: |
+          set -o pipefail
+          # Public headers live under include/kcenon/network/ excluding the
+          # detail/ subtree. detail/ headers are implementation detail and
+          # outside the v1.0 contract per docs/v1.0-api-surface.md.
+          PUBLIC_WARNINGS=$(grep -E '^.*include/kcenon/network/.*warning:' \
+              doxygen-warnings.log \
+              | grep -v '/detail/' || true)
+          if [ -n "$PUBLIC_WARNINGS" ]; then
+            echo "Public-header Doxygen warnings detected:"
+            echo "$PUBLIC_WARNINGS"
+            echo "count=$(echo "$PUBLIC_WARNINGS" | wc -l)" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          echo "OK -- zero Doxygen warnings on public headers."
+          echo "count=0" >> "$GITHUB_OUTPUT"
+
+      - name: Upload full warning log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: doxygen-warnings-log
+          path: |
+            doxygen-warnings.log
+            doxygen-stdout.log
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -697,6 +697,30 @@ thread_integration_manager::instance().set_thread_pool(adapted);
 - 🔧 [Build Guide](docs/guides/BUILD.md) - Detailed build instructions
 - 🚀 [Migration Guide](docs/MIGRATION.md) - Migrating from messaging_system
 
+#### Generated API Docs (Doxygen)
+
+The full Doxygen-generated reference for the v1.0 public API is published from
+the `main` branch by the
+[Generate-Documentation workflow](.github/workflows/build-Doxygen.yaml) and
+hosted on GitHub Pages at:
+
+- https://kcenon.github.io/network_system/
+
+To regenerate the HTML locally:
+
+```bash
+doxygen Doxyfile
+# Output: documents/html/index.html
+```
+
+The
+[Doxygen Warnings Check workflow](.github/workflows/doxygen-warnings-check.yml)
+runs on every PR and fails the build if any header under
+`include/kcenon/network/` (excluding `detail/`) emits a Doxygen warning.
+This guards the v1.0 public API surface defined in
+[docs/v1.0-api-surface.md](docs/v1.0-api-surface.md) against documentation
+regressions.
+
 ### Advanced Topics
 - ⚡ [Performance & Benchmarks](docs/BENCHMARKS.md) - Performance metrics and testing
 - 🏭 [Production Quality](docs/PRODUCTION_QUALITY.md) - CI/CD, security, quality assurance

--- a/include/kcenon/network/integration/thread_integration.h
+++ b/include/kcenon/network/integration/thread_integration.h
@@ -128,7 +128,8 @@ private:
      * @warning Do not "fix" this by changing to unique_ptr or adding a real
      *          deleter. Doing so will cause heap corruption on shutdown.
      *
-     * @see docs/DESIGN_DECISIONS.md#intentional-leak-pattern
+     * @see docs/DESIGN_DECISIONS.md (Intentional Leak Pattern in Thread
+     *      Integration)
      */
     std::shared_ptr<impl> pimpl_;
 };
@@ -215,7 +216,8 @@ private:
      * @warning Do not "fix" this by changing to unique_ptr or adding a real
      *          deleter. Doing so will cause heap corruption on shutdown.
      *
-     * @see docs/DESIGN_DECISIONS.md#intentional-leak-pattern
+     * @see docs/DESIGN_DECISIONS.md (Intentional Leak Pattern in Thread
+     *      Integration)
      */
     std::shared_ptr<impl> pimpl_;
 };

--- a/include/kcenon/network/types/result.h
+++ b/include/kcenon/network/types/result.h
@@ -9,7 +9,7 @@
  * This is the public API header for result types. Use this header instead of
  * including detail/utils/result_types.h directly.
  *
- * @example
+ * Example usage:
  * @code
  * #include <kcenon/network/types/result.h>
  *


### PR DESCRIPTION
## What

Complete the v1.0 Doxygen API reference and add a CI gate that prevents future regressions in public-header documentation quality.

### Change Type
- [x] Documentation
- [x] CI / Infrastructure

### Affected Components
- `include/kcenon/network/integration/thread_integration.h` — fix two unresolved `@see` anchors
- `include/kcenon/network/types/result.h` — fix malformed `@example` directive
- `.github/workflows/doxygen-warnings-check.yml` — new
- `README.md` — document hosted location and the new CI gate

## Why

`v1.0` requires "Documentation: Complete API reference" (#964 / #639). Without a hard CI gate, Doxygen warnings can re-appear silently and degrade the public reference, which is the primary onboarding surface for new consumers.

### Related Issues
- Closes #1128
- Part of #964

## Where

| Area | Files | Note |
|------|-------|------|
| Public headers | 2 | Surgical fix only on warning sites |
| CI workflow | 1 (new) | PR-gated on changes to `include/` or `Doxyfile` |
| README | 1 | Docs section update |

## How

### Audit method
Ran `doxygen Doxyfile` against `develop` (`de159f34`). Filtered warnings by path to isolate those originating from `include/kcenon/network/` excluding `detail/`. Initial count: **3** public-header warnings (2 from `thread_integration.h`, 1 from `result.h`). All other public headers under `docs/v1.0-api-surface.md` (31 headers across 12 functional groups, frozen in d7ac0416) already have complete `@file` / `@brief` coverage.

### Fixes
1. **`types/result.h` (line 12)** — Doxygen treats `@example` as a path directive and consumed the next whitespace-separated token as a filename, producing `included file '/Volumes/T5' is not found`. Replaced with prose "Example usage:" before the `@code` block. Same rendered output, no false-positive path resolution.
2. **`integration/thread_integration.h` (lines 131, 218)** — `@see docs/DESIGN_DECISIONS.md#intentional-leak-pattern` referenced an anchor that does not exist. The actual heading is "Intentional Leak Pattern in Thread Integration" producing anchor `intentional-leak-pattern-in-thread-integration`. Replaced fragile inline anchor with a parenthetical section reference that survives heading rewrites.

### CI gate
`doxygen-warnings-check.yml` triggers on push to `main`/`develop`/`phase-*` and on PRs to `main`/`develop` whose diff touches `include/`, `Doxyfile`, or the workflow itself. It installs Doxygen + Graphviz on the runner, runs a full Doxygen pass, and fails the job if any line matching `include/kcenon/network/.*warning:` (excluding `/detail/`) is emitted. The full warning log is uploaded as an artifact for triage on failure.

### Why not flip `WARN_AS_ERROR=YES` in the Doxyfile
Setting `WARN_AS_ERROR=YES` would also fail the build on warnings from internal `detail/` headers and `src/internal/` paths, which carry historical warnings outside the scope of the v1.0 public-API contract. The new workflow filters to the public surface so the gate matches the contract exactly.

### Testing Done
- [x] Local `doxygen Doxyfile` pass: zero public-header warnings, exit code 0
- [x] HTML output verified at `documents/html/index.html`
- [x] Workflow YAML structure reviewed (steps, paths filter, artifact upload)
- [x] Confirmed all 31 public headers in `docs/v1.0-api-surface.md` have `@file`/`@brief` (or `\file`/`\brief`) tags

### Acceptance Criteria
- [x] Zero undocumented public symbols (Doxygen warning count = 0 for `include/`)
- [x] At least one usage example per public class — pre-existing, verified
- [x] CI step verifies docs build without warnings — new `doxygen-warnings-check.yml`
- [x] Generated HTML hosted location documented in README — added under Documentation/Generated API Docs

### Breaking Changes
None.

### Rollback Plan
Revert this PR. No runtime, build, or schema changes.
