### PR TITLE
docs(changelog): convert CHANGELOG to keep-a-changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
@@ -32,23 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Protocol factories (4): `tcp`, `udp`, `websocket`, `quic`
   - HTTP/2 (1): `http2_server_stream`
   - Internal (1): `websocket_socket`
-
-### Changed
-
-- Unify vcpkg manifest mode across all CI platforms (Linux, macOS, Windows) replacing per-platform manual ecosystem dependency builds ([#885](https://github.com/kcenon/network_system/issues/885))
-- **Complete `Result<T>` migration for public API** — public headers now contain zero `throw` statements; every public function either returns `common::Result<T>` / `common::VoidResult` or is `noexcept`. Enforced by a new `public-api-check` CI job that rejects any PR reintroducing `throw` into `include/kcenon/network/`. ([#988](https://github.com/kcenon/network_system/issues/988))
-- **Deprecated API audit for v1.0 freeze** — completed inventory of every `[[deprecated]]` attribute and `#pragma message("Deprecated:")` shim across `include/`, `src/`, and `cmake/`. Audit decision: freeze the deprecated surface as-is for v1.0; no symbols removed in this audit. Disposition recorded for 1 `[[deprecated]]` macro (retained, permanent), 14 `cmake/compat/` header shims (retained, removal target v1.1.0), and 6 CHANGELOG-announced deprecations missing source-level markers (retained through v1.x). See [`docs/migration/deprecated_api_audit_v1_0.md`](docs/migration/deprecated_api_audit_v1_0.md) for the full inventory and per-symbol removal targets ([#1127](https://github.com/kcenon/network_system/issues/1127), part of [#964](https://github.com/kcenon/network_system/issues/964))
-
-### Performance
-
-- Parallelize connection pool initialization with `std::async` ([#870](https://github.com/kcenon/network_system/issues/870))
-
-### Security
-
-- Mark `no_tls` policy as deprecated with warning to use TLS-enabled policies in production ([#871](https://github.com/kcenon/network_system/issues/871))
-
-### Tests
-
+- Extend `rate_limiter` to support composite session-based identification keys ([#872](https://github.com/kcenon/network_system/issues/872))
+- Migration guide for transitioning from adapters to NetworkSystemBridge pattern
+  - Comprehensive step-by-step migration instructions
+  - API comparison tables for old vs new patterns
+  - Common migration patterns and examples
+  - Troubleshooting section
 - Increase unit test coverage from 21% to 40% target ([#873](https://github.com/kcenon/network_system/issues/873))
   - Add `network_system_test` covering `network_manager` lifecycle, connection, and disconnection
   - Add `message_validator_extended_test` for extended message validation edge cases
@@ -57,61 +46,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expand HPACK (`src/protocols/http2/hpack.cpp`) unit coverage with `hpack_extra_coverage_test` — closes static-table boundary lookups, decoder happy paths for literal-without-indexing / never-indexed prefixes, multi-byte integer non-overflow path, huffman stub contract, and mixed static/dynamic round-trips ([#1031](https://github.com/kcenon/network_system/issues/1031))
 - Pivot 7 dispatcher-only TEST_F in `tests/unit/http2_client_branch_test.cpp` to friend-injected `process_frame` (Round 6) — adds `tests/support/http2_client_test_access.h` as a single dedicated friend struct gated by the existing `NETWORK_ENABLE_TEST_INJECTION` macro (matching the `quic_server.h:55` / `websocket_server.h:33` pattern), bypassing the SETTINGS-handshake `wait_for` path that PR #1114 (Round 5) demonstrated to be structurally bounded by the ctest 300 s timeout under coverage instrumentation. Test #5868 measured 15.175 s and test #5869 hit the 300 s timeout in Coverage Analysis run [25562347620](https://github.com/kcenon/network_system/actions/runs/25562347620); after this refactor the same seven `Server*` TEST_F (`ServerPingFrameDrivesHandlePingAndKeepsConnectionAlive`, `ServerPingAckFrameIsAbsorbedSilently`, `ServerGoawayFrameFlipsConnectionStateToDisconnected`, `ServerWindowUpdateOnConnectionStreamExpandsWindow`, `ServerWindowUpdateOnUnknownStreamIsSilentlyIgnored`, `ServerRstStreamOnUnknownStreamIsSilentlyIgnored`, `ServerUnknownFrameTypeIsHandledWithoutCrashing`) complete in 0 ms wall-time under both Debug and Coverage builds. The 14 connect-state public-API TEST_F (`StartStream*`, `WriteStream*`, `CancelStream*`, `SecondConnect*`, `SendRequestTimesOut*`, `PostWithBody*`, `SetSettings*`) genuinely require the connected-state path and remain on the PR #1114 multiplier scaffold — out of scope for Round 6. Production header (`src/internal/protocols/http2/http2_client.h`) compiles byte-identical when `BUILD_TESTS=OFF` because the `NETWORK_ENABLE_TEST_INJECTION` macro is undefined in production builds. Post-merge `Coverage Analysis` workflow on develop will produce the definitive lcov measurement against the PR #1109 baseline (LH/LF=108/576 = 18.75% line, BRH/BRF=97/979 = 9.91% branch); acceptance gate is ≥+20pp line / ≥+10pp branch on `src/internal/protocols/http2/http2_client.cpp` ([#1115](https://github.com/kcenon/network_system/issues/1115), [#1116](https://github.com/kcenon/network_system/pull/1116), part of [#953](https://github.com/kcenon/network_system/issues/953))
 
-### Added
+### Changed
 
-- Extend `rate_limiter` to support composite session-based identification keys ([#872](https://github.com/kcenon/network_system/issues/872))
-- Migration guide for transitioning from adapters to NetworkSystemBridge pattern
-  - Comprehensive step-by-step migration instructions
-  - API comparison tables for old vs new patterns
-  - Common migration patterns and examples
-  - Troubleshooting section
+- Unify vcpkg manifest mode across all CI platforms (Linux, macOS, Windows) replacing per-platform manual ecosystem dependency builds ([#885](https://github.com/kcenon/network_system/issues/885))
+- **Complete `Result<T>` migration for public API** — public headers now contain zero `throw` statements; every public function either returns `common::Result<T>` / `common::VoidResult` or is `noexcept`. Enforced by a new `public-api-check` CI job that rejects any PR reintroducing `throw` into `include/kcenon/network/`. ([#988](https://github.com/kcenon/network_system/issues/988))
+- **Deprecated API audit for v1.0 freeze** — completed inventory of every `[[deprecated]]` attribute and `#pragma message("Deprecated:")` shim across `include/`, `src/`, and `cmake/`. Audit decision: freeze the deprecated surface as-is for v1.0; no symbols removed in this audit. Disposition recorded for 1 `[[deprecated]]` macro (retained, permanent), 14 `cmake/compat/` header shims (retained, removal target v1.1.0), and 6 CHANGELOG-announced deprecations missing source-level markers (retained through v1.x). See [`docs/migration/deprecated_api_audit_v1_0.md`](docs/migration/deprecated_api_audit_v1_0.md) for the full inventory and per-symbol removal targets ([#1127](https://github.com/kcenon/network_system/issues/1127), part of [#964](https://github.com/kcenon/network_system/issues/964))
+- Parallelize connection pool initialization with `std::async` ([#870](https://github.com/kcenon/network_system/issues/870))
 
 ### Deprecated
-- `thread_system_pool_adapter` class
-  - Replaced by `ThreadPoolBridge` from `network_system_bridge.h`
-  - Will be removed in v3.0.0
-  - See [migration guide](docs/migration/adapter_to_bridge_migration.md)
 
-- `common_thread_pool_adapter` class
-  - Replaced by `ThreadPoolBridge` from `network_system_bridge.h`
-  - Will be removed in v3.0.0
-  - See [migration guide](docs/migration/adapter_to_bridge_migration.md)
+- `thread_system_pool_adapter` class — replaced by `ThreadPoolBridge` from `network_system_bridge.h`; removal target v3.0.0. See [migration guide](docs/migration/adapter_to_bridge_migration.md)
+- `common_thread_pool_adapter` class — replaced by `ThreadPoolBridge` from `network_system_bridge.h`; removal target v3.0.0. See [migration guide](docs/migration/adapter_to_bridge_migration.md)
+- `common_logger_adapter` class — replaced by `ObservabilityBridge` from `network_system_bridge.h`; removal target v3.0.0. See [migration guide](docs/migration/adapter_to_bridge_migration.md)
+- `common_monitoring_adapter` class — replaced by `ObservabilityBridge` from `network_system_bridge.h`; removal target v3.0.0. See [migration guide](docs/migration/adapter_to_bridge_migration.md)
+- `bind_thread_system_pool_into_manager()` function — replaced by `NetworkSystemBridge::with_thread_system()`; removal target v3.0.0. See [migration guide](docs/migration/adapter_to_bridge_migration.md)
 
-- `common_logger_adapter` class
-  - Replaced by `ObservabilityBridge` from `network_system_bridge.h`
-  - Will be removed in v3.0.0
-  - See [migration guide](docs/migration/adapter_to_bridge_migration.md)
-
-- `common_monitoring_adapter` class
-  - Replaced by `ObservabilityBridge` from `network_system_bridge.h`
-  - Will be removed in v3.0.0
-  - See [migration guide](docs/migration/adapter_to_bridge_migration.md)
-
-- `bind_thread_system_pool_into_manager()` function
-  - Replaced by `NetworkSystemBridge::with_thread_system()`
-  - Will be removed in v3.0.0
-  - See [migration guide](docs/migration/adapter_to_bridge_migration.md)
-
-### Deprecation Timeline
+Deprecation timeline:
 - **v2.1.0** (current): Deprecated adapters marked with `[[deprecated]]` attribute
 - **v2.2.0** (Q2 2026): Migration strongly encouraged
 - **v3.0.0** (Q3 2026): Deprecated adapters will be removed
 
-Users are encouraged to migrate to the new `NetworkSystemBridge` facade as soon as possible.
-See the [migration guide](docs/migration/adapter_to_bridge_migration.md) for detailed instructions.
+Users are encouraged to migrate to the new `NetworkSystemBridge` facade as soon as possible. See the [migration guide](docs/migration/adapter_to_bridge_migration.md) for detailed instructions.
+
+### Security
+
+- Mark `no_tls` policy as deprecated with warning to use TLS-enabled policies in production ([#871](https://github.com/kcenon/network_system/issues/871))
 
 ---
 
-## How to Read This Changelog
+## [v1.0.0] - TBD
 
-- **Added**: New features
-- **Changed**: Changes in existing functionality
-- **Deprecated**: Features that will be removed in future versions
-- **Removed**: Removed features
-- **Fixed**: Bug fixes
-- **Security**: Security fixes
-
-For migration assistance, please refer to the migration guides in the `docs/migration/` directory.
+> **Note**: v1.0.0 is the API-frozen public release. Entries currently in the `[Unreleased]` section will be moved here at tag time. After v1.0.0, public headers under `include/kcenon/network/` are governed by Semantic Versioning and may not have symbols removed, renamed, or signature-changed without a major version bump. The `detail/` subtree remains free to evolve in v1.x patches without SemVer impact. See [`docs/v1.0-api-surface.md`](docs/v1.0-api-surface.md) and the v1.0 freeze policy in `CONTRIBUTING.md`.
 
 ---
 
@@ -162,20 +127,16 @@ For migration assistance, please refer to the migration guides in the `docs/migr
 - Renamed `_KO.md` documentation files to `.kr.md` for naming consistency
 
 ### Removed
-- `compatibility.h` and `network_module` namespace aliases (#488)
-- Deprecated WebSocket API methods (#487)
-- Deprecated UDP API methods (#490)
-- Deprecated `generate_session_id()` method (#489)
+- **BREAKING**: `compatibility.h` and `network_module` namespace aliases — `network_module` namespace no longer available (#488)
+- **BREAKING**: Deprecated WebSocket API methods (#487)
+- **BREAKING**: Deprecated UDP API methods (#490)
+- **BREAKING**: Deprecated `generate_session_id()` method (#489)
+- **BREAKING**: Dropped OpenSSL 1.1.1 support; OpenSSL 3.x is now required (#491)
 
 ### Fixed
 - `io_context` lifecycle management issues (#400, #410)
 - Thread pool API compatibility for `thread_system` integration (#493, #495)
 - PTO timeout loss detection handling for QUIC (#414, #418)
-
-### Breaking Changes
-- **OpenSSL 3.x only**: Dropped OpenSSL 1.1.1 support; OpenSSL 3.x is now required (#491)
-- **Namespace aliases removed**: `network_module` namespace no longer available (#488)
-- **Deprecated APIs removed**: WebSocket, UDP, and session manager deprecated methods removed (#487, #489, #490)
 
 ---
 
@@ -526,3 +487,36 @@ For migration assistance, please refer to the migration guides in the `docs/migr
 - Session management foundation
 - Message pipeline processing
 - High-performance asynchronous messaging infrastructure
+
+---
+
+## Section Definitions
+
+This changelog follows the [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) standard sections:
+
+- **Added** — new features
+- **Changed** — changes in existing functionality
+- **Deprecated** — soon-to-be removed features
+- **Removed** — now-removed features
+- **Fixed** — bug fixes
+- **Security** — vulnerability fixes
+
+For migration assistance, please refer to the migration guides in the `docs/migration/` directory.
+
+[Unreleased]: https://github.com/kcenon/network_system/compare/v2.0.0...HEAD
+[v1.0.0]: https://github.com/kcenon/network_system/releases/tag/v1.0.0
+[v2.0.0]: https://github.com/kcenon/network_system/compare/v1.5.0...v2.0.0
+[v1.5.0]: https://github.com/kcenon/network_system/compare/v1.4.0...v1.5.0
+[v1.4.0]: https://github.com/kcenon/network_system/compare/v1.3.0...v1.4.0
+[v1.3.0]: https://github.com/kcenon/network_system/compare/v1.2.0...v1.3.0
+[v1.2.0]: https://github.com/kcenon/network_system/compare/v1.1.0...v1.2.0
+[v1.1.0]: https://github.com/kcenon/network_system/compare/v1.0.0...v1.1.0
+[v0.8.0]: https://github.com/kcenon/network_system/compare/v0.7.0...v0.8.0
+[v0.7.0]: https://github.com/kcenon/network_system/compare/v0.6.0...v0.7.0
+[v0.6.0]: https://github.com/kcenon/network_system/compare/v0.5.0...v0.6.0
+[v0.5.0]: https://github.com/kcenon/network_system/compare/v0.4.0...v0.5.0
+[v0.4.0]: https://github.com/kcenon/network_system/compare/v0.3.0...v0.4.0
+[v0.3.0]: https://github.com/kcenon/network_system/compare/v0.2.0...v0.3.0
+[v0.2.0]: https://github.com/kcenon/network_system/compare/v0.1.0...v0.2.0
+[v0.1.0]: https://github.com/kcenon/network_system/compare/v0.0.1...v0.1.0
+[v0.0.1]: https://github.com/kcenon/network_system/releases/tag/v0.0.1

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,7 +16,7 @@ category: "PROJ"
 
 All notable changes to the Network System project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
@@ -587,7 +587,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Simplifies code by ~300 lines across multiple files
   - `utils::compression_pipeline` (actual LZ4/gzip implementation) remains available as standalone utility
 
-### Refactored
+### Changed
 - **Memory Profiler**: Migrated from `std::thread` to `thread_integration_manager::submit_delayed_task()` (#277)
   - Removed dedicated `std::thread worker_` member
   - Periodic sampling now runs through shared thread pool
@@ -732,11 +732,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Constexpr helper functions for length calculation
   - Comprehensive test suite with RFC 9000 example values
 
-### Planned
-- C++20 coroutine full integration
-- HTTP/2 and HTTP/3 support
-- Advanced load balancing algorithms
-
 ---
 
 ## [1.5.0] - 2025-11-14
@@ -798,7 +793,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Simplified test data to use std::string
   - All tests work without container_system dependency
 
-### Technical Details
+**Technical details:**
 - ZLIB version 1.2.12 integration
 - AddressSanitizer verified: zero memory leaks
 - ThreadSanitizer verified: no data races or deadlocks
@@ -849,7 +844,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated IMPROVEMENTS.md to mark Issue #4 (Add TLS/SSL Support) as completed
 - Reorganized CMakeLists.txt to separate TLS/SSL sources from base library
 
-### Technical Details
+**Technical details:**
 - Uses OpenSSL 3.6.0 for cryptographic operations
 - Parallel class hierarchy maintains backward compatibility
 - SSL context lifetime managed by server/client instances
@@ -893,7 +888,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `messaging_server` thread safety documentation to reflect mutex-protected sessions
 - Updated IMPROVEMENTS.md to mark Issues #1, #2, #3 as completed
 
-### Technical Details
+**Technical details:**
 - Session cleanup uses `is_stopped()` check with atomic operations
 - Backpressure applies at 1000 messages, disconnects at 2000
 - Connection pool uses RAII for safe resource management
@@ -975,7 +970,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reorganized integration test CMakeLists.txt with framework library
 - Updated test suite count from 4 to 7 (added TCP, UDP, WebSocket load tests)
 
-### Technical Details
+**Technical details:**
 - All load tests use localhost loopback for consistent measurements
 - Tests automatically skip in CI environments to avoid timing-related flakiness
 - Memory profiling uses platform-native APIs for accurate measurements


### PR DESCRIPTION
## What

### Summary
Converts both `CHANGELOG.md` (root) and `docs/CHANGELOG.md` (canonical SSOT) to the [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format required by the v1.0 API freeze. Adds a `v1.0.0 - TBD` stub for the upcoming API-frozen release, normalizes non-standard subsections to the keep-a-changelog taxonomy (Added / Changed / Deprecated / Removed / Fixed / Security), and adds a reference link list at the bottom of the root file.

### Change Type
- [x] Documentation
- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Test
- [ ] Chore

### Affected Components
- `CHANGELOG.md` (repo root, retained for tool compatibility)
- `docs/CHANGELOG.md` (canonical SSOT)

## Why

### Problem Solved
The v1.0 contract requires keep-a-changelog format ahead of tagging v1.0.0. The previous changelog had multiple format issues:
- `Unreleased` section had two duplicate `### Added` blocks
- Non-standard subsections (`### Performance`, `### Tests`, `### Refactored`, `### Planned`, `### Technical Details`, `### Breaking Changes`, `### Deprecation Timeline`) violated the keep-a-changelog 1.1.0 taxonomy
- Format reference still pointed to `keepachangelog.com/en/1.0.0/` instead of the current 1.1.0 spec
- No `v1.0.0` stub for the upcoming API-frozen release
- No reference link list for inter-version comparison URLs

### Related Issues
- Closes #1130
- Part of #964

### Business Value
- Required before tagging v1.0.0 to set the format precedent for the v1.x line
- Enables tooling for release-note generation and downstream upgrade audits
- Aligns the changelog with the same SSOT discipline as other ecosystem documentation

## Who

### Reviewers
- Documentation owner

### Required Approvals
- [ ] Documentation review

## When

### Urgency
- [x] Normal - Follow standard review process

### Target Release
- v1.0.0 (API freeze)

### Dependencies
- None — documentation-only change

## Where

### Files Changed
| File | Lines | Type of Change |
|------|-------|----------------|
| `CHANGELOG.md` | +/- 136 | Reformat to keep-a-changelog 1.1.0; add v1.0.0 stub; add link reference list |
| `docs/CHANGELOG.md` | +/- 17 | Bump format reference to 1.1.0; normalize Refactored/Planned/Technical Details headings |

### Architecture/API Impact
- None. Documentation-only change.

## How

### Implementation Highlights
- **Root `CHANGELOG.md` Unreleased section**: merged the duplicate `### Added` block (line 60 was a second sibling of line 14); reclassified `### Performance`, `### Tests` and the second `### Added` content into the canonical `### Added` and `### Changed` buckets; collapsed the `### Deprecation Timeline` heading and its prose into a paragraph inside `### Deprecated`.
- **Root v2.0.0 entry**: collapsed the non-standard `### Breaking Changes` section into `BREAKING`-prefixed bullets inside the existing `### Removed` section.
- **v1.0.0 stub**: added `## [v1.0.0] - TBD` with a note explaining the SemVer freeze contract and pointing to `docs/v1.0-api-surface.md` and the v1.0 freeze policy in `CONTRIBUTING.md`.
- **Section Definitions and Link References**: added the standard keep-a-changelog 1.1.0 section legend and a per-version comparison link list at the bottom of the root file.
- **`docs/CHANGELOG.md`**: bumped the format reference, renamed `### Refactored` to `### Changed`, removed the speculative `### Planned` block, and converted four `### Technical Details` headings into `**Technical details:**` bold-prefixed paragraphs to preserve information without violating the section taxonomy.

### Testing Done
- [x] Manual review of the diff
- [x] Verified no remaining non-standard `### *` headings inside release entries (`docs/CHANGELOG.md` retains H3 headings only inside the `Performance Benchmarks` and `Breaking Changes` appendices, which are not release entries)
- [x] Verified frontmatter (`doc_id`, `doc_status`) is unchanged in `docs/CHANGELOG.md`
- [x] Verified README `Documentation` section already has `docs/CHANGELOG.md` link (line 713) — no README change needed

### Test Plan for Reviewers
1. Open `CHANGELOG.md` and verify the header references `keepachangelog.com/en/1.1.0/`.
2. Verify the `Unreleased` section has exactly one each of Added / Changed / Deprecated / Security (no duplicate Added, no Performance/Tests/Deprecation Timeline subsections).
3. Verify a `## [v1.0.0] - TBD` stub appears between `Unreleased` and the pre-vcpkg history note.
4. Verify the bottom of the root file contains the Section Definitions block and the per-version reference link list.
5. Open `docs/CHANGELOG.md` and confirm the same 1.1.0 reference, no `### Refactored`, no `### Planned`, and that `### Technical Details` subsections were converted to bold prose.

### Breaking Changes
None. Documentation-only change.

### Rollback Plan
- Revert this PR. No source code, build system, or CI changes.