### PR TITLE
feat(udp): implement DTLS session payload handling in secure_messaging_udp_server

### DIFF
--- a/docs/PROTOCOL_SUPPORT.md
+++ b/docs/PROTOCOL_SUPPORT.md
@@ -27,7 +27,7 @@ the cross-system summary in kcenon/common_system#684.
 | HPACK | `network-http2` | `production` | `hpack_branch_test`, `hpack_coverage_test`, `hpack_extra_coverage_test`, `test_http2_hpack_rfc7541` | RFC 7541 static/dynamic table, integer/string coding. Huffman coding is an experimental pass-through (see HPACK Huffman row). |
 | QUIC | `network-quic` | `production` | 30+ unit tests: `quic_packet_branch_test`, `quic_connection_branch_test`, `quic_frame_branch_test`, `quic_loss_detector_test`, `quic_congestion_controller_test`, `quic_socket_branch_test`, `test_quic_e2e` | RFC 9000/9001/9002 core: packets, frames, streams, loss detection, congestion control, crypto, varint, transport params. Connection-stats/ALPN-result accessors on the experimental client surface are incomplete (see experimental rows). |
 | gRPC | `network-grpc` | `production` | `grpc_client_branch_test`, `grpc_client_extended_coverage_test`, `test_grpc_*`, `mock_grpc_server_peer` | Custom HTTP/2 transport + optional official `grpc++` wrapper (`NETWORK_ENABLE_GRPC_OFFICIAL`, OFF by default). |
-| DTLS (secure UDP) | `network-udp` | `experimental` | `test_dtls_socket` | DTLS socket exists and is tested, but server-side session payload handling in `secure_messaging_udp_server::process_session_data` is not yet wired (data buffer unused, `// TODO: Use when DTLS handling is implemented`). |
+| DTLS (secure UDP) | `network-udp` | `experimental` | `test_dtls_socket` | DTLS socket and server-side session payload handling are implemented and tested: `secure_messaging_udp_server::process_session_data` feeds inbound datagrams into the per-endpoint `dtls_session` via `dtls_socket::deliver_encrypted()`, advancing the handshake and dispatching decrypted application data to the receive callback (negative paths covered by `test_dtls_socket`). Remains `experimental` pending DTLS cookie exchange (DoS protection) and a consolidated single-socket demux model. |
 
 ## Sub-surface and code-level findings
 
@@ -40,7 +40,7 @@ classified with evidence and disposition.
 | `src/protocols/http2/hpack.cpp` (huffman::encode/decode/encoded_size, ~L306/609/651) | Huffman coding is a documented pass-through stub (returns input as-is); non-Huffman HPACK paths are fully RFC 7541 compliant | `experimental` | Keep; covered by `test_http2_hpack.cpp` Huffman stub tests asserting the pass-through contract and by `hpack_branch_test` H-bit branch. Real Huffman tables tracked by follow-up. |
 | `src/experimental/quic_client.cpp` `alpn_protocol()` (~L459) | Returns `std::nullopt`; ALPN negotiation result not retrieved from handshake | `experimental` | Header annotated as experimental. Internal header (`src/internal/experimental/`), not a public surface. Tracked by follow-up. |
 | `src/experimental/quic_client.cpp` `stats()` (~L470) | Returns default `quic_connection_stats{}`; not wired to live connection | `experimental` | Header annotated as experimental. Tracked by follow-up. |
-| `src/core/secure_messaging_udp_server.cpp` `process_session_data` (~L301) | `data` parameter `[[maybe_unused]]` pending DTLS payload handling | `experimental` | DTLS row above. Tracked by follow-up. |
+| `secure_messaging_udp_server.cpp` `process_session_data` (`libs/network-udp`, mirrored in `src/core`) | Feeds the inbound datagram into the per-endpoint `dtls_session` via `dtls_socket::deliver_encrypted()`; `[[maybe_unused]]`/TODO removed | `experimental` | Resolved in kcenon/network_system#1159. See DTLS row above; remaining experimental gap (cookie exchange) tracked there. |
 | `src/internal/quic_socket.cpp` `process_ack_frame` (~L719) | Tracks largest-acked only; full retransmission-queue pruning deferred (`(void)f; // Placeholder`) | `experimental` | Functional minimal ACK handling; full loss-recovery integration in `src/protocols/quic/loss_detector.cpp`. Tracked by follow-up. |
 | `src/tracing/exporters.cpp` (otlp_grpc/jaeger/zipkin, ~L547/560/573) | These exporters log "not implemented" and fall back to console/OTLP-HTTP | `experimental` | Tracing observability surface, not a network protocol. `otlp_http` exporter is production. README tracing note already says "use otlp_http". |
 | `src/http/http_server.cpp` `// TODO: Add error logging when needed` (~L665) | Compression-failure path returns silently | `production` | Benign: behavior (send uncompressed / abort) is correct; only optional logging is deferred. Marker removed in this audit. |
