### PR TITLE
feat(http2): implement RFC 7541 HPACK Huffman coding (replace pass-through stub)

### DIFF
--- a/docs/PROTOCOL_SUPPORT.md
+++ b/docs/PROTOCOL_SUPPORT.md
@@ -23,8 +23,8 @@ the cross-system summary in kcenon/common_system#684.
 | TLS/SSL | `network-tcp` | `production` | `test_tls_config`, `secure_session_test`, `secure_messaging_*_test`, `mock_tls_socket` | TLS 1.2/1.3, certificate validation, modern cipher suites. |
 | WebSocket | `network-websocket` | `production` | `websocket_socket_test`, `websocket_frame_test`, `websocket_handshake_test`, `websocket_protocol_test`, `websocket_server_branch_test` | RFC 6455 framing, fragmentation, ping/pong. |
 | HTTP/1.1 | (core `src/http`) | `production` | `http_parser_branch_test`, `http_server_test`, `http_client_test`, `http_error_coverage_test`, `http_types_test` | Routing, cookies, multipart, chunked encoding, gzip/deflate. |
-| HTTP/2 | `network-http2` | `production` | `http2_client_branch_test`, `http2_server_branch_test`, `*_dispatcher_branch_test`, `http2_server_stream_test`, `http2_request_test` | Multiplexed streams, frame layer, server/client dispatch. HPACK Huffman is an experimental sub-surface (see below). |
-| HPACK | `network-http2` | `production` | `hpack_branch_test`, `hpack_coverage_test`, `hpack_extra_coverage_test`, `test_http2_hpack_rfc7541` | RFC 7541 static/dynamic table, integer/string coding. Huffman coding is an experimental pass-through (see HPACK Huffman row). |
+| HTTP/2 | `network-http2` | `production` | `http2_client_branch_test`, `http2_server_branch_test`, `*_dispatcher_branch_test`, `http2_server_stream_test`, `http2_request_test` | Multiplexed streams, frame layer, server/client dispatch. HPACK Huffman coding is implemented per RFC 7541 Appendix B. |
+| HPACK | `network-http2` | `production` | `hpack_branch_test`, `hpack_coverage_test`, `hpack_extra_coverage_test`, `test_http2_hpack_rfc7541` | RFC 7541 static/dynamic table, integer/string coding, and Appendix B Huffman coding. |
 | QUIC | `network-quic` | `production` | 30+ unit tests: `quic_packet_branch_test`, `quic_connection_branch_test`, `quic_frame_branch_test`, `quic_loss_detector_test`, `quic_congestion_controller_test`, `quic_socket_branch_test`, `test_quic_e2e` | RFC 9000/9001/9002 core: packets, frames, streams, loss detection, congestion control, crypto, varint, transport params. Connection-stats/ALPN-result accessors on the experimental client surface are incomplete (see experimental rows). |
 | gRPC | `network-grpc` | `production` | `grpc_client_branch_test`, `grpc_client_extended_coverage_test`, `test_grpc_*`, `mock_grpc_server_peer` | Custom HTTP/2 transport + optional official `grpc++` wrapper (`NETWORK_ENABLE_GRPC_OFFICIAL`, OFF by default). |
 | DTLS (secure UDP) | `network-udp` | `experimental` | `test_dtls_socket` | DTLS socket exists and is tested, but server-side session payload handling in `secure_messaging_udp_server::process_session_data` is not yet wired (data buffer unused, `// TODO: Use when DTLS handling is implemented`). |
@@ -37,7 +37,7 @@ classified with evidence and disposition.
 
 | Location | Marker / behavior | Status | Disposition |
 |----------|-------------------|--------|-------------|
-| `src/protocols/http2/hpack.cpp` (huffman::encode/decode/encoded_size, ~L306/609/651) | Huffman coding is a documented pass-through stub (returns input as-is); non-Huffman HPACK paths are fully RFC 7541 compliant | `experimental` | Keep; covered by `test_http2_hpack.cpp` Huffman stub tests asserting the pass-through contract and by `hpack_branch_test` H-bit branch. Real Huffman tables tracked by follow-up. |
+| `src/protocols/http2/hpack.cpp` (huffman::encode/decode/encoded_size) | RFC 7541 Appendix B Huffman coding implemented: bit-packed encode, trie-based decode with EOS/padding validation (RFC 7541 5.2), accurate `encoded_size`; the encoder selects Huffman only when it produces a smaller output | `production` | Resolved in kcenon/network_system#1157. Covered by `test_http2_hpack.cpp` Appendix C.4/C.6 conformance vectors and an all-byte round-trip test. |
 | `src/experimental/quic_client.cpp` `alpn_protocol()` (~L459) | Returns `std::nullopt`; ALPN negotiation result not retrieved from handshake | `experimental` | Header annotated as experimental. Internal header (`src/internal/experimental/`), not a public surface. Tracked by follow-up. |
 | `src/experimental/quic_client.cpp` `stats()` (~L470) | Returns default `quic_connection_stats{}`; not wired to live connection | `experimental` | Header annotated as experimental. Tracked by follow-up. |
 | `src/core/secure_messaging_udp_server.cpp` `process_session_data` (~L301) | `data` parameter `[[maybe_unused]]` pending DTLS payload handling | `experimental` | DTLS row above. Tracked by follow-up. |