@@ -70,7 +70,6 @@ dedicated follow-up issues (see kcenon/network_system#1144 PR body for numbers):
 
 - HPACK Huffman coding: replace the pass-through stub with RFC 7541 Huffman tables.
 - Experimental QUIC client: wire `alpn_protocol()` and `stats()` to the live connection.
-- DTLS server: implement `secure_messaging_udp_server::process_session_data` payload handling.
 
 No rows were classified `remove`; the `libs/network-*` wrapper `.cpp` files are
 retained as documented standalone-build scaffolding rather than deleted.

--- a/libs/network-udp/src/secure_messaging_udp_server.cpp
+++ b/libs/network-udp/src/secure_messaging_udp_server.cpp
@@ -298,7 +298,7 @@ auto secure_messaging_udp_server::do_receive() -> void
 }
 
 auto secure_messaging_udp_server::process_session_data(
-	[[maybe_unused]] const std::vector<uint8_t>& data,  // TODO: Use when DTLS handling is implemented
+	const std::vector<uint8_t>& data,
 	const asio::ip::udp::endpoint& sender) -> void
 {
 	std::shared_ptr<dtls_session> session;
@@ -313,7 +313,9 @@ auto secure_messaging_udp_server::process_session_data(
 		}
 	}
 
-	// Create new session if needed
+	// Create a new session on first contact (e.g. an inbound ClientHello).
+	// create_session() registers the receive callback and starts the
+	// server-role handshake for this endpoint.
 	if (!session)
 	{
 		session = create_session(sender);
@@ -323,17 +325,15 @@ auto secure_messaging_udp_server::process_session_data(
 		}
 	}
 
-	// For a proper DTLS server, we would need to:
-	// 1. Parse the DTLS record to determine if it's a ClientHello
-	// 2. Handle cookie exchange for DoS protection
-	// 3. Create per-client SSL objects
-
-	// For this implementation, we rely on the dtls_socket to handle
-	// the DTLS protocol, but in a real server, each client needs its own
-	// SSL object and BIO pair.
-
-	// Note: A complete DTLS server implementation would require
-	// more sophisticated session management. This is a simplified version.
+	// Feed the encrypted datagram into the per-endpoint DTLS session. While
+	// the handshake is incomplete the record advances it; once established,
+	// the record is decrypted and the application payload is dispatched
+	// through the receive callback registered in create_session(). Malformed
+	// or out-of-order records are handled best-effort and dropped.
+	if (session->socket)
+	{
+		session->socket->deliver_encrypted(data, sender);
+	}
 }
 
 auto secure_messaging_udp_server::create_session(

--- a/src/core/secure_messaging_udp_server.cpp
+++ b/src/core/secure_messaging_udp_server.cpp
@@ -298,7 +298,7 @@ auto secure_messaging_udp_server::do_receive() -> void
 }
 
 auto secure_messaging_udp_server::process_session_data(
-	[[maybe_unused]] const std::vector<uint8_t>& data,  // TODO: Use when DTLS handling is implemented
+	const std::vector<uint8_t>& data,
 	const asio::ip::udp::endpoint& sender) -> void
 {
 	std::shared_ptr<dtls_session> session;
@@ -313,7 +313,9 @@ auto secure_messaging_udp_server::process_session_data(
 		}
 	}
 
-	// Create new session if needed
+	// Create a new session on first contact (e.g. an inbound ClientHello).
+	// create_session() registers the receive callback and starts the
+	// server-role handshake for this endpoint.
 	if (!session)
 	{
 		session = create_session(sender);
@@ -323,17 +325,15 @@ auto secure_messaging_udp_server::process_session_data(
 		}
 	}
 
-	// For a proper DTLS server, we would need to:
-	// 1. Parse the DTLS record to determine if it's a ClientHello
-	// 2. Handle cookie exchange for DoS protection
-	// 3. Create per-client SSL objects
-
-	// For this implementation, we rely on the dtls_socket to handle
-	// the DTLS protocol, but in a real server, each client needs its own
-	// SSL object and BIO pair.
-
-	// Note: A complete DTLS server implementation would require
-	// more sophisticated session management. This is a simplified version.
+	// Feed the encrypted datagram into the per-endpoint DTLS session. While
+	// the handshake is incomplete the record advances it; once established,
+	// the record is decrypted and the application payload is dispatched
+	// through the receive callback registered in create_session(). Malformed
+	// or out-of-order records are handled best-effort and dropped.
+	if (session->socket)
+	{
+		session->socket->deliver_encrypted(data, sender);
+	}
 }
 
 auto secure_messaging_udp_server::create_session(

--- a/src/internal/dtls_socket.cpp
+++ b/src/internal/dtls_socket.cpp
@@ -266,6 +266,20 @@ auto dtls_socket::do_receive() -> void
 		});
 }
 
+auto dtls_socket::deliver_encrypted(const std::vector<uint8_t>& data,
+                                     const asio::ip::udp::endpoint& sender) -> void
+{
+	if (data.empty())
+	{
+		return;
+	}
+
+	// Reuse the same record-processing path the internal receive loop uses.
+	// SSL/BIO access inside process_received_data() is serialized by
+	// ssl_mutex_, so injecting from a server's demultiplexing thread is safe.
+	process_received_data(data, sender);
+}
+
 auto dtls_socket::process_received_data(const std::vector<uint8_t>& data,
                                          const asio::ip::udp::endpoint& sender) -> void
 {

--- a/src/internal/tcp/dtls_socket.h
+++ b/src/internal/tcp/dtls_socket.h
@@ -129,6 +129,27 @@ namespace kcenon::network::internal
 		auto stop_receive() -> void;
 
 		/*!
+		 * \brief Injects an already-received encrypted datagram for DTLS processing.
+		 *
+		 * Intended for a server that owns the underlying UDP socket and
+		 * demultiplexes datagrams to per-client sessions itself, instead of
+		 * letting each \c dtls_socket drive its own receive loop via
+		 * \c start_receive(). The bytes are fed through the read BIO exactly as
+		 * the internal receive loop would: an in-progress handshake is advanced,
+		 * and once the handshake is complete the record is decrypted and the
+		 * application payload is delivered to the receive callback.
+		 *
+		 * Safe to call with malformed, truncated, or pre-handshake records: such
+		 * data is processed best-effort and dropped without invoking the receive
+		 * callback when it does not yield a complete decrypted record.
+		 *
+		 * \param data   The encrypted datagram bytes received from the peer.
+		 * \param sender The endpoint the datagram was received from.
+		 */
+		auto deliver_encrypted(const std::vector<uint8_t>& data,
+		                       const asio::ip::udp::endpoint& sender) -> void;
+
+		/*!
 		 * \brief Initiates an asynchronous encrypted send.
 		 * \param data The plaintext data to encrypt and send (moved for efficiency).
 		 * \param handler A completion handler with signature

--- a/tests/unit/test_dtls_socket.cpp
+++ b/tests/unit/test_dtls_socket.cpp
@@ -241,6 +241,90 @@ TEST_F(DtlsSocketTest, SendBeforeHandshakeFails)
 }
 
 // ============================================================================
+// Deliver Encrypted (server-side payload injection) Tests
+// ============================================================================
+//
+// deliver_encrypted() is the entry point a server uses to feed datagrams it
+// received on its own UDP socket into a per-client dtls_session. These tests
+// cover the negative paths called out by the server payload work: malformed
+// records, empty payloads, and injection before the handshake is established.
+
+// A datagram injected before the handshake completes must never surface as
+// decrypted application data on the receive callback.
+TEST_F(DtlsSocketTest, DeliverEncryptedBeforeHandshakeDoesNotInvokeReceiveCallback)
+{
+	auto socket = create_server_socket();
+	auto dtls = dtls_socket::create(std::move(socket), server_ctx_.get()).value();
+
+	std::atomic<bool> received{false};
+	dtls->set_receive_callback(
+		[&received](const std::vector<uint8_t>&, const asio::ip::udp::endpoint&)
+		{
+			received.store(true);
+		});
+
+	asio::ip::udp::endpoint sender(asio::ip::make_address("127.0.0.1"), 55555);
+	std::vector<uint8_t> bogus = {0x17, 0xfe, 0xfd, 0x00, 0x01, 0xde, 0xad, 0xbe, 0xef};
+
+	EXPECT_NO_THROW({ dtls->deliver_encrypted(bogus, sender); });
+	EXPECT_FALSE(received.load());
+}
+
+// Empty payloads are a no-op: no BIO write, no callback, no crash.
+TEST_F(DtlsSocketTest, DeliverEncryptedEmptyDataIsNoOp)
+{
+	auto socket = create_server_socket();
+	auto dtls = dtls_socket::create(std::move(socket), server_ctx_.get()).value();
+
+	std::atomic<bool> received{false};
+	dtls->set_receive_callback(
+		[&received](const std::vector<uint8_t>&, const asio::ip::udp::endpoint&)
+		{
+			received.store(true);
+		});
+
+	asio::ip::udp::endpoint sender(asio::ip::make_address("127.0.0.1"), 55556);
+	EXPECT_NO_THROW({ dtls->deliver_encrypted(std::vector<uint8_t>{}, sender); });
+	EXPECT_FALSE(received.load());
+}
+
+// A malformed record injected while a server-role handshake is in progress
+// must be handled gracefully. The handshake either reports failure or keeps
+// waiting for valid input; in neither case is the receive callback invoked.
+TEST_F(DtlsSocketTest, DeliverEncryptedMalformedHandshakeRecordIsHandledGracefully)
+{
+	auto socket = create_server_socket();
+	auto dtls = dtls_socket::create(std::move(socket), server_ctx_.get()).value();
+
+	std::atomic<bool> received{false};
+	dtls->set_receive_callback(
+		[&received](const std::vector<uint8_t>&, const asio::ip::udp::endpoint&)
+		{
+			received.store(true);
+		});
+
+	asio::ip::udp::endpoint sender(asio::ip::make_address("127.0.0.1"), 55557);
+	dtls->set_peer_endpoint(sender);
+
+	// Begin a server-role handshake so the injected record is routed through
+	// the handshake state machine rather than the application-data path.
+	dtls->async_handshake(dtls_socket::handshake_type::server,
+	                      [](std::error_code) {});
+
+	std::vector<uint8_t> garbage(64, 0xAB);
+
+	EXPECT_NO_THROW({
+		dtls->deliver_encrypted(garbage, sender);
+		dtls->deliver_encrypted(garbage, sender);
+	});
+
+	// Malformed handshake input never yields decrypted application data.
+	EXPECT_FALSE(received.load());
+
+	dtls->stop_receive();
+}
+
+// ============================================================================
 // Handshake Tests
 // ============================================================================
 


### PR DESCRIPTION
Closes #1159

## Summary
- Wire `secure_messaging_udp_server::process_session_data` to feed inbound datagrams into the per-endpoint `dtls_session` instead of marking the payload `[[maybe_unused]]` and dropping it.
- Add `dtls_socket::deliver_encrypted(data, sender)` as the public injection entry point. A server that owns the UDP socket and demultiplexes to per-client sessions uses it to advance the DTLS handshake and, once established, decrypt the record and dispatch the application payload via the receive callback registered in `create_session()`.
- SSL/BIO access inside the reused `process_received_data` path stays serialized by `ssl_mutex_`, so injection from the server's demultiplexing thread is thread-safe.
- The change is applied to the built `libs/network-udp` copy and mirrored in the legacy `src/core` copy.

## Test Plan
- Added negative-path tests to `tests/unit/test_dtls_socket.cpp` exercising `deliver_encrypted`:
  - pre-handshake record does not invoke the receive callback
  - empty payload is a no-op
  - malformed record during an in-progress server handshake is handled gracefully (no decrypted payload, no crash)
- Local build (`cmake --preset ci-standalone`) + `network_dtls_socket_test`: 23/23 tests pass (20 existing + 3 new).

## Notes
- `docs/PROTOCOL_SUPPORT.md` DTLS row updated: payload handling is now wired and tested. The row stays `experimental` pending DTLS cookie exchange (DoS protection) and a consolidated single-socket demux model — these remain out of scope for this issue.