@@ -68,7 +68,6 @@ adapter types. They are listed above so the markers are fully accounted for.
 Rows classified `experimental` with a genuine implementation gap are tracked by
 dedicated follow-up issues (see kcenon/network_system#1144 PR body for numbers):
 
-- HPACK Huffman coding: replace the pass-through stub with RFC 7541 Huffman tables.
 - Experimental QUIC client: wire `alpn_protocol()` and `stats()` to the live connection.
 - DTLS server: implement `secure_messaging_udp_server::process_session_data` payload handling.
 

--- a/src/protocols/http2/hpack.cpp
+++ b/src/protocols/http2/hpack.cpp
@@ -295,21 +295,24 @@ namespace kcenon::network::protocols::http2
     {
         std::vector<uint8_t> result;
 
-        // String length (with Huffman bit)
-        auto length_bytes = encode_integer(str.size(), 7);
-        if (!huffman)
+        if (huffman)
         {
-            result.insert(result.end(), length_bytes.begin(), length_bytes.end());
-        }
-        else
-        {
-            // Huffman encoding not implemented yet
-            // Set H bit in first byte
-            length_bytes[0] |= 0x80;
-            result.insert(result.end(), length_bytes.begin(), length_bytes.end());
+            // Only use Huffman coding when it actually shrinks the string;
+            // RFC 7541 5.2 lets the encoder choose per string.
+            auto encoded = huffman::encode(str);
+            if (encoded.size() < str.size())
+            {
+                auto length_bytes = encode_integer(encoded.size(), 7);
+                length_bytes[0] |= 0x80;  // Set H bit
+                result.insert(result.end(), length_bytes.begin(), length_bytes.end());
+                result.insert(result.end(), encoded.begin(), encoded.end());
+                return result;
+            }
         }
 
-        // String data
+        // Raw literal: length with the H bit clear, then the octets verbatim.
+        auto length_bytes = encode_integer(str.size(), 7);
+        result.insert(result.end(), length_bytes.begin(), length_bytes.end());
         result.insert(result.end(), str.begin(), str.end());
 
         return result;
@@ -606,8 +609,12 @@ namespace kcenon::network::protocols::http2
         std::string result;
         if (huffman)
         {
-            // Huffman decoding not implemented yet - just return raw for now
-            result.assign(data.begin(), data.begin() + length);
+            auto decoded = huffman::decode(data.subspan(0, length));
+            if (decoded.is_err())
+            {
+                return decoded.error();
+            }
+            result = std::move(decoded.value());
         }
         else
         {
@@ -648,25 +655,214 @@ namespace kcenon::network::protocols::http2
         return error_info(107, "Invalid dynamic table index", "hpack");
     }
 
-    // Huffman coding (basic stub implementation)
+    // Huffman coding (RFC 7541 Appendix B)
     namespace huffman
     {
+        namespace
+        {
+            // RFC 7541 Appendix B static Huffman code: {code, bit length} per
+            // symbol. Index 0..255 are octet values; index 256 is the EOS symbol.
+            struct huffman_symbol
+            {
+                uint32_t code;
+                uint8_t bits;
+            };
+
+            constexpr huffman_symbol kHuffmanTable[257] = {
+                {0x1ff8u, 13},    {0x7fffd8u, 23},  {0xfffffe2u, 28}, {0xfffffe3u, 28},
+                {0xfffffe4u, 28}, {0xfffffe5u, 28}, {0xfffffe6u, 28}, {0xfffffe7u, 28},
+                {0xfffffe8u, 28}, {0xffffeau, 24},  {0x3ffffffcu, 30},{0xfffffe9u, 28},
+                {0xfffffeau, 28}, {0x3ffffffdu, 30},{0xfffffebu, 28}, {0xfffffecu, 28},
+                {0xfffffedu, 28}, {0xfffffeeu, 28}, {0xfffffefu, 28}, {0xffffff0u, 28},
+                {0xffffff1u, 28}, {0xffffff2u, 28}, {0x3ffffffeu, 30},{0xffffff3u, 28},
+                {0xffffff4u, 28}, {0xffffff5u, 28}, {0xffffff6u, 28}, {0xffffff7u, 28},
+                {0xffffff8u, 28}, {0xffffff9u, 28}, {0xffffffau, 28}, {0xffffffbu, 28},
+                {0x14u, 6},       {0x3f8u, 10},     {0x3f9u, 10},     {0xffau, 12},
+                {0x1ff9u, 13},    {0x15u, 6},       {0xf8u, 8},       {0x7fau, 11},
+                {0x3fau, 10},     {0x3fbu, 10},     {0xf9u, 8},       {0x7fbu, 11},
+                {0xfau, 8},       {0x16u, 6},       {0x17u, 6},       {0x18u, 6},
+                {0x0u, 5},        {0x1u, 5},        {0x2u, 5},        {0x19u, 6},
+                {0x1au, 6},       {0x1bu, 6},       {0x1cu, 6},       {0x1du, 6},
+                {0x1eu, 6},       {0x1fu, 6},       {0x5cu, 7},       {0xfbu, 8},
+                {0x7ffcu, 15},    {0x20u, 6},       {0xffbu, 12},     {0x3fcu, 10},
+                {0x1ffau, 13},    {0x21u, 6},       {0x5du, 7},       {0x5eu, 7},
+                {0x5fu, 7},       {0x60u, 7},       {0x61u, 7},       {0x62u, 7},
+                {0x63u, 7},       {0x64u, 7},       {0x65u, 7},       {0x66u, 7},
+                {0x67u, 7},       {0x68u, 7},       {0x69u, 7},       {0x6au, 7},
+                {0x6bu, 7},       {0x6cu, 7},       {0x6du, 7},       {0x6eu, 7},
+                {0x6fu, 7},       {0x70u, 7},       {0x71u, 7},       {0x72u, 7},
+                {0xfcu, 8},       {0x73u, 7},       {0xfdu, 8},       {0x1ffbu, 13},
+                {0x7fff0u, 19},   {0x1ffcu, 13},    {0x3ffcu, 14},    {0x22u, 6},
+                {0x7ffdu, 15},    {0x3u, 5},        {0x23u, 6},       {0x4u, 5},
+                {0x24u, 6},       {0x5u, 5},        {0x25u, 6},       {0x26u, 6},
+                {0x27u, 6},       {0x6u, 5},        {0x74u, 7},       {0x75u, 7},
+                {0x28u, 6},       {0x29u, 6},       {0x2au, 6},       {0x7u, 5},
+                {0x2bu, 6},       {0x76u, 7},       {0x2cu, 6},       {0x8u, 5},
+                {0x9u, 5},        {0x2du, 6},       {0x77u, 7},       {0x78u, 7},
+                {0x79u, 7},       {0x7au, 7},       {0x7bu, 7},       {0x7ffeu, 15},
+                {0x7fcu, 11},     {0x3ffdu, 14},    {0x1ffdu, 13},    {0xffffffcu, 28},
+                {0xfffe6u, 20},   {0x3fffd2u, 22},  {0xfffe7u, 20},   {0xfffe8u, 20},
+                {0x3fffd3u, 22},  {0x3fffd4u, 22},  {0x3fffd5u, 22},  {0x7fffd9u, 23},
+                {0x3fffd6u, 22},  {0x7fffdau, 23},  {0x7fffdbu, 23},  {0x7fffdcu, 23},
+                {0x7fffddu, 23},  {0x7fffdeu, 23},  {0xffffebu, 24},  {0x7fffdfu, 23},
+                {0xffffecu, 24},  {0xffffedu, 24},  {0x3fffd7u, 22},  {0x7fffe0u, 23},
+                {0xffffeeu, 24},  {0x7fffe1u, 23},  {0x7fffe2u, 23},  {0x7fffe3u, 23},
+                {0x7fffe4u, 23},  {0x1fffdcu, 21},  {0x3fffd8u, 22},  {0x7fffe5u, 23},
+                {0x3fffd9u, 22},  {0x7fffe6u, 23},  {0x7fffe7u, 23},  {0xffffefu, 24},
+                {0x3fffdau, 22},  {0x1fffddu, 21},  {0xfffe9u, 20},   {0x3fffdbu, 22},
+                {0x3fffdcu, 22},  {0x7fffe8u, 23},  {0x7fffe9u, 23},  {0x1fffdeu, 21},
+                {0x7fffeau, 23},  {0x3fffddu, 22},  {0x3fffdeu, 22},  {0xfffff0u, 24},
+                {0x1fffdfu, 21},  {0x3fffdfu, 22},  {0x7fffebu, 23},  {0x7fffecu, 23},
+                {0x1fffe0u, 21},  {0x1fffe1u, 21},  {0x3fffe0u, 22},  {0x1fffe2u, 21},
+                {0x7fffedu, 23},  {0x3fffe1u, 22},  {0x7fffeeu, 23},  {0x7fffefu, 23},
+                {0xfffeau, 20},   {0x3fffe2u, 22},  {0x3fffe3u, 22},  {0x3fffe4u, 22},
+                {0x7ffff0u, 23},  {0x3fffe5u, 22},  {0x3fffe6u, 22},  {0x7ffff1u, 23},
+                {0x3ffffe0u, 26}, {0x3ffffe1u, 26}, {0xfffebu, 20},   {0x7fff1u, 19},
+                {0x3fffe7u, 22},  {0x7ffff2u, 23},  {0x3fffe8u, 22},  {0x1ffffecu, 25},
+                {0x3ffffe2u, 26}, {0x3ffffe3u, 26}, {0x3ffffe4u, 26}, {0x7ffffdeu, 27},
+                {0x7ffffdfu, 27}, {0x3ffffe5u, 26}, {0xfffff1u, 24},  {0x1ffffedu, 25},
+                {0x7fff2u, 19},   {0x1fffe3u, 21},  {0x3ffffe6u, 26}, {0x7ffffe0u, 27},
+                {0x7ffffe1u, 27}, {0x3ffffe7u, 26}, {0x7ffffe2u, 27}, {0xfffff2u, 24},
+                {0x1fffe4u, 21},  {0x1fffe5u, 21},  {0x3ffffe8u, 26}, {0x3ffffe9u, 26},
+                {0xffffffdu, 28}, {0x7ffffe3u, 27}, {0x7ffffe4u, 27}, {0x7ffffe5u, 27},
+                {0xfffecu, 20},   {0xfffff3u, 24},  {0xfffedu, 20},   {0x1fffe6u, 21},
+                {0x3fffe9u, 22},  {0x1fffe7u, 21},  {0x1fffe8u, 21},  {0x7ffff3u, 23},
+                {0x3fffeau, 22},  {0x3fffebu, 22},  {0x1ffffeeu, 25}, {0x1ffffefu, 25},
+                {0xfffff4u, 24},  {0xfffff5u, 24},  {0x3ffffeau, 26}, {0x7ffff4u, 23},
+                {0x3ffffebu, 26}, {0x7ffffe6u, 27}, {0x3ffffecu, 26}, {0x3ffffedu, 26},
+                {0x7ffffe7u, 27}, {0x7ffffe8u, 27}, {0x7ffffe9u, 27}, {0x7ffffeau, 27},
+                {0x7ffffebu, 27}, {0xffffffeu, 28}, {0x7ffffecu, 27}, {0x7ffffedu, 27},
+                {0x7ffffeeu, 27}, {0x7ffffefu, 27}, {0x7fffff0u, 27}, {0x3ffffeeu, 26},
+                {0x3fffffffu, 30},  // 256: EOS
+            };
+
+            constexpr int kEosSymbol = 256;
+
+            // Decoding trie node: child indices for bit 0 / bit 1 (-1 if absent)
+            // and the decoded symbol at a leaf (-1 for internal nodes).
+            struct decode_node
+            {
+                int children[2] = {-1, -1};
+                int symbol = -1;
+            };
+
+            auto build_decode_tree() -> std::vector<decode_node>
+            {
+                std::vector<decode_node> nodes(1);  // root at index 0
+                for (int sym = 0; sym < 257; ++sym)
+                {
+                    const auto& entry = kHuffmanTable[sym];
+                    int cur = 0;
+                    for (int b = static_cast<int>(entry.bits) - 1; b >= 0; --b)
+                    {
+                        int bit = static_cast<int>((entry.code >> b) & 1u);
+                        int next = nodes[cur].children[bit];
+                        if (next == -1)
+                        {
+                            nodes.push_back(decode_node{});
+                            next = static_cast<int>(nodes.size()) - 1;
+                            nodes[cur].children[bit] = next;
+                        }
+                        cur = next;
+                    }
+                    nodes[cur].symbol = sym;
+                }
+                return nodes;
+            }
+        }  // namespace
+
         auto encode(std::string_view input) -> std::vector<uint8_t>
         {
-            // Stub: just return the input as-is
-            return std::vector<uint8_t>(input.begin(), input.end());
+            std::vector<uint8_t> out;
+            out.reserve(input.size());
+
+            uint64_t buffer = 0;
+            int buffer_bits = 0;
+
+            for (unsigned char ch : input)
+            {
+                const auto& entry = kHuffmanTable[ch];
+                buffer = (buffer << entry.bits) | entry.code;
+                buffer_bits += entry.bits;
+
+                while (buffer_bits >= 8)
+                {
+                    buffer_bits -= 8;
+                    out.push_back(static_cast<uint8_t>(buffer >> buffer_bits));
+                }
+                // Keep only the still-pending low bits to avoid emitting stale data.
+                buffer &= (1ull << buffer_bits) - 1;
+            }
+
+            if (buffer_bits > 0)
+            {
+                // Pad the final byte with the most significant bits of EOS (all 1s).
+                int pad = 8 - buffer_bits;
+                out.push_back(static_cast<uint8_t>((buffer << pad) | ((1u << pad) - 1)));
+            }
+
+            return out;
         }
 
         auto decode(std::span<const uint8_t> data) -> Result<std::string>
         {
-            // Stub: just return the data as-is
-            return std::string(data.begin(), data.end());
+            static const std::vector<decode_node> tree = build_decode_tree();
+
+            std::string out;
+            int node = 0;
+            int partial_bits = 0;
+            bool partial_all_ones = true;
+
+            for (uint8_t byte : data)
+            {
+                for (int i = 7; i >= 0; --i)
+                {
+                    int bit = (byte >> i) & 1;
+                    node = tree[node].children[bit];
+                    if (node == -1)
+                    {
+                        return error_info(108, "Invalid Huffman code", "hpack");
+                    }
+                    ++partial_bits;
+                    if (bit == 0)
+                    {
+                        partial_all_ones = false;
+                    }
+
+                    if (tree[node].symbol >= 0)
+                    {
+                        if (tree[node].symbol == kEosSymbol)
+                        {
+                            // RFC 7541 5.2: EOS in the encoded data is an error.
+                            return error_info(108, "EOS symbol in Huffman-encoded data",
+                                              "hpack");
+                        }
+                        out.push_back(static_cast<char>(tree[node].symbol));
+                        node = 0;
+                        partial_bits = 0;
+                        partial_all_ones = true;
+                    }
+                }
+            }
+
+            // RFC 7541 5.2: any trailing bits must be valid EOS padding —
+            // at most 7 bits, all set to 1.
+            if (node != 0 && (partial_bits > 7 || !partial_all_ones))
+            {
+                return error_info(108, "Invalid Huffman padding", "hpack");
+            }
+
+            return out;
         }
 
         auto encoded_size(std::string_view input) -> size_t
         {
-            // Stub: return input size
-            return input.size();
+            size_t bits = 0;
+            for (unsigned char ch : input)
+            {
+                bits += kHuffmanTable[ch].bits;
+            }
+            return (bits + 7) / 8;
         }
     }
 

--- a/tests/test_http2_hpack.cpp
+++ b/tests/test_http2_hpack.cpp
@@ -756,31 +756,108 @@ TEST_F(HpackTest, DecoderHandlesMultipleHeadersWithSameName)
 }
 
 // ============================================================
-// Huffman Stub Tests
+// Huffman Coding Tests (RFC 7541 Appendix B / Appendix C)
 // ============================================================
 
-TEST_F(HpackTest, HuffmanEncodeStub)
+TEST_F(HpackTest, HuffmanEncodeRfc7541C41Authority)
 {
-    auto encoded = huffman::encode("hello");
-    // Stub returns raw bytes
-    ASSERT_EQ(encoded.size(), 5u);
-    EXPECT_EQ(encoded[0], 'h');
-    EXPECT_EQ(encoded[4], 'o');
+    // RFC 7541 C.4.1: ":authority: www.example.com"
+    auto encoded = huffman::encode("www.example.com");
+    std::vector<uint8_t> expected = {0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a,
+                                     0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xff};
+    EXPECT_EQ(encoded, expected);
+    EXPECT_EQ(huffman::encoded_size("www.example.com"), expected.size());
 }
 
-TEST_F(HpackTest, HuffmanDecodeStub)
+TEST_F(HpackTest, HuffmanEncodeRfc7541C42NoCache)
 {
-    std::vector<uint8_t> data = {'w', 'o', 'r', 'l', 'd'};
-    auto result = huffman::decode(data);
-    ASSERT_TRUE(result.is_ok());
-    EXPECT_EQ(result.value(), "world");
+    // RFC 7541 C.4.2: "cache-control: no-cache"
+    auto encoded = huffman::encode("no-cache");
+    std::vector<uint8_t> expected = {0xa8, 0xeb, 0x10, 0x64, 0x9c, 0xbf};
+    EXPECT_EQ(encoded, expected);
 }
 
-TEST_F(HpackTest, HuffmanEncodedSizeStub)
+TEST_F(HpackTest, HuffmanEncodeRfc7541C43Custom)
 {
-    EXPECT_EQ(huffman::encoded_size("test"), 4u);
-    EXPECT_EQ(huffman::encoded_size(""), 0u);
-    EXPECT_EQ(huffman::encoded_size("hello world"), 11u);
+    // RFC 7541 C.4.3: "custom-key: custom-value"
+    EXPECT_EQ(huffman::encode("custom-key"),
+              (std::vector<uint8_t>{0x25, 0xa8, 0x49, 0xe9, 0x5b, 0xa9, 0x7d, 0x7f}));
+    EXPECT_EQ(huffman::encode("custom-value"),
+              (std::vector<uint8_t>{0x25, 0xa8, 0x49, 0xe9, 0x5b, 0xb8, 0xe8, 0xb4, 0xbf}));
+}
+
+TEST_F(HpackTest, HuffmanEncodeRfc7541C6Response)
+{
+    // RFC 7541 C.6.1 response header field values.
+    EXPECT_EQ(huffman::encode("302"), (std::vector<uint8_t>{0x64, 0x02}));
+    EXPECT_EQ(huffman::encode("private"),
+              (std::vector<uint8_t>{0xae, 0xc3, 0x77, 0x1a, 0x4b}));
+    EXPECT_EQ(huffman::encode("https://www.example.com"),
+              (std::vector<uint8_t>{0x9d, 0x29, 0xad, 0x17, 0x18, 0x63, 0xc7, 0x8f, 0x0b,
+                                    0x97, 0xc8, 0xe9, 0xae, 0x82, 0xae, 0x43, 0xd3}));
+}
+
+TEST_F(HpackTest, HuffmanDecodeRfc7541Vectors)
+{
+    // Explicit decode of the C.4.1 Huffman-coded vector.
+    std::vector<uint8_t> c41 = {0xf1, 0xe3, 0xc2, 0xe5, 0xf2, 0x3a,
+                                0x6b, 0xa0, 0xab, 0x90, 0xf4, 0xff};
+    auto decoded = huffman::decode(c41);
+    ASSERT_TRUE(decoded.is_ok());
+    EXPECT_EQ(decoded.value(), "www.example.com");
+
+    auto roundtrip = [](const std::string& s) {
+        auto dec = huffman::decode(huffman::encode(s));
+        return dec.is_ok() ? dec.value() : std::string("<error>");
+    };
+    EXPECT_EQ(roundtrip("no-cache"), "no-cache");
+    EXPECT_EQ(roundtrip("custom-key"), "custom-key");
+    EXPECT_EQ(roundtrip("custom-value"), "custom-value");
+    EXPECT_EQ(roundtrip("Mon, 21 Oct 2013 20:13:21 GMT"),
+              "Mon, 21 Oct 2013 20:13:21 GMT");
+    EXPECT_EQ(roundtrip("https://www.example.com"), "https://www.example.com");
+}
+
+TEST_F(HpackTest, HuffmanRoundTripAllByteValues)
+{
+    // Every octet value must survive an encode/decode round trip, and
+    // encoded_size must match the produced byte count.
+    for (int c = 0; c < 256; ++c)
+    {
+        std::string s(1, static_cast<char>(c));
+        auto enc = huffman::encode(s);
+        auto dec = huffman::decode(enc);
+        ASSERT_TRUE(dec.is_ok()) << "decode failed for byte " << c;
+        ASSERT_EQ(dec.value().size(), 1u);
+        EXPECT_EQ(static_cast<unsigned char>(dec.value()[0]),
+                  static_cast<unsigned char>(c)) << "round trip mismatch for byte " << c;
+        EXPECT_EQ(huffman::encoded_size(s), enc.size());
+    }
+}
+
+TEST_F(HpackTest, HuffmanDecodeRejectsEosSymbol)
+{
+    // A run of 1-bits long enough to contain the 30-bit EOS code is invalid
+    // (RFC 7541 5.2).
+    std::vector<uint8_t> all_ones = {0xff, 0xff, 0xff, 0xff};
+    EXPECT_TRUE(huffman::decode(all_ones).is_err());
+}
+
+TEST_F(HpackTest, HuffmanDecodeRejectsInvalidPadding)
+{
+    // 'a' = 00101 (5 bits); a trailing pad of 000 is not the EOS prefix.
+    std::vector<uint8_t> bad_padding = {0x28};  // 00101 000
+    EXPECT_TRUE(huffman::decode(bad_padding).is_err());
+}
+
+TEST_F(HpackTest, HuffmanEncodedSizeMatchesEncode)
+{
+    for (const auto& s : {std::string("hello world"), std::string("test"),
+                          std::string(""), std::string(":method"),
+                          std::string("X-Custom-Header-Value-123")})
+    {
+        EXPECT_EQ(huffman::encoded_size(s), huffman::encode(s).size());
+    }
 }
 
 TEST_F(HpackTest, HuffmanEmptyInput)

--- a/tests/unit/hpack_extra_coverage_test.cpp
+++ b/tests/unit/hpack_extra_coverage_test.cpp
@@ -320,36 +320,35 @@ class HuffmanExtraTest : public ::testing::Test
 {
 };
 
-TEST_F(HuffmanExtraTest, EncodedSizeMatchesInputSizeForStub)
+TEST_F(HuffmanExtraTest, EncodedSizeMatchesRfc7541AppendixB)
 {
-    // Stub implementation returns input size verbatim. Locking this contract
-    // makes any move to a real Huffman encoder visible here.
-    EXPECT_EQ(http2::huffman::encoded_size("a"), 1u);
-    EXPECT_EQ(http2::huffman::encoded_size("hello"), 5u);
-    EXPECT_EQ(http2::huffman::encoded_size(std::string(100, 'x')), 100u);
+    // Real RFC 7541 Appendix B Huffman code sizes (in bytes).
+    EXPECT_EQ(http2::huffman::encoded_size("a"), 1u);      // 5 bits -> 1 byte
+    EXPECT_EQ(http2::huffman::encoded_size("hello"), 4u);  // 28 bits -> 4 bytes
+    EXPECT_EQ(http2::huffman::encoded_size(std::string(100, 'x')),
+              88u);  // 700 bits -> 88 bytes
+    // encoded_size must always agree with the actual encoded byte count.
+    EXPECT_EQ(http2::huffman::encoded_size("hello"),
+              http2::huffman::encode("hello").size());
 }
 
-TEST_F(HuffmanExtraTest, EncodeProducesByteForByteStubOutput)
+TEST_F(HuffmanExtraTest, EncodeRoundTripsArbitraryBytes)
 {
     const std::string input = "abc\x01\x02\x03";
     auto encoded = http2::huffman::encode(input);
-    ASSERT_EQ(encoded.size(), input.size());
-    for (size_t i = 0; i < input.size(); ++i)
-    {
-        EXPECT_EQ(encoded[i], static_cast<uint8_t>(input[i]));
-    }
+    auto decoded = http2::huffman::decode(as_span(encoded));
+    ASSERT_TRUE(decoded.is_ok());
+    EXPECT_EQ(decoded.value(), input);
 }
 
-TEST_F(HuffmanExtraTest, DecodeReturnsByteForByteStubOutput)
+TEST_F(HuffmanExtraTest, DecodeRoundTripsControlAndHighBytes)
 {
-    std::vector<uint8_t> data = {'x', 'y', 'z', 0x00, 0xFF};
-    auto result = http2::huffman::decode(as_span(data));
-    ASSERT_TRUE(result.is_ok());
-    ASSERT_EQ(result.value().size(), data.size());
-    for (size_t i = 0; i < data.size(); ++i)
-    {
-        EXPECT_EQ(static_cast<uint8_t>(result.value()[i]), data[i]);
-    }
+    const std::string input = {'x', 'y', 'z', '\x00', '\xff'};
+    auto encoded = http2::huffman::encode(input);
+    auto decoded = http2::huffman::decode(as_span(encoded));
+    ASSERT_TRUE(decoded.is_ok());
+    ASSERT_EQ(decoded.value().size(), input.size());
+    EXPECT_EQ(decoded.value(), input);
 }
 
 // ============================================================================


### PR DESCRIPTION
Closes #1157

## Summary
- Replace the documented pass-through Huffman stub in `src/protocols/http2/hpack.cpp` with the full RFC 7541 Appendix B static Huffman code.
- `encode()` bit-packs symbols MSB-first and pads the final byte with the most significant bits of EOS (all 1s); `encoded_size()` returns the exact `ceil(total_bits / 8)`.
- `decode()` walks a prefix-code trie built from the table and enforces RFC 7541 §5.2: the EOS symbol appearing in the data, padding longer than 7 bits, and padding not matching the EOS prefix are all decoding errors.
- `hpack_encoder::encode_string()` now Huffman-encodes only when the result is strictly smaller than the raw literal (sets the H bit accordingly); `hpack_decoder::decode_string()` decodes the H-bit path.

## Test Plan
- Replaced the four stub-contract tests in `tests/test_http2_hpack.cpp` with RFC 7541 Appendix C.4 / C.6 Huffman conformance vectors, an all-256-byte round-trip, and EOS / invalid-padding rejection tests.
- Updated the stub-locking tests in `tests/unit/hpack_extra_coverage_test.cpp` to the real RFC sizes / round-trip behavior.
- Local build (`ci-standalone`) + all HPACK suites pass: `network_http2_hpack_test` (57), `network_http2_hpack_rfc7541_test` (18), `network_hpack_module_test` (48), `network_hpack_extra_coverage_test` (26).

## Notes
- `docs/PROTOCOL_SUPPORT.md` HPACK / HPACK-Huffman rows flipped from `experimental` to `production`, and the HPACK Huffman follow-up bullet removed.